### PR TITLE
Fix images not showing up in ALE docs

### DIFF
--- a/doc/source/methods/ALE.ipynb
+++ b/doc/source/methods/ALE.ipynb
@@ -75,7 +75,7 @@
     "\n",
     "The following is an example ALE plot of a logistic regression model on the Iris dataset (see worked [example](../examples/ale_classification.nblink)):\n",
     "\n",
-    "![ALE_iris](ale_iris.png)"
+    "![ALE-iris](ale_iris.png)"
    ]
   },
   {
@@ -162,7 +162,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![PDP_M_estimation](pdp_m.png)"
+    "![PDP-M-estimation](pdp_m.png)"
    ]
   },
   {
@@ -211,7 +211,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![ALE_estimation](ale_est.png)"
+    "![ALE-estimation](ale_est.png)"
    ]
   },
   {
@@ -228,7 +228,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![ALE_plots](ale_plots.png)"
+    "![ALE-plots](ale_plots.png)"
    ]
   },
   {


### PR DESCRIPTION
This was due to the older version of `pandoc` on readthedocs not liking underscores in alt-text....