### PR TITLE
Require typing_extensions version at least 3.7.2

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,4 +12,4 @@ prettyprinter>=0.18.0
 shap>=0.35.0
 scipy>=1.3.1
 matplotlib>=3.1.2
-typing-extensions>=3.7.4
+typing-extensions>=3.7.2

--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -32,4 +32,4 @@ shap>=0.35.0
 scipy>=1.3.1
 matplotlib>=3.1.2
 catboost>=0.23
-typing-extensions>=3.7.4
+typing-extensions>=3.7.2

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(name='alibi',
           'tensorflow<2.0',
           'shap',
           'scipy',
-          'typing-extensions'
+          'typing-extensions>=3.7.2'
       ],
       tests_require=[
           'pytest',


### PR DESCRIPTION
Prior to 3.7.2 there was no Literal type. It is necessary to provide a
minimum version in setup.py especially as e.g. Colab uses an older
version due to an older Chainer being pre-installed.