### PR TITLE
Upgrade deprecated pre-commit flake8, add nbqa-pyupgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,13 @@
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
     hooks:
       - id: flake8
+  - repo: https://github.com/nbQA-dev/nbqa
+    rev: 0.3.2
+    hooks:
+      - id: nbqa-pyupgrade
+        args: [--nbqa-mutate, --py36-plus]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.740
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ one of the requirements for running the test suite.
 We use `flake8` for linting adhering to PEP8 with exceptions defined in `setup.cfg`.
 
 ## Syntax
-We use `pyupgrade` (via `nbqa`) to ensure that the Jupyter Notebooks in the documentation make use of syntax from
+We use `pyupgrade` (run via `nbqa`) to ensure that the Jupyter Notebooks in the documentation make use of syntax from
 Python3.6 onwards.
 
 ## Type checking

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,10 @@ one of the requirements for running the test suite.
 ## Linter
 We use `flake8` for linting adhering to PEP8 with exceptions defined in `setup.cfg`.
 
+## Syntax
+We use `pyupgrade` (via `nbqa`) to ensure that the Jupyter Notebooks in the documentation make use of syntax from
+Python3.6 onwards.
+
 ## Type checking
 We use type hints to develop the libary and `mypy` to for static type checking. Some
 options are defined in `setup.cfg`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ This will install everything needed to run alibi and all the dev tools
 
 ## Git pre-commit hooks
 To make it easier to format code locally before submitting a PR, we provide
-integration with `pre-commit` to run `flake8` and `mypy` hooks before every commit.
+integration with `pre-commit` to run `flake8`, `mypy` and `pyupgrade` (via `nbqa`) hooks before every commit.
 After installing the development requirements and cloning the package, run `pre-commit install`
 from the project root to install the hooks locally. Now before every `git commit ...`
 these hooks will be run to verify that the linting and type checking is correct. If there are
@@ -34,8 +34,8 @@ one of the requirements for running the test suite.
 We use `flake8` for linting adhering to PEP8 with exceptions defined in `setup.cfg`.
 
 ## Syntax
-We use `pyupgrade` (run via `nbqa`) to ensure that the Jupyter Notebooks in the documentation make use of syntax from
-Python3.6 onwards.
+We use `pyupgrade` (run via `nbqa`) to ensure that the Jupyter notebooks in the documentation make use of syntax from
+Python 3.6 onwards.
 
 ## Type checking
 We use type hints to develop the libary and `mypy` to for static type checking. Some

--- a/examples/anchor_image_imagenet.ipynb
+++ b/examples/anchor_image_imagenet.ipynb
@@ -70,7 +70,7 @@
     "category = 'Persian cat'\n",
     "image_shape = (299, 299, 3)\n",
     "data, labels = fetch_imagenet(category, nb_images=10, target_size=image_shape[:2], seed=2, return_X_y=True)\n",
-    "print('Images shape: {}'.format(data.shape))"
+    "print(f'Images shape: {data.shape}')"
    ]
   },
   {

--- a/examples/cem_iris.ipynb
+++ b/examples/cem_iris.ipynb
@@ -266,7 +266,7 @@
     }
    ],
    "source": [
-    "print('Original instance: {}'.format(explanation.X))\n",
+    "print(f'Original instance: {explanation.X}')\n",
     "print('Predicted class: {}'.format(class_names[explanation.X_pred]))"
    ]
   },
@@ -285,7 +285,7 @@
     }
    ],
    "source": [
-    "print('Pertinent negative: {}'.format(explanation.PN))\n",
+    "print(f'Pertinent negative: {explanation.PN}')\n",
     "print('Predicted class: {}'.format(class_names[explanation.PN_pred]))"
    ]
   },
@@ -362,7 +362,7 @@
     }
    ],
    "source": [
-    "print('Pertinent positive: {}'.format(explanation.PP))\n",
+    "print(f'Pertinent positive: {explanation.PP}')\n",
     "print('Predicted class: {}'.format(class_names[explanation.PP_pred]))"
    ]
   },
