### PR TITLE
Pin shap version to 0.35.0 to prepare for upgrade for 0.36.0

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,7 +9,7 @@ beautifulsoup4>=4.7.1
 tensorflow>=2.0
 attrs>=19.1.0
 prettyprinter>=0.18.0
-shap>=0.35.0
+shap==0.35.0
 scipy>=1.3.1
 matplotlib>=3.1.2
 typing-extensions>=3.7.2

--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -28,7 +28,7 @@ ipykernel>=5.1.0
 ipython>=7.2.0
 codecov>=2.0.15
 pre-commit>=1.20.0
-shap>=0.35.0
+shap==0.35.0
 scipy>=1.3.1
 matplotlib>=3.1.2
 catboost>=0.23

--- a/requirements/requirements_ci.txt
+++ b/requirements/requirements_ci.txt
@@ -15,7 +15,7 @@ ipykernel>=5.1.0
 ipython>=7.2.0
 codecov>=2.0.15
 pre-commit>=1.20.0
-shap>=0.35.0
+shap==0.35.0
 catboost>=0.23
 Keras>=2.2.4,<2.4.0
 git+git://github.com/SeldonIO/alibi-testing@master#egg=alibi-testing

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(name='alibi',
           'spacy[lookups]',
           'scikit-image!=0.17.1',  # https://github.com/SeldonIO/alibi/issues/215
           'tensorflow>=2.0',
-          'shap',
+          'shap==0.35',
           'scipy',
           'typing-extensions>=3.7.2'
       ],


### PR DESCRIPTION
Pinning `shap` version until we uprade the wrappers and examples to support `0.36.0` 