### PR TITLE
Revert "Don't mock keras for docs"

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -71,7 +71,7 @@ apidoc_extra_args = ['-d 6']
 
 # mock imports
 autodoc_mock_imports = ['pandas', 'sklearn', 'spacy', 'skimage', 'requests',
-                        'cv2', 'bs4', 'seaborn']
+                        'cv2', 'bs4', 'keras', 'seaborn']
 
 # Napoleon settings
 napoleon_google_docstring = True


### PR DESCRIPTION
Reverts SeldonIO/alibi#98, something went wrong and the API docs are not build at all.