### PR TITLE
Add warning boxes about re-initalizing TF1.x based explainers

### DIFF
--- a/doc/source/methods/CEM.ipynb
+++ b/doc/source/methods/CEM.ipynb
@@ -188,6 +188,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-warning\">\n",
+    "Warning\n",
+    "\n",
+    "Once a `CEM` instance is initialized, the parameters of it are frozen even if creating a new instance. This is due to TensorFlow behaviour which holds on to some global state. In order to change parameters of the explainer in the same session (e.g. for explaining different models), you will need to reset the TensorFlow graph manually:\n",
+    "    \n",
+    "```python\n",
+    "import tensorflow as tf\n",
+    "tf.keras.backend.clear_session()\n",
+    "```\n",
+    "You may need to reload your model after this. Then you can create a new `CEM` instance with new parameters.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Explanation"
    ]
   },
@@ -307,7 +325,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.5"
   },
   "varInspector": {
    "cols": {

--- a/doc/source/methods/CF.ipynb
+++ b/doc/source/methods/CF.ipynb
@@ -138,6 +138,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-warning\">\n",
+    "Warning\n",
+    "\n",
+    "Once a `CounterFactual` instance is initialized, the parameters of it are frozen even if creating a new instance. This is due to TensorFlow behaviour which holds on to some global state. In order to change parameters of the explainer in the same session (e.g. for explaining different models), you will need to reset the TensorFlow graph manually:\n",
+    "    \n",
+    "```python\n",
+    "import tensorflow as tf\n",
+    "tf.keras.backend.clear_session()\n",
+    "```\n",
+    "You may need to reload your model after this. Then you can create a new `CounterFactual` instance with new parameters.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Fit\n",
     "\n",
     "The method is purely unsupervised so no fit method is necessary."
@@ -245,7 +263,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.5"
   },
   "varInspector": {
    "cols": {

--- a/doc/source/methods/CFProto.ipynb
+++ b/doc/source/methods/CFProto.ipynb
@@ -157,6 +157,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-warning\">\n",
+    "Warning\n",
+    "\n",
+    "Once a `CFProto` instance is initialized, the parameters of it are frozen even if creating a new instance. This is due to TensorFlow behaviour which holds on to some global state. In order to change parameters of the explainer in the same session (e.g. for explaining different models), you will need to reset the TensorFlow graph manually:\n",
+    "    \n",
+    "```python\n",
+    "import tensorflow as tf\n",
+    "tf.keras.backend.clear_session()\n",
+    "```\n",
+    "You may need to reload your model after this. Then you can create a new `CFProto` instance with new parameters.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Fit\n",
     "\n",
     "If we use an encoder to find the class prototypes, we need an additional `fit` step on the training data:\n",
@@ -344,7 +362,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.8.5"
   },
   "varInspector": {
    "cols": {


### PR DESCRIPTION
Relates to #298. Whilst we can't fix the behaviour due to TF1.x behaviour, we can highlight this limitation in the docs.