### PR TITLE
Update expected value after explain call

### DIFF
--- a/alibi/explainers/shap_wrappers.py
+++ b/alibi/explainers/shap_wrappers.py
@@ -770,12 +770,13 @@ class KernelShap(Explainer, FitMixin):
             X = X.toarray()
 
         shap_values = self._explainer.shap_values(X, **kwargs)
+        self.expected_value = self._explainer.expected_value
         expected_value = self.expected_value
         # for scalar model outputs a single numpy array is returned
         if isinstance(shap_values, np.ndarray):
             shap_values = [shap_values]
         if isinstance(expected_value, float):
-            expected_value = [self.expected_value]
+            expected_value = [expected_value]
 
         explanation = self.build_explanation(
             X,
@@ -1246,11 +1247,12 @@ class TreeShap(Explainer, FitMixin):
                 approximate=self.approximate,
                 check_additivity=check_additivity,
             )
+        self.expected_value = self._explainer.expected_value
         expected_value = self.expected_value
         if isinstance(shap_output, np.ndarray):
             shap_output = [shap_output]
         if isinstance(expected_value, float):
-            expected_value = [self.expected_value]
+            expected_value = [expected_value]
 
         explanation = self.build_explanation(
             X,


### PR DESCRIPTION
Fixes #253 .

Also updated `KernelShap` for consistency even though the current implementation in `shap.kernel` doesn't change the `expected_value` after the call to `shap_values`.

Initially was going to remove `expected_value` as an attribute, then realized we use it in tests. Was rewriting tests when realized we also use it in examples, so in the end kept it as an attribute that is present after `fit`.