### PR TITLE
Fix unused format argument

### DIFF
--- a/alibi/explainers/tests/test_kernel_shap.py
+++ b/alibi/explainers/tests/test_kernel_shap.py
@@ -362,7 +362,7 @@ def test__get_data(mock_ks_explainer, data_dimension, data_type, group_settings,
     )
     # the algorithm would take this step in fit before calling _get_data
     if not b_group_names and b_groups:
-        group_names = ['group_i'.format(i) for i in range(len(groups))]
+        group_names = ['group_{}'.format(i) for i in range(len(groups))]
 
     # initialise a KernelShap with a mock predictor
     explainer = mock_ks_explainer


### PR DESCRIPTION
Newest flake8 release caught an unused string format argument error in a test file.