### PR TITLE
WIP: counterfactuals

### DIFF
--- a/alibi/explainers/__init__.py
+++ b/alibi/explainers/__init__.py
@@ -6,8 +6,10 @@ from .anchor.anchor_tabular import AnchorTabular
 from .anchor.anchor_text import AnchorText
 from .anchor.anchor_image import AnchorImage
 from .cem.cem import CEM
+from .counterfactual.counterfactual import CounterFactual
 
 __all__ = ["AnchorTabular",
            "AnchorText",
            "AnchorImage",
-           "CEM"]
+           "CEM",
+           "CounterFactual"]

--- a/alibi/explainers/counterfactual/counterfactual.py
+++ b/alibi/explainers/counterfactual/counterfactual.py
@@ -1,0 +1,51 @@
+import numpy as np
+from typing import Callable, Tuple, Union
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _define_func(predict_fn: Callable,
+                 pred_class: int,
+                 target_class: Union[str, int] = 'same') -> Tuple[Callable, Union[str, int]]:
+    """
+    Define the class-specific prediction function to be used in the optimization.
+
+    Parameters
+    ----------
+    predict_fn
+        Classifier prediction function
+    pred_class
+        Predicted class of the instance to be explained
+    target_class
+        Target class of the explanation, one of 'same', 'other' or an integer class
+
+    Returns
+    -------
+        Class-specific prediction function and the target class used.
+
+    """
+    if target_class == 'other':
+
+        def func(X):
+            probas = predict_fn(X)
+            sorted = np.argsort(-probas)  # class indices in decreasing order of probability
+
+            # take highest probability class different from class predicted for X
+            if sorted[0, 0] == pred_class:
+                target_class = sorted[0, 1]
+            else:
+                target_class = sorted[0, 0]
+
+            logger.debug('Current best target class: %s', target_class)
+            return predict_fn(X)[:, target_class]
+
+        return func, target_class
+
+    elif target_class == 'same':
+        target_class = pred_class
+
+    def func(X):  # type: ignore
+        return predict_fn(X)[:, target_class]
+
+    return func, target_class

--- a/alibi/explainers/counterfactual/counterfactual.py
+++ b/alibi/explainers/counterfactual/counterfactual.py
@@ -1,9 +1,13 @@
 import numpy as np
-from typing import Callable, Tuple, Union
+from typing import Callable, Dict, Optional, Tuple, Union
 from statsmodels.tools.numdiff import approx_fprime
+from scipy.spatial.distance import cityblock
+import tensorflow as tf
 import logging
 
 logger = logging.getLogger(__name__)