@@ -563,7 +563,7 @@
     }
    ],
    "source": [
-    "print('Original instance: {}'.format(explanation.X))\n",
+    "print(f'Original instance: {explanation.X}')\n",
     "print('Predicted class: {}'.format(class_names[explanation.X_pred]))"
    ]
   },
@@ -582,7 +582,7 @@
     }
    ],
    "source": [
-    "print('Pertinent negative: {}'.format(explanation.X))\n",
+    "print(f'Pertinent negative: {explanation.X}')\n",
     "print('Predicted class: {}'.format(class_names[explanation.X_pred]))"
    ]
   },

--- a/examples/cem_mnist.ipynb
+++ b/examples/cem_mnist.ipynb
@@ -537,7 +537,7 @@
     }
    ],
    "source": [
-    "print('Pertinent negative prediction: {}'.format(explanation.PN_pred))\n",
+    "print(f'Pertinent negative prediction: {explanation.PN_pred}')\n",
     "plt.imshow(explanation.PN.reshape(28, 28));"
    ]
   },
@@ -606,7 +606,7 @@
     }
    ],
    "source": [
-    "print('Pertinent positive prediction: {}'.format(explanation.PP_pred))\n",
+    "print(f'Pertinent positive prediction: {explanation.PP_pred}')\n",
     "plt.imshow(explanation.PP.reshape(28, 28));"
    ]
   },

--- a/examples/cfproto_housing.ipynb
+++ b/examples/cfproto_housing.ipynb
@@ -319,7 +319,7 @@
     }
    ],
    "source": [
-    "print('Original prediction: {}'.format(explanation.orig_class))\n",
+    "print(f'Original prediction: {explanation.orig_class}')\n",
     "print('Counterfactual prediction: {}'.format(explanation.cf['class']))"
    ]
   },

--- a/examples/cfproto_mnist.ipynb
+++ b/examples/cfproto_mnist.ipynb
@@ -433,7 +433,7 @@
    ],
    "source": [
     "print('Counterfactual prediction: {}'.format(explanation.cf['class']))\n",
-    "print('Closest prototype class: {}'.format(explanation.id_proto))\n",
+    "print(f'Closest prototype class: {explanation.id_proto}')\n",
     "plt.imshow(explanation.cf['X'].reshape(28, 28));"
    ]
   },
@@ -471,7 +471,7 @@
    ],
    "source": [
     "iter_cf = 0\n",
-    "print('iteration c {}'.format(iter_cf))\n",
+    "print(f'iteration c {iter_cf}')\n",
     "n = len(explanation['all'][iter_cf])\n",
     "plt.figure(figsize=(20, 4))\n",
     "for i in range(n):\n",
@@ -553,7 +553,7 @@
    ],
    "source": [
     "print('Counterfactual prediction: {}'.format(explanation_k1.cf['class']))\n",
-    "print('Closest prototype class: {}'.format(explanation.id_proto))\n",
+    "print(f'Closest prototype class: {explanation.id_proto}')\n",
     "plt.imshow(explanation_k1.cf['X'].reshape(28, 28));"
    ]
   },
@@ -592,7 +592,7 @@
    ],
    "source": [
     "print('Counterfactual prediction: {}'.format(explanation_k20.cf['class']))\n",
-    "print('Closest prototype class: {}'.format(explanation.id_proto))\n",
+    "print(f'Closest prototype class: {explanation.id_proto}')\n",
     "plt.imshow(explanation_k20.cf['X'].reshape(28, 28));"
    ]
   },
@@ -676,7 +676,7 @@
    ],
    "source": [
     "print('Counterfactual prediction: {}'.format(explanation.cf['class']))\n",
-    "print('Closest prototype class: {}'.format(explanation.id_proto))\n",
+    "print(f'Closest prototype class: {explanation.id_proto}')\n",
     "plt.imshow(explanation.cf['X'].reshape(28, 28));"
    ]
   },
