### PR TITLE
Import lazy_fixture explicitly due to pytest namespace deprecation

### DIFF
--- a/alibi/explainers/tests/test_ale.py
+++ b/alibi/explainers/tests/test_ale.py
@@ -7,7 +7,7 @@ from alibi.api.defaults import DEFAULT_DATA_ALE, DEFAULT_META_ALE
 
 
 @pytest.mark.parametrize('min_bin_points', [1, 4, 10])
-@pytest.mark.parametrize('dataset', [pytest.lazy_fixture('boston_data')])
+@pytest.mark.parametrize('dataset', [lazy_fixture('boston_data')])
 @pytest.mark.parametrize('lr_regressor',
                          [lazy_fixture('boston_data')],
                          indirect=True,

--- a/alibi/explainers/tests/test_ale.py
+++ b/alibi/explainers/tests/test_ale.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest_lazyfixture import lazy_fixture
 import numpy as np
 from numpy.testing import assert_allclose
 from alibi.explainers.ale import ale_num, adaptive_grid, get_quantiles, minimum_satisfied
@@ -8,7 +9,7 @@ from alibi.api.defaults import DEFAULT_DATA_ALE, DEFAULT_META_ALE
 @pytest.mark.parametrize('min_bin_points', [1, 4, 10])
 @pytest.mark.parametrize('dataset', [pytest.lazy_fixture('boston_data')])
 @pytest.mark.parametrize('lr_regressor',
-                         [pytest.lazy_fixture('boston_data')],
+                         [lazy_fixture('boston_data')],
                          indirect=True,
                          ids='reg=lr_{}'.format)
 def test_ale_num_linear_regression(min_bin_points, lr_regressor, dataset):
@@ -26,9 +27,9 @@ def test_ale_num_linear_regression(min_bin_points, lr_regressor, dataset):
 
 
 @pytest.mark.parametrize('min_bin_points', [1, 4, 10])
-@pytest.mark.parametrize('dataset', [pytest.lazy_fixture('iris_data')])
+@pytest.mark.parametrize('dataset', [lazy_fixture('iris_data')])
 @pytest.mark.parametrize('lr_classifier',
-                         [pytest.lazy_fixture('iris_data')],
+                         [lazy_fixture('iris_data')],
                          indirect=True,
                          ids='clf=lr_{}'.format)
 def test_ale_num_logistic_regression(min_bin_points, lr_classifier, dataset):

--- a/alibi/explainers/tests/test_anchor_base.py
+++ b/alibi/explainers/tests/test_anchor_base.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest_lazyfixture import lazy_fixture
 
 import numpy as np
 
@@ -6,7 +7,7 @@ from copy import deepcopy
 
 
 @pytest.mark.parametrize('rf_classifier',
-                         [pytest.lazy_fixture('iris_data')],
+                         [lazy_fixture('iris_data')],
                          indirect=True,
                          ids='clf=rf_{}'.format,
                          )

--- a/alibi/explainers/tests/test_anchor_tabular.py
+++ b/alibi/explainers/tests/test_anchor_tabular.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 
 import numpy as np
 import pytest
+from pytest_lazyfixture import lazy_fixture
 
 from collections import defaultdict
 from copy import deepcopy
@@ -45,12 +46,12 @@ def uncollect_if_test_explainer(**kwargs):
 @pytest.mark.parametrize('n_explainer_runs', [10], ids='n_exp_runs={}'.format)
 @pytest.mark.parametrize('at_defaults', [0.9, 0.95], ids='threshold={}'.format, indirect=True)
 @pytest.mark.parametrize('rf_classifier',
-                         [pytest.lazy_fixture('iris_dataset'), pytest.lazy_fixture('adult_data')],
+                         [lazy_fixture('iris_dataset'), lazy_fixture('adult_data')],
                          indirect=True,
                          ids='clf=rf_{}'.format,
                          )
 @pytest.mark.parametrize('explainer',
-                         [pytest.lazy_fixture('at_iris_explainer'), pytest.lazy_fixture('at_adult_explainer')],
+                         [lazy_fixture('at_iris_explainer'), lazy_fixture('at_adult_explainer')],
                          ids='exp={}'.format,
                          )
 @pytest.mark.parametrize('test_instance_idx', [0], ids='test_instance_idx={}'.format)
@@ -89,7 +90,7 @@ def test_explainer(n_explainer_runs, at_defaults, rf_classifier, explainer, test
 @pytest.mark.parametrize('predict_type', ('proba', 'class'), ids='predict_type={}'.format)
 @pytest.mark.parametrize('at_defaults', [0.95], ids='threshold={}'.format, indirect=True)
 @pytest.mark.parametrize('rf_classifier',
-                         [pytest.lazy_fixture('iris_data')],
+                         [lazy_fixture('iris_data')],
                          indirect=True,
                          ids='clf=rf_{}'.format,
                          )
@@ -184,16 +185,16 @@ def uncollect_if_test_sampler(**kwargs):
 @pytest.mark.parametrize('nb_samples', [100], ids='nb_samples={}'.format)
 @pytest.mark.parametrize('anchors', [((2,), (10,), (11,), (7, 10, 11), (3, 11))], ids='anchors={}'.format)
 @pytest.mark.parametrize('dataset',
-                         [pytest.lazy_fixture('adult_data'), pytest.lazy_fixture('iris_data')],
+                         [lazy_fixture('adult_data'), lazy_fixture('iris_data')],
                          ids='dataset={}'.format,
                          )
 @pytest.mark.parametrize('rf_classifier',
-                         [pytest.lazy_fixture('adult_data'), pytest.lazy_fixture('iris_data')],
+                         [lazy_fixture('adult_data'), lazy_fixture('iris_data')],
                          indirect=True,
                          ids='clf=rf_{}'.format,
                          )
 @pytest.mark.parametrize('explainer',
-                         [pytest.lazy_fixture('at_iris_explainer'), pytest.lazy_fixture('at_adult_explainer')],
+                         [lazy_fixture('at_iris_explainer'), lazy_fixture('at_adult_explainer')],
                          ids='exp={}'.format,
                          )
 def test_sampler(test_instance_idx, anchors, nb_samples, dataset, rf_classifier, explainer):

--- a/alibi/explainers/tests/test_anchor_text.py
+++ b/alibi/explainers/tests/test_anchor_text.py
@@ -1,5 +1,6 @@
 # flake8: noqa E731
 import pytest
+from pytest_lazyfixture import lazy_fixture
 import spacy
 
 import numpy as np
@@ -19,7 +20,7 @@ nlp = spacy.load(model)
 @pytest.mark.parametrize('text, n_punctuation_marks, n_unique_words',
                          [('This is a good book.', 1, 6),
                           ('I, for one, hate it.', 3, 7)])
-@pytest.mark.parametrize('lr_classifier', [pytest.lazy_fixture('movie_sentiment_data')], indirect=True)
+@pytest.mark.parametrize('lr_classifier', [lazy_fixture('movie_sentiment_data')], indirect=True)
 @pytest.mark.parametrize("predict_type, anchor, use_similarity_proba, use_unk, threshold", [
     ('proba', (), False, True, 0.95),
     ('class', (), False, True, 0.95),


### PR DESCRIPTION
`pytest` has deprecated their namespace hooks so functionality from plugins must be imported explicitly. This bug was found by running `mypy` with the latest `pytest` in the environment here: #280 .