### PR TITLE
Fix incorrect coverage calculation in anchor tabular

### DIFF
--- a/alibi/explainers/anchor_tabular.py
+++ b/alibi/explainers/anchor_tabular.py
@@ -276,7 +276,7 @@ class TabularSampler:
             [allowed_rows[feat] for feat in uniq_feat_ids],
             np.intersect1d),
         )
-        nb_partial_anchors = np.array([len(n_records) for n_records in reversed(partial_anchor_rows)])
+        nb_partial_anchors = np.array([len(n_records) for n_records in partial_anchor_rows])
         coverage = nb_partial_anchors[-1] / self.n_records
 
         # if there are enough train records containing the anchor, replace the original records and return...

--- a/alibi/explainers/anchor_tabular.py
+++ b/alibi/explainers/anchor_tabular.py
@@ -276,8 +276,9 @@ class TabularSampler:
             [allowed_rows[feat] for feat in uniq_feat_ids],
             np.intersect1d),
         )
-        nb_partial_anchors = np.array([len(n_records) for n_records in partial_anchor_rows])
-        coverage = nb_partial_anchors[-1] / self.n_records
+        nb_partial_anchors = np.array([len(n_records) for n_records in
+                                       reversed(partial_anchor_rows)])  # reverse required for np.searchsorted later
+        coverage = nb_partial_anchors[0] / self.n_records  # since we sorted, the correct coverage is first not last
 
         # if there are enough train records containing the anchor, replace the original records and return...
         num_samples_pos = np.searchsorted(nb_partial_anchors, num_samples)


### PR DESCRIPTION
Resolves #328 . The bug was caused by a call to `reversed` on a list holding the number of instances from the training set satisfying each partial anchor. As a result, for every anchor of length >=2, the coverage value was being overwritten by the coverage value of the partial anchor of length 1. I'm not sure why the `reversed` call was there in the first place, I don't think it serves any other purpose.

Tested manually that this gives the correct coverage calculations on the Adult example. Ideally we would have a test for this, but it's non-trivial to check.