+
+_metric_dict = {'l1': cityblock}  # type: Dict[str, Callable]
 
 
 def _define_func(predict_fn: Callable,
@@ -35,10 +39,11 @@ def _define_func(predict_fn: Callable,
             # take highest probability class different from class predicted for X
             if sorted[0, 0] == pred_class:
                 target_class = sorted[0, 1]
+                # logger.debug('Target class equals predicted class')
             else:
                 target_class = sorted[0, 0]
 
-            logger.debug('Current best target class: %s', target_class)
+            # logger.debug('Current best target class: %s', target_class)
             return predict_fn(X)[:, target_class]
 
         return func, target_class
@@ -78,7 +83,9 @@ def get_wachter_grads(X_current: np.ndarray,
                       distance_fn: Callable,
                       X_test: np.ndarray,
                       target_proba: float,
-                      lam: float) -> np.ndarray:
+                      lam: float,
+                      epsilons: Union[float, np.ndarray] = None,
+                      method: str = 'wachter') -> Tuple[Union[float, np.ndarray], ...]:
     """
     Calculate the gradients of the loss function in Wachter et al. (2017)
     Parameters
@@ -98,32 +105,212 @@ def get_wachter_grads(X_current: np.ndarray,
 
     Returns
     -------
-    Gradient of the Wachter loss
+    Loss and gradient of the Wachter loss
 
     """
+    if isinstance(epsilons, float):
+        eps = epsilons
+    else:
+        eps = None
+
     pred = predict_class_fn(X_current)
+    logger.debug('Current prediction: %s', pred)
 
     # numerical gradient of the black-box prediction function (specific to the target class)
-    prediction_grad = num_grad(predict_class_fn, X_current.squeeze())
+    prediction_grad = num_grad(predict_class_fn, X_current.squeeze(), epsilon=eps)  # TODO feature-wise epsilons
 
     # numerical gradient of the distance function between the current point and the point to be explained
-    distance_grad = num_grad(distance_fn, X_current.squeeze(), args=tuple([X_test.squeeze()]))
+    distance_grad = num_grad(distance_fn, X_current.squeeze(), args=tuple([X_test.squeeze()]),
+                             epsilon=eps)  # TODO epsilons
+
+    logger.debug('Norm of prediction_grad: %s', np.linalg.norm(prediction_grad.flatten()))
+    logger.debug('Norm of distance_grad: %s', np.linalg.norm(distance_grad.flatten()))
+    logger.debug('pred - target_proba = %s', pred - target_proba)
 
     # gradient of the Wachter loss
-    grad_loss = 2 * lam * (pred - target_proba) * prediction_grad + distance_grad
+    if method == 'wachter':
+        loss = lam * (pred - target_proba) ** 2 + distance_fn(X_current, X_test)
+        grad_loss = 2 * lam * (pred - target_proba) * prediction_grad + distance_grad  # TODO convex combination
 
-    return grad_loss
+    elif method == 'adiabatic':
+        loss = lam * (pred - target_proba) ** 2 + (1 - lam) * distance_fn(X_current, X_test)
+        grad_loss = 2 * lam * (pred - target_proba) * prediction_grad + (1 - lam) * distance_grad
 
+    else:
+        raise ValueError('Only loss optimization methods available are wachter and adiabatic')
 
-def minimize_wachter_loss(): ...
+    logger.debug('Method: %s', method)
+    logger.debug('Loss: %s', loss)
+    logger.debug('Norm of grad_loss: %s', np.linalg.norm(grad_loss.flatten()))
+
+    return loss, grad_loss
 
 
 class CounterFactual:
 
-    def __init__(self): ...
+    def __init__(self,
+                 sess: tf.Session,
+                 predict_fn: Callable,
+                 data_shape: Tuple[int, ...],
+                 distance_fn: str = 'l1',
+                 target_proba: float = 0.9,
+                 target_class: Union[str, int] = 'other',
+                 max_iter: int = 100,
+                 lam_init: float = 0.01,
+                 lam_step: float = 0.001,
+                 tol: float = 0.05,
+                 feature_range: Union[Tuple, str] = None,  # important for positive features
+                 epsilons: Union[float, np.ndarray] = None,  # feature-wise epsilons
+                 method: str = 'wachter'):
+        logger.warning('Counterfactual explainer currently only supports numeric features')
+        self.sess = sess
+        self.data_shape = data_shape
+        self.target_proba = target_proba
+        self.target_class = target_class
 
-    def _initialize(self): ...
+        # options for the optimizer
+        self.max_iter = max_iter
+        self.lam_init = lam_init
+        self.lam_step = lam_step
+        self.tol = tol
 
-    def fit(self): ...
+        self.epsilons = epsilons
+        self.method = method
 
-    def explain(self): ...
+        # TODO: support predict and predict_proba types for functions
+        self.predict_fn = lambda x: predict_fn(x.reshape(1, -1))  # Is this safe?
+
+        try:
+            self.distance_fn = _metric_dict[distance_fn]
+        except KeyError:
+            logger.exception('Distance metrics %s not supported', distance_fn)
+            raise
+
+        if feature_range is not None:
+            logger.warning('Feature range specified')
+
+        # flag to keep track if explainer is fit or not
+        self.fitted = False
+
+        # set up graph session
+        self.cf = tf.get_variable('counterfactual', shape=data_shape,
+                                  dtype=tf.float32)  # TODO initialize when explain is called
+
+        # optimizer
+        opt = tf.train.AdamOptimizer()  # TODO optional argument to change type
+
+        # training setup
+        self.global_step = tf.Variable(0, trainable=False, name='global_step')
+        # grads_and_vars = opt.compute_gradients(, vars = [cf]) TODO if differentiable distance
+        self.grad_ph = tf.placeholder(shape=data_shape, dtype=tf.float32)
+        grad_and_var = [(self.grad_ph, self.cf)]  # could be cf.name
+
+        self.apply_grad = opt.apply_gradients(grad_and_var, global_step=self.global_step)  # TODO gradient clipping?
+
+        # self.init = tf.variables_initializer(var_list=[self.global_step, self.cf])
+        # self.sess.run(self.init)  # where to put this?
+        self.sess.run(tf.global_variables_initializer())  # TODO replace with localized version?
+
+        return
+
+    def _initialize(self):
+        # TODO initialization strategies ("same", "random", "from_train")
+
+        pass
+
+    def fit(self,
+            X: np.ndarray,
+            y: Optional[np.ndarray]) -> None:
+        # TODO feature ranges, epsilons and MADs
+
+        self.fitted = True
+
+    def explain(self, X: np.ndarray) -> Dict:
+
+        # make a prediction
+        probas = self.predict_fn(X)
+        pred_class = probas.argmax()
+
+        # define the class-specific prediction function
+        self.predict_class_fn, t_class = _define_func(self.predict_fn, pred_class, self.target_class)
+
+        if not self.fitted:
+            logger.warning('Explain called before fit, explainer will operate in unsupervised mode.')
+
+        # initialize with an instance
+        X_init = X  # TODO use _initialize
+
+        # minimize loss iteratively
+        exp_dict = self._minimize_wachter_loss(X, X_init)
+
+        return exp_dict
+
+    def _minimize_wachter_loss(self,
+                               X: np.ndarray,
+                               X_init: np.ndarray) -> Dict:
+        # first minimization
+        logger.debug('######################################################## ITERATION: 0')
+
+        X_current = X_init
+        lam = self.lam_init
+        loss, gradients = get_wachter_grads(X_current=X_current, predict_class_fn=self.predict_class_fn,
+                                            distance_fn=self.distance_fn, X_test=X, target_proba=self.target_proba,
+                                            lam=lam, epsilons=self.epsilons, method=self.method)
+        self.sess.run(self.apply_grad, feed_dict={self.grad_ph: gradients})
+        X_current = self.sess.run(self.cf)
+        probas = self.predict_fn(X_current)
+        pred_class = probas.argmax()
+        p = probas.max()
+        logger.debug('Iteration: 0, cf pred_class: %s, cf proba: %s', pred_class, p)
+        logger.debug('Iteration: 0, distance d(X_current, X): %s', self.distance_fn(X, X_current))
+
+        Xs = []
+        losses = []
+        grads = []
+        lambdas = []
+        Xs.append(X_current)
+        losses.append(loss)
+        grads.append(gradients)
+        lambdas.append(lam)
+
+        num_iter = 0
+        return_dict = {'X_cf': X_current,
+                       'loss': losses,
+                       'grads': grads,
+                       'Xs': Xs,
+                       'lambdas': lambdas,
+                       'n_iter': num_iter}
+        # main loop
+        while np.abs(self.predict_class_fn(X_current) - self.target_proba) > self.tol:
+            logger.debug('######################################################## ITERATION: %s', num_iter + 1)
+            if num_iter == self.max_iter:
+                logger.warning(
+                    'Maximum number of iterations reached without finding a counterfactual.'
+                    'Increase max_iter, tolerance or the lambda hyperparameter.')
+                return return_dict
+
+            # minimize the loss
+            num_iter += 1
+            lam += self.lam_step
+            logger.debug('Increased lambda to %s', lam)
+            loss, gradients = get_wachter_grads(X_current=X_current, predict_class_fn=self.predict_class_fn,
+                                                distance_fn=self.distance_fn, X_test=X, target_proba=self.target_proba,
+                                                lam=lam, epsilons=self.epsilons, method=self.method)
+            self.sess.run(self.apply_grad, feed_dict={self.grad_ph: gradients})
+            X_current = self.sess.run(self.cf)
+
+            probas = self.predict_fn(X_current)
+            pred_class = probas.argmax()
+            p = probas.max()
+            logger.debug('Iteration: %s, cf pred_class: %s, cf proba: %s', num_iter, pred_class, p)
+            logger.debug('Iteration: %s, distance d(X_current, X): %s', num_iter, self.distance_fn(X, X_current))
+
+            Xs.append(X_current)
+            losses.append(loss)
+            grads.append(gradients)
+            lambdas.append(lam)
+
+            return_dict['X_cf'] = X_current
+            return_dict['n_iter'] = num_iter
+
+        return return_dict

--- a/alibi/explainers/counterfactual/counterfactual.py
+++ b/alibi/explainers/counterfactual/counterfactual.py
@@ -79,6 +79,28 @@ def get_wachter_grads(X_current: np.ndarray,
                       X_test: np.ndarray,
                       target_proba: float,
                       lam: float) -> np.ndarray:
+    """
+    Calculate the gradients of the loss function in Wachter et al. (2017)
+    Parameters
+    ----------
+    X_current
+        Candidate counterfactual wrt which the gradient is taken
+    predict_class_fn
+        Prediction function specific to the target class of the counterfactual
+    distance_fn
+        Distance function in feature space
+    X_test
+        Sample to be explained
+    target_proba
+        Target probability to for the counterfactual instance to satisfy
+    lam
+        Hyperparameter balancing the loss contribution of the distance in prediction (higher lam -> more weight)
+
+    Returns
+    -------
+    Gradient of the Wachter loss
+
+    """
     pred = predict_class_fn(X_current)
 
     # numerical gradient of the black-box prediction function (specific to the target class)

--- a/alibi/explainers/counterfactual/counterfactual.py
+++ b/alibi/explainers/counterfactual/counterfactual.py
@@ -49,3 +49,23 @@ def _define_func(predict_fn: Callable,
         return predict_fn(X)[:, target_class]
 
     return func, target_class
+
+
+def get_num_grads(): ...
+
+
+def get_wachter_grads(): ...
+
+
+def minimize_wachter_loss(): ...
+
+
+class CounterFactual:
+
+    def __init__(self): ...
+
+    def _initialize(self): ...
+
+    def fit(self): ...
+
+    def explain(self): ...

--- a/alibi/explainers/counterfactual/counterfactual.py
+++ b/alibi/explainers/counterfactual/counterfactual.py
@@ -319,7 +319,8 @@ class CounterFactual:
                        'grads': grads,
                        'Xs': Xs,
                        'lambdas': lambdas,
-                       'n_iter': num_iter}
+                       'n_iter': num_iter,
+                       'success': True}
         # main loop
         while np.abs(self.predict_class_fn(X_current) - self.target_proba) > self.tol:
             logger.debug('######################################################## ITERATION: %s', num_iter + 1)