@@ -769,7 +769,7 @@
    ],
    "source": [
     "print('Counterfactual prediction: {}'.format(explanation_1.cf['class']))\n",
-    "print('Closest prototype class: {}'.format(proto_1))\n",
+    "print(f'Closest prototype class: {proto_1}')\n",
     "plt.imshow(explanation_1.cf['X'].reshape(28, 28));"
    ]
   },
@@ -801,7 +801,7 @@
    ],
    "source": [
     "print('Counterfactual prediction: {}'.format(explanation_2.cf['class']))\n",
-    "print('Closest prototype class: {}'.format(proto_2))\n",
+    "print(f'Closest prototype class: {proto_2}')\n",
     "plt.imshow(explanation_2.cf['X'].reshape(28, 28));"
    ]
   },
@@ -914,7 +914,7 @@
    ],
    "source": [
     "print('Counterfactual prediction: {}'.format(explanation.cf['class']))\n",
-    "print('Closest prototype class: {}'.format(explanation.id_proto))\n",
+    "print(f'Closest prototype class: {explanation.id_proto}')\n",
     "plt.imshow(explanation.cf['X'].reshape(28, 28));"
    ]
   },
@@ -990,7 +990,7 @@
    ],
    "source": [
     "print('Counterfactual prediction: {}'.format(explanation.cf['class']))\n",
-    "print('Closest prototype class: {}'.format(explanation.id_proto))\n",
+    "print(f'Closest prototype class: {explanation.id_proto}')\n",
     "plt.imshow(explanation.cf['X'].reshape(28, 28));"
    ]
   },

--- a/examples/integrated_gradients_imagenet.ipynb
+++ b/examples/integrated_gradients_imagenet.ipynb
@@ -73,7 +73,7 @@
     "category = 'Persian cat'\n",
     "image_shape = (224, 224, 3)\n",
     "data, labels = fetch_imagenet(category, nb_images=3, target_size=image_shape[:2], seed=2, return_X_y=True)\n",
-    "print('Images shape: {}'.format(data.shape))\n",
+    "print(f'Images shape: {data.shape}')\n",
     "data = (data / 255).astype('float32')"
    ]
   },

--- a/examples/integrated_gradients_imdb.ipynb
+++ b/examples/integrated_gradients_imdb.ipynb
@@ -105,7 +105,7 @@
     "print('x_test shape:', x_test.shape)\n",
     "\n",
     "index = imdb.get_word_index()\n",
