### PR TITLE
Pin spacy to v2

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.17.4
 pandas>=0.23.4
 scikit-learn>=0.21.2
-spacy[lookups]>=2.0.18
+spacy[lookups]>=2.0.18,<3.0.0
 scikit-image>=0.14.2,!=0.17.1
 requests>=2.21.0
 Pillow>=6.0.0

--- a/requirements/requirements_all.txt
+++ b/requirements/requirements_all.txt
@@ -1,7 +1,7 @@
 numpy>=1.17.4
 pandas>=0.23.4
 scikit-learn>=0.21.2
-spacy[lookups]>=2.0.18
+spacy[lookups]>=2.0.18,<3.0.0
 scikit-image>=0.14.2,!=0.17.1
 requests>=2.21.0
 Pillow>=6.0.0

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='alibi',
           'pandas',
           'requests',
           'scikit-learn',
-          'spacy[lookups]',
+          'spacy[lookups]<3.0.0',
           'scikit-image!=0.17.1',  # https://github.com/SeldonIO/alibi/issues/215
           'tensorflow>=2.0',
           'shap>=0.36,!=0.38.1',  # https://github.com/SeldonIO/alibi/issues/333


### PR DESCRIPTION
There are currently some issues loading probability tables in spacy 3.0. Pinning to spacy 2.x for the time being until resolved. See https://github.com/explosion/spaCy/discussions/6388#discussioncomment-330606 .