@@ -327,6 +328,7 @@ class CounterFactual:
                 logger.warning(
                     'Maximum number of iterations reached without finding a counterfactual.'
                     'Increase max_iter, tolerance or the lambda hyperparameter.')
+                return_dict['success'] = False
                 return return_dict
 
             # minimize the loss

--- a/alibi/explainers/counterfactual/counterfactual.py
+++ b/alibi/explainers/counterfactual/counterfactual.py
@@ -73,7 +73,24 @@ def num_grad(func: Callable, X: np.ndarray, args: Tuple = (), epsilon: float = 1
     return gradient
 
 
-def get_wachter_grads(): ...
+def get_wachter_grads(X_current: np.ndarray,
+                      predict_class_fn: Callable,
+                      distance_fn: Callable,
+                      X_test: np.ndarray,
+                      target_proba: float,
+                      lam: float) -> np.ndarray:
+    pred = predict_class_fn(X_current)
+
+    # numerical gradient of the black-box prediction function (specific to the target class)
+    prediction_grad = num_grad(predict_class_fn, X_current.squeeze())
+
+    # numerical gradient of the distance function between the current point and the point to be explained
+    distance_grad = num_grad(distance_fn, X_current.squeeze(), args=tuple([X_test.squeeze()]))
+
+    # gradient of the Wachter loss
+    grad_loss = 2 * lam * (pred - target_proba) * prediction_grad + distance_grad
+
+    return grad_loss
 
 
 def minimize_wachter_loss(): ...

--- a/alibi/explainers/counterfactual/counterfactual.py
+++ b/alibi/explainers/counterfactual/counterfactual.py
@@ -102,7 +102,10 @@ def get_wachter_grads(X_current: np.ndarray,
         Target probability to for the counterfactual instance to satisfy
     lam
         Hyperparameter balancing the loss contribution of the distance in prediction (higher lam -> more weight)
-
+    epsilons
+        Steps sizes for computing the gradient passed to the num_grad function
+    method
+        Loss optimization method - one of 'wachter' or 'adiabatic'
     Returns
     -------
     Loss and gradient of the Wachter loss

--- a/alibi/explainers/counterfactual/counterfactual.py
+++ b/alibi/explainers/counterfactual/counterfactual.py
@@ -60,6 +60,7 @@ def _define_func(predict_fn: Callable,
 def num_grad(func: Callable, X: np.ndarray, args: Tuple = (), epsilon: float = 1e-08) -> np.ndarray:
     """
     Compute the numerical gradient using the symmetric difference. Currently wraps statsmodels implementation.
+
     Parameters
     ----------
     func
@@ -88,6 +89,7 @@ def get_wachter_grads(X_current: np.ndarray,
                       method: str = 'wachter') -> Tuple[Union[float, np.ndarray], ...]:
     """
     Calculate the gradients of the loss function in Wachter et al. (2017)
+
     Parameters
     ----------
     X_current
@@ -165,6 +167,41 @@ class CounterFactual:
                  feature_range: Union[Tuple, str] = None,  # important for positive features
                  epsilons: Union[float, np.ndarray] = None,  # feature-wise epsilons
                  method: str = 'wachter'):
+        """
+        Initialize counterfactual explanation method based on Wachter et al. (2017)
+
+        Parameters
+        ----------
+        sess
+            TensorFlow session
+        predict_fn
+            A model's prediction function returning class probabilities
+        data_shape
+            Shape of input data TODO: specify format
+        distance_fn
+            Distance function to use in the loss term
+        target_proba
+            Target probability for the counterfactual to reach
+        target_class
+            Target class for the counterfactual to reach, one of 'other', 'same' or an integer denoting
+            desired class membership for the counterfactual instance
+        max_iter
+            Maximum number of interations to run the search for
+        lam_init
+            Initial regularization constant for the prediction part of the Wachter loss
+        lam_step
+            Regularization constant step size used in the search
+        tol
+            Tolerance for the counterfactual target probability
+        feature_range
+            Tuple with min ahnd max ranges to allow for the counterfactual search. TODO
+        epsilons
+            Gradient step sizes used in calculating numerical gradients, defaults to a single value for all
+            features, but can be passed an array for feature-wise step sizes
+        method
+            Optimization method, one of 'wachter' or 'adiabatic' TODO: method or different algorithm?
+        """
+
         logger.warning('Counterfactual explainer currently only supports numeric features')
         self.sess = sess
         self.data_shape = data_shape

--- a/alibi/explainers/counterfactual/counterfactual.py
+++ b/alibi/explainers/counterfactual/counterfactual.py
@@ -1,5 +1,6 @@
 import numpy as np
 from typing import Callable, Tuple, Union
+from statsmodels.tools.numdiff import approx_fprime
 import logging
 
 logger = logging.getLogger(__name__)
@@ -51,7 +52,25 @@ def _define_func(predict_fn: Callable,
     return func, target_class
 
 
-def get_num_grads(): ...
+def num_grad(func: Callable, X: np.ndarray, args: Tuple = (), epsilon: float = 1e-08) -> np.ndarray:
+    """
+    Compute the numerical gradient using the symmetric difference. Currently wraps statsmodels implementation.
+    Parameters
+    ----------
+    func
+        Function to differentiate
+    X
+        Point at which to compute the gradient
+    args
+        Additional arguments to the function
+    epsilon
+        Step size for computing the gradient
+    Returns
+    -------
+    Numerical gradient
+    """
+    gradient = approx_fprime(X, func, epsilon=epsilon, args=args, centered=True)
+    return gradient
 
 
 def get_wachter_grads(): ...

--- a/alibi/explainers/counterfactual/tests/test_counterfactual.py
+++ b/alibi/explainers/counterfactual/tests/test_counterfactual.py
@@ -4,8 +4,10 @@ import numpy as np
 from sklearn.datasets import load_iris
 from sklearn.linear_model import LogisticRegression
 from scipy.spatial.distance import cityblock
+import tensorflow as tf
 
 from alibi.explainers.counterfactual.counterfactual import _define_func, num_grad, get_wachter_grads
+from alibi.explainers import CounterFactual
 
 
 @pytest.fixture
@@ -13,6 +15,17 @@ def logistic_iris():
     X, y = load_iris(return_X_y=True)
     lr = LogisticRegression(solver='lbfgs', multi_class='multinomial', max_iter=200).fit(X, y)
     return X, y, lr
+
+
+@pytest.fixture
+def iris_explainer(logistic_iris):
+    X, y, lr = logistic_iris
+    predict_fn = lambda x: lr.predict_proba(x.reshape(1, -1))
+    sess = tf.Session()
+
+    cf_explainer = CounterFactual(sess=sess, predict_fn=predict_fn, data_shape=(4,), lam_init=1000, max_iter=2000)
+
+    return cf_explainer
 
 
 @pytest.mark.parametrize('target_class', ['other', 'same', 0, 1, 2])
@@ -77,7 +90,32 @@ def test_get_wachter_grads(logistic_iris):
     pred_class = probas.argmax()
     func, target = _define_func(predict_fn, pred_class, 'same')
 
-    grad_loss = get_wachter_grads(X_current=x, predict_class_fn=func, distance_fn=cityblock,
-                                  X_test=x, target_proba=0.1, lam=1)
+    loss, grad_loss = get_wachter_grads(X_current=x, predict_class_fn=func, distance_fn=cityblock,
+                                        X_test=x, target_proba=0.1, lam=1)
 
+    assert loss.shape == (1,)
     assert grad_loss.shape == x.shape
+
+
+def test_cf_explainer_iris(iris_explainer, logistic_iris):
+    X, y, lr = logistic_iris
+    x = X[0]
+    probas = iris_explainer.predict_fn(x)
+    pred_class = probas.argmax()
+
+    assert iris_explainer.data_shape == (4,)
+
+    # test explanation
+    exp = iris_explainer.explain(x)
+    x_cf = exp['X_cf']
+    assert x.shape == x_cf.shape
+
+    probas_cf = iris_explainer.predict_fn(x_cf)
+    pred_class_cf = probas_cf.argmax()
+
+    # check if 'other' class condition is met
+    assert pred_class != pred_class_cf
+
+    # check if probability is within tolerance
+    assert np.abs((iris_explainer.predict_class_fn(x_cf) - iris_explainer.target_proba)) <= iris_explainer.tol
+

--- a/alibi/explainers/counterfactual/tests/test_counterfactual.py
+++ b/alibi/explainers/counterfactual/tests/test_counterfactual.py
@@ -102,7 +102,7 @@ def test_get_num_gradients_logistic_iris(logistic_iris):
 @pytest.mark.parametrize('batch_size', [1, 2, 5])
 def test_get_batch_num_gradients_logistic_iris(logistic_iris, batch_size):
     X, y, lr = logistic_iris
-    predict_fn = lr.predict_proba  # need squeezed x for numerical gradient
+    predict_fn = lr.predict_proba
     x = X[0:batch_size]
     probas = predict_fn(x)
 
@@ -122,19 +122,20 @@ def test_get_batch_num_gradients_logistic_iris(logistic_iris, batch_size):
 
 def test_get_wachter_grads(logistic_iris):
     X, y, lr = logistic_iris
-    predict_fn = lambda x: lr.predict_proba(x.reshape(1, -1))
-    x = X[0]
+    predict_fn = lr.predict_proba
+    x = X[0].reshape(1, -1)
     probas = predict_fn(x)
     pred_class = probas.argmax()
     func, target = _define_func(predict_fn, pred_class, 'same')
 
-    loss, grad_loss = get_wachter_grads(X_current=x, predict_class_fn=func, distance_fn=cityblock,
+    loss, grad_loss = get_wachter_grads(X_current=x, predict_class_fn=func, distance_fn=cityblock_batch,
                                         X_test=x, target_proba=0.1, lam=1)
 
-    assert loss.shape == (1,)
-    assert grad_loss.shape == x.shape
+    assert loss.shape == (1, 1)
+    assert grad_loss.shape == x.reshape(1, 1, 4).shape
 
 
+@pytest.mark.skip(reason='This will change')
 @pytest.mark.parametrize('iris_explainer',
                          ['other', 'same', 0, 1, 2],
                          indirect=True)

--- a/alibi/explainers/counterfactual/tests/test_counterfactual.py
+++ b/alibi/explainers/counterfactual/tests/test_counterfactual.py
@@ -2,14 +2,15 @@ import pytest
 import numpy as np
 from sklearn.datasets import load_iris
 from sklearn.linear_model import LogisticRegression
+from scipy.spatial.distance import cityblock
 
-from alibi.explainers.counterfactual.counterfactual  import _define_func
+from alibi.explainers.counterfactual.counterfactual import _define_func, num_grad
 
 
 @pytest.fixture
 def logistic_iris():
     X, y = load_iris(return_X_y=True)
-    lr = LogisticRegression().fit(X, y)
+    lr = LogisticRegression(solver='lbfgs', multi_class='multinomial', max_iter=200).fit(X, y)
     return X, y, lr
 
 
@@ -36,3 +37,38 @@ def test_define_func(logistic_iris, target_class):
         # highest probability different to the class of x
         ix2 = np.argsort(-probas)[:, 1]
         assert func(x) == probas[:, ix2]
+
+
+@pytest.mark.parametrize('dim', [1, 2, 3, 10])
+def test_get_num_gradients_cityblock(dim):
+    u = np.random.rand(dim)
+    v = np.random.rand(dim)
+
+    grad_true = np.sign(u - v)
+    grad_approx = num_grad(cityblock, u, args=tuple([v])).flatten()  # promote 0-D to 1-D
+
+    assert grad_approx.shape == grad_true.shape
+    assert np.allclose(grad_true, grad_approx)
+
+
+def test_get_num_gradients_logistic_iris(logistic_iris):
+    X, y, lr = logistic_iris
+    predict_fn = lr.predict_proba
+    x = X[0].reshape(1, -1)
+    probas = predict_fn(x)
+    pred_class = probas.argmax()
+
+    # true gradient of the softmax function wrt x
+    grad_true = (probas.T * (np.eye(3, 3) - probas) @ lr.coef_).sum(axis=1)
+    grad_approx = num_grad(predict_fn, x)
+
+    assert grad_approx.shape == grad_true.shape
+    assert np.allclose(grad_true, grad_approx)
+
+    # now restrict to just one class
+    func, target = _define_func(predict_fn, pred_class, 'same')
+    grad_true = grad_true[0]
+    grad_approx = num_grad(func, x)
+
+    assert grad_approx.shape == grad_true.shape
+    assert np.allclose(grad_true, grad_approx)

--- a/alibi/explainers/counterfactual/tests/test_counterfactual.py
+++ b/alibi/explainers/counterfactual/tests/test_counterfactual.py
@@ -1,0 +1,38 @@
+import pytest
+import numpy as np
+from sklearn.datasets import load_iris
+from sklearn.linear_model import LogisticRegression
+
+from alibi.explainers.counterfactual.counterfactual  import _define_func
+
+
+@pytest.fixture
+def logistic_iris():
+    X, y = load_iris(return_X_y=True)
+    lr = LogisticRegression().fit(X, y)
+    return X, y, lr
+
+
+@pytest.mark.parametrize('target_class', ['other', 'same', 0, 1, 2])
+def test_define_func(logistic_iris, target_class):
+    X, y, model = logistic_iris
+
+    x = X[0].reshape(1, -1)
+    predict_fn = model.predict_proba
+    probas = predict_fn(x)
+    pred_class = probas.argmax(axis=1)[0]
+    pred_prob = probas[:, pred_class][0]
+
+    func, target = _define_func(predict_fn, pred_class, target_class)
+
+    if target_class == 'same':
+        assert target == pred_class
+        assert func(x) == pred_prob
+    elif isinstance(target_class, int):
+        assert target == target_class
+        assert func(x) == probas[:, target]
+    elif target_class == 'other':
+        assert target == 'other'
+        # highest probability different to the class of x
+        ix2 = np.argsort(-probas)[:, 1]
+        assert func(x) == probas[:, ix2]

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,3 +9,4 @@ beautifulsoup4>=4.7.1
 Keras>=2.2.4
 tensorflow>=1.13.1
 seaborn>=0.9.0
+statsmodels>=0.9.0

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(name='alibi',
           'spacy',
           'scikit-image',
           'tensorflow',
-          'seaborn'
+          'seaborn',
           'statsmodels'
       ],
       tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(name='alibi',
           'scikit-image',
           'tensorflow',
           'seaborn'
+          'statsmodels'
       ],
       tests_require=[
           'pytest',


### PR DESCRIPTION
This pull request will implement the counterfactual search algorithm from [Wachter et al. (2017)](https://arxiv.org/abs/1711.00399).

- [x] Define a prediction function to be optimized (options: 'same' to optimize towards a target probability of the same class, 'other' - any other class different from the predicted class, and an integer value - find a counterfactual with a specific class)
 - [x] Numerical gradient function for the black-box prediction function (can use `statsmodels.tools.numdiff.approx_fprime`
 - [x] Distance function (`L1`)
 - [ ] Optional `.fit` method if training set is available - scale distance by MADs (use `functools.partial` to make it a 2-argument distance)
 - [x] Calculate gradients of the Wachter loss
 - [x] Minimize loss for some number of steps or until a maximum `lambda` is reached
 - [x] Incorporate tolerance around the target probability
 - [x] Sensible defaults for allowed feature ranges and epsilons in numerical gradient evaluations
 - [ ] Incorporate distance loss into the TF graph for speed
 - [ ] Support TF and Keras models by directly back-propagating through to get prediction gradients
 - [ ] Use bisection to increase/decrease `lambda` to find the counterfactual with the highest possible `lambda` (closest to the test instance)
 - [ ] Look into learning rate scheduling, particularly to accelerate learning if prediction gradients are small