-    "reverse_index = dict([(value, key) for (key, value) in index.items()]) "
+    "reverse_index = {value: key for (key, value) in index.items()} "
    ]
   },
   {
@@ -433,7 +433,7 @@
     "    \"\"\"\n",
     "    Return HTML markup highlighting text with the desired color.\n",
     "    \"\"\"\n",
-    "    return \"<mark style=background-color:{}>{} </mark>\".format(color, string)"
+    "    return f\"<mark style=background-color:{color}>{string} </mark>\""
    ]
   },
   {

--- a/examples/kernel_shap_adult_categorical_preproc.ipynb
+++ b/examples/kernel_shap_adult_categorical_preproc.ipynb
@@ -622,7 +622,7 @@
     "                                 fraction_explained, \n",
     "                                 )\n",
     "X_explain_proc = preprocessor.transform(X_explain)\n",
-    "X_explain_proc_d = sparse2ndarray(X_explain_proc)\n"
+    "X_explain_proc_d = sparse2ndarray(X_explain_proc)"
    ]
   },
   {
@@ -740,7 +740,7 @@
     "\n",
     "def compare_ranking(ranking_1, ranking_2, methods=None):\n",
     "    for i, (combined, grouped) in enumerate(zip(ranking_1, ranking_2)):\n",
-    "        print(\"Class: {}\".format(i))\n",
+    "        print(f\"Class: {i}\")\n",
     "        c_names, g_names = combined[1], grouped[1]\n",
     "        c_mag, g_mag = combined[0], grouped[0]\n",
     "        different = []\n",
@@ -757,7 +757,7 @@
     "            print(df)\n",
     "        else:\n",
     "            print(\"The methods provided the same ranking for the feature effects.\")\n",
-    "            print(\"The ranking is: {}\".format(c_names))\n",
+    "            print(f\"The ranking is: {c_names}\")\n",
     "        print(\"\")\n",
     "        \n",
     "def reorder_feats(vals_and_names, src_vals_and_names):\n",
@@ -785,7 +785,7 @@
     "    of the feature names provided in the baseline entries and displays the feature values for comparison.\n",
     "    \"\"\"\n",
     "    \n",
-    "    methods = kwargs.get(\"methods\", [\"method_{}\".format(i) for i in range(len(comparisons) + 1)])\n",
+    "    methods = kwargs.get(\"methods\", [f\"method_{i}\" for i in range(len(comparisons) + 1)])\n",
     "    \n",
     "    n_features = len(baseline[class_idx][0])\n",
     "    \n",
@@ -857,7 +857,7 @@
     "    plt.grid(True)\n",
     "    plt.title(title, fontsize=title_font)\n",
     "\n",
-    "    return ax, fig, df\n"
+    "    return ax, fig, df"
    ]
   },
   {

--- a/examples/kernel_shap_adult_lr.ipynb
+++ b/examples/kernel_shap_adult_lr.ipynb
@@ -523,7 +523,7 @@
     "df = pd.DataFrame(data=d)\n",
     "print(df)\n",
     "total_dim = df['encoded_dim'].sum() \n",
-    "print(\"The dimensionality of the encoded categorical features is {}.\".format(total_dim))\n",
+    "print(f\"The dimensionality of the encoded categorical features is {total_dim}.\")\n",
     "assert total_dim == len(cat_enc_feat_names)"
    ]
   },
@@ -715,7 +715,7 @@
     "    ax.set_yticks(y_pos)\n",
     "    ax.set_yticklabels(feat_names, fontsize=15)\n",
     "    ax.invert_yaxis()                  # labels read top-to-bottom\n",
-    "    ax.set_xlabel('Feature effects for class {}'.format(class_idx), fontsize=15)\n",
+    "    ax.set_xlabel(f'Feature effects for class {class_idx}', fontsize=15)\n",
     "    ax.set_xlim(left=left_x, right=right_x)\n",
     "    \n",
     "    for i, v in enumerate(feat_imp):\n",
