### PR TITLE
Allow a list of strings of column names for dataframes in gen_category_map

### DIFF
--- a/alibi/utils/data.py
+++ b/alibi/utils/data.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pandas as pd
 from sklearn.preprocessing import LabelEncoder
-from typing import Dict, Union
+from typing import Dict, List, Union
+
 
 # TODO: This should inherit from collections.UserDict not dict
 
@@ -29,7 +30,7 @@ class Bunch(dict):
 
 
 def gen_category_map(data: Union[pd.DataFrame, np.ndarray],
-                     categorical_columns: list = None) -> Dict[int, list]:
+                     categorical_columns: Union[List[int], List[str], None] = None) -> Dict[int, list]:
     """
 
     Parameters
@@ -55,6 +56,8 @@ def gen_category_map(data: Union[pd.DataFrame, np.ndarray],
         # if numpy array, we need categorical_columns, otherwise impossible to infer
         if categorical_columns is None:
             raise ValueError('If passing a numpy array, `categorical_columns` is required')
+        elif not all(isinstance(ix, int) for ix in categorical_columns):
+            raise ValueError('If passing a numpy array, `categorical_columns` must be a list of integers')
         data = pd.DataFrame(data)
 
     # infer categorical columns
@@ -65,8 +68,10 @@ def gen_category_map(data: Union[pd.DataFrame, np.ndarray],
             raise
 
     # create the map
-    category_map = dict.fromkeys(categorical_columns)
+    category_map = {}
     for col in categorical_columns:
+        if not isinstance(col, int):
+            col = int(data.columns.get_loc(col))
         le = LabelEncoder()
         try:
             _ = le.fit_transform(data.iloc[:, col])

--- a/alibi/utils/tests/test_data.py
+++ b/alibi/utils/tests/test_data.py
@@ -9,21 +9,21 @@ data = {'col1': [1, 2, 3, 4, 5],
         'col3': [1., 2., 3., 4., 5.],
         'col4': ['a', 'a', 'b', 'b', 'c']}
 
+expected_category_map = {1: ['a', 'b', 'c', 'd', 'f'],
+                         3: ['a', 'b', 'c']}
+
 dframe = pd.DataFrame(data=data)
 arr = dframe.values
 
 
 @pytest.mark.parametrize('df', [dframe, arr])
-@pytest.mark.parametrize('categorical_columns', [None, [1, 3]])
+@pytest.mark.parametrize('categorical_columns', [None, [1, 3], ['col2', 'col4']])
 def test_get_category_map(categorical_columns, df):
     # test numpy case with no categorical_columns raises error
-    if df is arr and categorical_columns is None:
+    if df is arr and (categorical_columns is None or categorical_columns == ['col2', 'col4']):
         with pytest.raises(ValueError):
             _ = gen_category_map(df)
 
     else:
         category_map = gen_category_map(df, categorical_columns=categorical_columns)
-        assert list(category_map.keys()) == CAT_COLUMNS_IX
-
-        for ix, C in zip(CAT_COLUMNS_IX, CAT_COLUMNS):
-            assert len(set(data[C])) == len(category_map[ix])
+        assert category_map == expected_category_map


### PR DESCRIPTION
Resolves #213.

- Can specify `categorical_columns` as `List[str]` if `data` is `pd.DataFrame`
- Simplified test, now checking for equality of `categorical_map`
- Note that even if `categorical_columns` is `List[str]` the output is always `Dict[int, list]`, the integer indices are got by calling `data.columns.get_loc(col)`.