### PR TITLE
Fix math typo in treeshap

### DIFF
--- a/doc/source/methods/TreeSHAP.ipynb
+++ b/doc/source/methods/TreeSHAP.ipynb
@@ -41,7 +41,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -573,7 +572,7 @@
     "\n",
     "To summarise, the efficient algorithm relies on the following key ideas:\n",
     "\n",
-    "- each node in the tree is assigned a positive contribution reflecting membership of the splitting feature in a subset $S$ and a negative contribution to indicate the feature is missing ($i \\in \\bar{S} $)\n",
+    "- each node in the tree is assigned a positive contribution reflecting membership of the splitting feature in a subset $S$ and a negative contribution to indicate the feature is missing ($i\\in \\bar{S}$)\n",
     "\n",
     "- the positive and negative contributions of a node can be computed by summing the positive and negative contributions  of the children nodes, in keeping with the fact that the Shapley value can be computed by summing a contribution from each path the feature is on \n",
     "\n",


### PR DESCRIPTION
Nbsphinx doesn't like spaces next to $ signs in math mode...