@@ -1370,7 +1370,7 @@
    "source": [
     "def compare_ranking(ranking_1, ranking_2, methods=None):\n",
     "    for i, (combined, grouped) in enumerate(zip(ranking_1, ranking_2)):\n",
-    "        print(\"Class: {}\".format(i))\n",
+    "        print(f\"Class: {i}\")\n",
     "        c_names, g_names = combined[1], grouped[1]\n",
     "        c_mag, g_mag = combined[0], grouped[0]\n",
     "        different = []\n",
@@ -1387,7 +1387,7 @@
     "            print(df)\n",
     "        else:\n",
     "            print(\"The methods provided the same ranking for the feature effects.\")\n",
-    "            print(\"The ranking is: {}\".format(c_names))\n",
+    "            print(f\"The ranking is: {c_names}\")\n",
     "        print(\"\")\n",
     "        \n",
     "compare_ranking(ranked_combined_shap_vals, ranked_grouped_shap_vals)"
@@ -1545,7 +1545,7 @@
     "    of the feature names provided in the baseline entries and displays the feature values for comparison.\n",
     "    \"\"\"\n",
     "    \n",
-    "    methods = kwargs.get(\"methods\", [\"method_{}\".format(i) for i in range(len(comparisons) + 1)])\n",
+    "    methods = kwargs.get(\"methods\", [f\"method_{i}\" for i in range(len(comparisons) + 1)])\n",
     "    \n",
     "    n_features = len(baseline[class_idx][0])\n",
     "    \n",
@@ -1719,7 +1719,7 @@
     "idx = 0\n",
     "base_record = X_explain[idx, ]\n",
     "cap_gain = X_explain[idx,feature_names.index('Capital Gain')]\n",
-    "print(\"The capital gain of individual {} is {}!\".format(idx, cap_gain))"
+    "print(f\"The capital gain of individual {idx} is {cap_gain}!\")"
    ]
   },
   {
@@ -1985,10 +1985,10 @@
    "source": [
     "# the 7th record from the filtered ones would be predicted to make an income > $50k\n",
     "income_pred_probas = pred_fcn(preprocessor.transform(hyp_record[0:-1:5][7,:][None,:]))\n",
-    "print(\"Prediction probabilities: {}\".format(income_pred_probas))\n",
+    "print(f\"Prediction probabilities: {income_pred_probas}\")\n",
     "# we can see that the minimum capital gain for the prediction to change is: $3,500\n",
     "cap_gain_min = hyp_record[0:-1:5][7,feature_names.index('Capital Gain')]\n",
-    "print(\"Minimum capital gain is: ${}\".format(cap_gain_min))"
+    "print(f\"Minimum capital gain is: ${cap_gain_min}\")"
    ]
   },
   {
@@ -2195,7 +2195,7 @@
    "outputs": [],
    "source": [
     "comparisons = exp_data['ranked_shap_vals']\n",
-    "methods = ['train_fraction={}'.format(fr) for fr in split_fractions] + ['exact']\n",
+    "methods = [f'train_fraction={fr}' for fr in split_fractions] + ['exact']\n",
     "_, fg, df = compare_avg_mag_shap(class_idx,\n",
     "                                 comparisons,\n",
     "                                 ranked_combined_exact_shap,\n",
@@ -2320,7 +2320,7 @@
     "                                 tick_labels_fontsize=15,\n",
     "                                 title=\"Comparison of exact shap values infered from a small (128) and a large (1024) explanation dataset\",\n",
     "                                 title_fontsize=15,\n",
-    "                                 xlabel='Feature effects (class {})'.format(class_idx),\n",
+    "                                 xlabel=f'Feature effects (class {class_idx})',\n",
     "                                 ylabel='Features'\n",
     "                                )"
    ]
@@ -2363,7 +2363,7 @@
     "                                 tick_labels_fontsize=15,\n",
     "                                 title=\"Comparison of approximate shap values infered from a small (128) and a large (1024) explanation dataset\",\n",
     "                                 title_fontsize=15,\n",
-    "                                 xlabel='Feature effects (class {})'.format(class_idx),\n",
+    "                                 xlabel=f'Feature effects (class {class_idx})',\n",
     "                                 ylabel='Features'\n",
     "                                )"
    ]

--- a/examples/kernel_shap_wine_intro.ipynb
+++ b/examples/kernel_shap_wine_intro.ipynb
@@ -652,7 +652,7 @@
     "    decision_scores = classifier.decision_function(instance)\n",
     "    \n",
     "    if not class_names:\n",
-    "        class_names = ['Class {}'.format(i) for i in range(decision_scores.shape[1])]\n",
+    "        class_names = [f'Class {i}' for i in range(decision_scores.shape[1])]\n",
     "    \n",
     "    for i, score in enumerate(np.nditer(decision_scores)):\n",
     "        class_names[i] = class_names[i] + ' ({})'.format(round(score.item(),3))\n",

--- a/examples/kernel_shap_wine_lr.ipynb
+++ b/examples/kernel_shap_wine_lr.ipynb
@@ -441,7 +441,7 @@
     "                                 feat_names, \n",
     "                                 left_x=-1.,\n",
     "                                 right_x=1.25,\n",
-    "                                 xlabel = \"Feature effects (class {})\".format(class_idx),\n",
+    "                                 xlabel = f\"Feature effects (class {class_idx})\",\n",
     "                                 ylabel = \"Features\"\n",
     "                                 )"
    ]
@@ -788,9 +788,9 @@
     "x = np.linspace(-3, 4, 1000)\n",
     "plt.scatter(exact_shap[class_idx,...][:, feat_idx], lr_explanation.shap_values[class_idx][:, feat_idx])\n",
     "plt.plot(x, x, linestyle='dashed', color='red')\n",
-    "plt.xlabel('Exact $\\phi_j$', fontsize=18)\n",
-    "plt.ylabel('Estimated $\\phi_j$', fontsize=18)\n",
-    "plt.title(r\"Comparison of estimated and exact shap values for feature '{}'\".format(feat_name))\n",
+    "plt.xlabel(r'Exact $\\phi_j$', fontsize=18)\n",
+    "plt.ylabel(r'Estimated $\\phi_j$', fontsize=18)\n",
+    "plt.title(fr\"Comparison of estimated and exact shap values for feature '{feat_name}'\")\n",
     "plt.grid(True)"
    ]
   },

--- a/examples/linearity_measure_fashion_mnist.ipynb
+++ b/examples/linearity_measure_fashion_mnist.ipynb
@@ -445,17 +445,17 @@
     "lins_classes = []\n",
     "t_0 = time()\n",
     "for j in range(len(class_groups)):\n",
-    "    print('Calculating linearity for instances belonging to class {}'.format(j))\n",
+    "    print(f'Calculating linearity for instances belonging to class {j}')\n",
     "    class_group = class_groups[j]\n",
     "    class_group = np.random.permutation(class_group)[:2000]\n",
     "    t_i = time()\n",
     "    lin = linearity_measure(predict_fn, class_group, feature_range=features_range,\n",
     "                            agg='global', model_type='classifier', nb_samples=20)\n",
     "    t_i_1 = time() - t_i\n",
-    "    print('Run time for class {}: {}'.format(j, t_i_1))\n",
+    "    print(f'Run time for class {j}: {t_i_1}')\n",
     "    lins_classes.append(lin)\n",
     "t_fin = time() - t_0\n",
-    "print('Total run time: {}'.format(t_fin))"
+    "print(f'Total run time: {t_fin}')"
    ]
   },
   {

--- a/examples/trustscore_iris.ipynb
+++ b/examples/trustscore_iris.ipynb
@@ -109,7 +109,7 @@
     "clf = LogisticRegression(solver='liblinear', multi_class='auto')\n",
     "clf.fit(X_train, y_train)\n",
     "y_pred = clf.predict(X_test)\n",
-    "print('Predicted class: {}'.format(y_pred))"
+    "print(f'Predicted class: {y_pred}')"
    ]
   },
   {
@@ -193,8 +193,8 @@
     "                                y_pred, k=2,  # kth nearest neighbor used \n",
     "                                              # to compute distances for each class\n",
     "                                dist_type='point')  # 'point' or 'mean' distance option\n",
-    "print('Trust scores: {}'.format(score))\n",
-    "print('\\nClosest not predicted class: {}'.format(closest_class))"
+    "print(f'Trust scores: {score}')\n",
+    "print(f'\\nClosest not predicted class: {closest_class}')"
    ]
   },
   {


### PR DESCRIPTION
Hi again :wave:

I noticed that in your pre-commit file you reference a deprecated hook, see https://github.com/pre-commit/pre-commit-hooks

> flake8: instead use upstream flake8

So, I've replaced that with the repo homepage (`pre-commit run flake8 --all` still passes). Also, since the minimum Python version you support is Python3.6, I thought I'd add a hook to upgrade the syntax to make sure of Python3.6+'s features