### PR TITLE
Pydantic schemas for explainer outputs

### DIFF
--- a/alibi/api/defaults.py
+++ b/alibi/api/defaults.py
@@ -3,63 +3,6 @@ This module defines the default metadata and data dictionaries for each explanat
 Note that the "name" field is automatically populated upon initialization of the corresponding
 Explainer class.
 """
-from alibi.api.types import Array
-from pydantic import BaseModel, conlist, confloat
-from typing import Any, List, Optional, Union
-from typing_extensions import Literal
-
-import numpy as np
-
-ModelType = Literal['blackbox', 'whitebox']
-ExpType = Literal['local', 'global']
-
-
-class AlibiBaseModel(BaseModel):
-    class Config:
-        json_encoders = {
-            np.ndarray: lambda x: numpy_encoder(x)
-        }
-
-
-class DefaultMeta(AlibiBaseModel):
-    name: Optional[str] = None
-    type: List[ModelType] = []
-    explanations: List[ExpType] = []
-    params: dict = {}
-
-
-class AnchorDataRawExamples(AlibiBaseModel):
-    covered_true: Array[Any, (-1, -1)]
-    covered_false: Array[Any, (-1, -1)]
-    uncovered_true: Array[Any, (-1, -1)]
-    uncovered_false: Array[Any, (-1, -1)]
-
-
-class AnchorDataRaw(AlibiBaseModel):
-    feature: List[int]
-    mean: List[float]
-    precision: List[confloat(ge=0.0, le=1.0)]
-    coverage: List[confloat(ge=0.0, le=1.0)]
-    examples: conlist(AnchorDataRawExamples, min_items=2, max_items=2)
-    all_precision: float
-    num_preds: int
-    success: bool
-    names: List[str]
-    prediction: int
-    instance: Array[Any, (-1,)]
-
-
-class AnchorData(AlibiBaseModel):
-    anchor: List[str]
-    precision: float
-    coverage: float
-    raw: AnchorDataRaw
-
-
-class ExplanationModel(AlibiBaseModel):
-    meta: DefaultMeta
-    data: Union[AnchorData]
-
 
 # Anchors
 DEFAULT_META_ANCHOR = {"name": None,
@@ -280,27 +223,3 @@ DEFAULT_DATA_INTGRAD = {
 """
 Default IntegratedGradients data.
 """
-
-
-def numpy_encoder(obj: Any) -> Any:
-    if isinstance(
-            obj,
-            (
-                    np.int_,
-                    np.intc,
-                    np.intp,
-                    np.int8,
-                    np.int16,
-                    np.int32,
-                    np.int64,
-                    np.uint8,
-                    np.uint16,
-                    np.uint32,
-                    np.uint64,
-            ),
-    ):
-        return int(obj)
-    elif isinstance(obj, (np.float_, np.float16, np.float32, np.float64)):
-        return float(obj)
-    elif isinstance(obj, (np.ndarray,)):
-        return obj.tolist()

--- a/alibi/api/defaults.py
+++ b/alibi/api/defaults.py
@@ -3,6 +3,64 @@ This module defines the default metadata and data dictionaries for each explanat
 Note that the "name" field is automatically populated upon initialization of the corresponding
 Explainer class.
 """
+from alibi.api.types import Array
+from pydantic import BaseModel, conlist, confloat
+from typing import Any, List, Optional, Union
+from typing_extensions import Literal
+
+import numpy as np
+
+ModelType = Literal['blackbox', 'whitebox']
+ExpType = Literal['local', 'global']
+
+
+class AlibiBaseModel(BaseModel):
+    class Config:
+        json_encoders = {
+            np.ndarray: lambda x: numpy_encoder(x)
+        }
+
+
+class DefaultMeta(AlibiBaseModel):
+    name: Optional[str] = None
+    type: List[ModelType] = []
+    explanations: List[ExpType] = []
+    params: dict = {}
+
+
+class AnchorDataRawExamples(AlibiBaseModel):
+    covered_true: Array[Any, (-1, -1)]
+    covered_false: Array[Any, (-1, -1)]
+    uncovered_true: Array[Any, (-1, -1)]
+    uncovered_false: Array[Any, (-1, -1)]
+
+
+class AnchorDataRaw(AlibiBaseModel):
+    feature: List[int]
+    mean: List[float]
+    precision: List[confloat(ge=0.0, le=1.0)]
+    coverage: List[confloat(ge=0.0, le=1.0)]
+    examples: conlist(AnchorDataRawExamples, min_items=2, max_items=2)
+    all_precision: float
+    num_preds: int
+    success: bool
+    names: List[str]
+    prediction: int
+    instance: Array[Any, (-1,)]
+
+
+class AnchorData(AlibiBaseModel):
+    anchor: List[str]
+    precision: float
+    coverage: float
+    raw: AnchorDataRaw
+
+
+class ExplanationModel(AlibiBaseModel):
+    meta: DefaultMeta
+    data: Union[AnchorData]
+
+
 # Anchors
 DEFAULT_META_ANCHOR = {"name": None,
                        "type": ["blackbox"],
@@ -222,3 +280,27 @@ DEFAULT_DATA_INTGRAD = {
 """
 Default IntegratedGradients data.
 """
+
+
+def numpy_encoder(obj: Any) -> Any:
+    if isinstance(
+            obj,
+            (
+                    np.int_,
+                    np.intc,
+                    np.intp,
+                    np.int8,
+                    np.int16,
+                    np.int32,
+                    np.int64,
+                    np.uint8,
+                    np.uint16,
+                    np.uint32,
+                    np.uint64,
+            ),
+    ):
+        return int(obj)
+    elif isinstance(obj, (np.float_, np.float16, np.float32, np.float64)):
+        return float(obj)
+    elif isinstance(obj, (np.ndarray,)):
+        return obj.tolist()

--- a/alibi/api/defaults.py
+++ b/alibi/api/defaults.py
@@ -4,6 +4,9 @@ Note that the "name" field is automatically populated upon initialization of the
 Explainer class.
 """
 
+# TODO: these should probably be moved into the modules where the explainer is defined
+# and refactored into factory functions.
+
 # Anchors
 DEFAULT_META_ANCHOR = {"name": None,
                        "type": ["blackbox"],

--- a/alibi/api/interfaces.py
+++ b/alibi/api/interfaces.py
@@ -7,7 +7,7 @@ from functools import partial
 import pprint
 
 import attr
-from alibi.api.defaults import ExplanationModel, DefaultMeta
+from alibi.api.schemas import ExplanationModel, DefaultMeta
 import numpy as np
 
 logger = logging.getLogger(__name__)

--- a/alibi/api/interfaces.py
+++ b/alibi/api/interfaces.py
@@ -138,7 +138,7 @@ class Explanation:
         """
         # this is pretty much the same as the previous version below,
         # `NumpyEncoder` is already part of `_explanation_model`
-        return self._explanation_model.json(dumps_kwargs=kwargs)
+        return self._explanation_model.json(**kwargs)
         # return json.dumps(attr.asdict(self), cls=NumpyEncoder, **kwargs)
 
     @classmethod

--- a/alibi/api/interfaces.py
+++ b/alibi/api/interfaces.py
@@ -136,7 +136,10 @@ class Explanation:
         -------
         String containing json representation of the explanation
         """
-        return json.dumps(attr.asdict(self), cls=NumpyEncoder, **kwargs)
+        # this is pretty much the same as the previous version below,
+        # `NumpyEncoder` is already part of `_explanation_model`
+        return self._explanation_model.json(dumps_kwargs=kwargs)
+        # return json.dumps(attr.asdict(self), cls=NumpyEncoder, **kwargs)
 
     @classmethod
     def from_json(cls, jsonrepr) -> "Explanation":

--- a/alibi/api/schemas.py
+++ b/alibi/api/schemas.py
@@ -1,6 +1,6 @@
 from alibi.api.types import Array
-from pydantic import BaseModel, conlist, confloat
-from typing import Any, List, Optional, Union
+from pydantic import BaseModel, Field, conlist, confloat
+from typing import Any, Dict, List, Optional, Union
 from typing_extensions import Literal
 
 import numpy as np
@@ -114,6 +114,23 @@ class CEMData(AlibiBaseModel):
 
 
 # CounterFactual
+class CounterFactualDataCF(AlibiBaseModel):
+    X: Array
+    distance: float
+    lambda_: float = Field(alias='lambda')
+    index: int
+    class_: int = Field(alias='class')
+    proba: Array[float, (1, -1)]
+    loss: float
+
+
+class CounterFactualData(AlibiBaseModel):
+    cf: Optional[CounterFactualDataCF] = None  # TODO: make non-optional?
+    all: Dict[int, List[CounterFactualDataCF]]
+    orig_class: int
+    orig_proba: float
+    success: Optional[bool] = None  # TODO: make non-optional
+
 
 # CFProto
 
@@ -125,7 +142,7 @@ class CEMData(AlibiBaseModel):
 
 class ExplanationModel(AlibiBaseModel):
     meta: DefaultMeta
-    data: Union[AnchorData, ALEData, CEMData]
+    data: Union[AnchorData, ALEData, CEMData, CounterFactualData]
     # What happens if the data is incorrect? The schema validation will fail for the correct type and
     # pydantic will attempt to check the other types in the Union which will also fail, but this results
     # in a relatively obscure message that the data of e.g. Anchor was not compatible in some fields in

--- a/alibi/api/schemas.py
+++ b/alibi/api/schemas.py
@@ -151,6 +151,15 @@ class CounterFactualProtoData(AlibiBaseModel):
 
 
 # IntegratedGradients
+class IGData(AlibiBaseModel):
+    attributions: List[Array]  # List because of potential for multi-input models
+    X: List[Array]  # ditto
+    baselines: List[Array]  # ditto
+    predictions: Array[float, (-1, -1)]  # n_instances x n_targets
+    deltas: Array[float, (-1,)]
+    target: List[int]  # TODO: `float` should be possible for multi-output regression but `_format_target` outputs int?
+    # TODO: should target input type be preserved? Or at least kept as np.ndarray?
+
 
 # KernelShap
 
@@ -158,7 +167,7 @@ class CounterFactualProtoData(AlibiBaseModel):
 
 class ExplanationModel(AlibiBaseModel):
     meta: DefaultMeta
-    data: Union[AnchorData, ALEData, CEMData, CounterFactualData, CounterFactualProtoData]
+    data: Union[AnchorData, ALEData, CEMData, CounterFactualData, CounterFactualProtoData, IGData]
     # What happens if the data is incorrect? The schema validation will fail for the correct type and
     # pydantic will attempt to check the other types in the Union which will also fail, but this results
     # in a relatively obscure message that the data of e.g. Anchor was not compatible in some fields in

--- a/alibi/api/schemas.py
+++ b/alibi/api/schemas.py
@@ -1,8 +1,7 @@
 from alibi.api.types import Array
-from pydantic import BaseModel, Field, conlist, confloat
+from pydantic import BaseModel, Field, confloat
 from typing import Any, Dict, List, Optional, Union
 from typing_extensions import Literal
-
 import numpy as np
 
 ModelType = Literal['blackbox', 'whitebox', 'tensorflow', 'keras']
@@ -216,6 +215,7 @@ class ExplanationModel(AlibiBaseModel):
     # interface to fetch the correct model given the name of the explainer in the `meta` dictionary.
     # TODO: we put TreeSHAPData before KernelSHAPData, otherwise TreeSHAP gets pattern matched with KernelSHAP
     # and the extra fields like `shap_interaction_values` get dropped. This is another shortcoming of this approach.
+
 
 def numpy_encoder(obj: Any) -> Any:
     if isinstance(

--- a/alibi/api/schemas.py
+++ b/alibi/api/schemas.py
@@ -10,6 +10,7 @@ ExpType = Literal['local', 'global']
 
 
 # TODO: add a numeric type like Union[float, int] to replace Any in Array declarations
+# TODO: we should take care with np.float32 datatypes as they would be converted to float
 
 class AlibiBaseModel(BaseModel):
     """

--- a/alibi/api/schemas.py
+++ b/alibi/api/schemas.py
@@ -162,12 +162,33 @@ class IGData(AlibiBaseModel):
 
 
 # KernelShap
+class ImportanceDict(AlibiBaseModel):
+    ranked_effect: Array[float, (-1,)]  # n_features
+    names: List[str]
+
+
+class KernelSHAPDataRaw(AlibiBaseModel):
+    raw_prediction: Array[float, (-1, -1)]  # n_instances x n_targets
+    prediction: Array[int, (-1,)]  # n_instances
+    instances: Array[float, (-1, -1)]  # n_instances x n_features
+    importances: Dict[str, ImportanceDict]  # n_targets + 1 keys (one for each target and 'aggregated')
+
+
+class KernelSHAPData(AlibiBaseModel):
+    shap_values: List[Array[float, (-1, -1)]]  # list of length n_targets with n_instances x n_features arrays
+    expected_value: Array[float, (-1,)]  # n_instances
+    # link: Literal['identity', 'logit'] TODO: change docs to reflect link is in meta
+    feature_names: List[str]
+    categorical_names: Dict[int, List[str]]
+    raw: KernelSHAPDataRaw
+
 
 # TreeShap
 
 class ExplanationModel(AlibiBaseModel):
     meta: DefaultMeta
-    data: Union[AnchorData, ALEData, CEMData, CounterFactualData, CounterFactualProtoData, IGData]
+    data: Union[AnchorData, ALEData, CEMData, CounterFactualData, CounterFactualProtoData,
+                IGData, KernelSHAPData]
     # What happens if the data is incorrect? The schema validation will fail for the correct type and
     # pydantic will attempt to check the other types in the Union which will also fail, but this results
     # in a relatively obscure message that the data of e.g. Anchor was not compatible in some fields in

--- a/alibi/api/schemas.py
+++ b/alibi/api/schemas.py
@@ -23,6 +23,17 @@ class DefaultMeta(AlibiBaseModel):
     params: dict = {}
 
 
+# ALE
+class ALEData(AlibiBaseModel):
+    ale_values: List[Array[float, (-1, -1)]]  # 2D for classification, for regression 1D empty axis, i.e. (-1, 1)
+    constant_value: float
+    ale0: List[Array[float, (-1,)]]  # size of array corresponds to the number of targets/classes
+    feature_values: List[Array[float, (-1,)]]  # TODO: should be same shape as ale_values
+    feature_names: Array[str, (-1,)]  # this is an array for easier post-processing
+    target_names: Array[str, (-1,)]  # ditto
+    feature_deciles: List[Array[float, (11,)]]  # inclusive of 0th and 10th decile, hence 11 points
+
+
 # Anchors
 
 class AnchorDataRawTabularExamples(AlibiBaseModel):
@@ -84,9 +95,21 @@ class AnchorData(AlibiBaseModel):
     raw: Union[AnchorDataRawTabular, AnchorDataRawText, AnchorDataRawImage]
 
 
+# CEM
+
+# CounterFactual
+
+# CFProto
+
+# IntegratedGradients
+
+# KernelShap
+
+# TreeShap
+
 class ExplanationModel(AlibiBaseModel):
     meta: DefaultMeta
-    data: AnchorData
+    data: Union[ALEData, AnchorData]
 
 
 def numpy_encoder(obj: Any) -> Any:

--- a/alibi/api/schemas.py
+++ b/alibi/api/schemas.py
@@ -1,0 +1,143 @@
+from alibi.api.types import Array
+from pydantic import BaseModel, conlist, confloat
+from typing import Any, List, Optional, Union
+from typing_extensions import Literal
+
+import numpy as np
+
+ModelType = Literal['blackbox', 'whitebox']
+ExpType = Literal['local', 'global']
+
+
+class AlibiBaseModel(BaseModel):
+    class Config:
+        json_encoders = {
+            np.ndarray: lambda x: numpy_encoder(x)
+        }
+
+
+class DefaultMeta(AlibiBaseModel):
+    name: Optional[str] = None
+    type: List[ModelType] = []
+    explanations: List[ExpType] = []
+    params: dict = {}
+
+
+# Anchors
+
+## Common
+
+class AnchorDataRawTabularExamples(AlibiBaseModel):
+    covered_true: Array[Any, (-1, -1)]
+    covered_false: Array[Any, (-1, -1)]
+    uncovered_true: Array[Any, (-1, -1)]
+    uncovered_false: Array[Any, (-1, -1)]
+
+
+class AnchorDataRawImageExamples(AlibiBaseModel):
+    covered_true: Union[List[Array], Array]
+    covered_false: Union[List[Array], Array]
+    uncovered_true: Union[List[Array], Array]
+    uncovered_false: Union[List[Array], Array]
+
+
+class AnchorDataRawTextExamples(AlibiBaseModel):
+    covered_true: Array[str, (-1,)]
+    covered_false: Array[str, (-1,)]
+    uncovered_true: Array[str, (-1,)]
+    uncovered_false: Array[str, (-1,)]
+
+
+class AnchorDataRawTabular(AlibiBaseModel):
+    feature: List[int]
+    mean: List[float]
+    precision: List[confloat(ge=0.0, le=1.0)]
+    coverage: List[confloat(ge=0.0, le=1.0)]
+    examples: conlist(AnchorDataRawTabularExamples, min_items=2, max_items=2)
+    all_precision: float
+    num_preds: int
+    success: bool
+    names: List[str]
+    prediction: int
+    instance: Array[Any, (-1,)]
+    instances: Array[Any, (-1, 1)]
+
+
+class AnchorDataRawImage(AlibiBaseModel):
+    feature: List[int]
+    mean: List[float]
+    precision: List[confloat(ge=0.0, le=1.0)]
+    coverage: List[confloat(ge=0.0, le=1.0)]
+    examples: List[AnchorDataRawImageExamples]
+    all_precision: float
+    num_preds: int
+    success: bool
+    prediction: int
+    instance: Array
+    instances: Array
+
+
+class AnchorDataRawText(AlibiBaseModel):
+    feature: List[int]
+    mean: List[float]
+    precision: List[confloat(ge=0.0, le=1.0)]
+    coverage: List[confloat(ge=0.0, le=1.0)]
+    examples: conlist(AnchorDataRawTextExamples, min_items=1, max_items=1)
+    all_precision: float
+    num_preds: int
+    success: bool
+    names: List[str]
+    prediction: int
+    instance: str
+    instances: List[str]
+
+
+class AnchorDataTabular(AlibiBaseModel):
+    anchor: List[str]
+    precision: confloat(ge=0.0, le=1.0)
+    coverage: confloat(ge=0.0, le=1.0)
+    raw: AnchorDataRawTabular
+
+
+class AnchorDataImage(AlibiBaseModel):
+    anchor: Array
+    precision: confloat(ge=0.0, le=1.0)
+    coverage: confloat(ge=0.0, le=1.0)
+    raw: AnchorDataRawImage
+    segments: Array
+
+
+class AnchorDataText(AlibiBaseModel):
+    anchor: List[str]
+    precision: confloat(ge=0.0, le=1.0)
+    coverage: confloat(ge=0.0, le=1.0)
+    raw: AnchorDataRawText
+
+
+class ExplanationModel(AlibiBaseModel):
+    meta: DefaultMeta
+    data: Union[AnchorDataTabular, AnchorDataText, AnchorDataImage]
+
+
+def numpy_encoder(obj: Any) -> Any:
+    if isinstance(
+            obj,
+            (
+                    np.int_,
+                    np.intc,
+                    np.intp,
+                    np.int8,
+                    np.int16,
+                    np.int32,
+                    np.int64,
+                    np.uint8,
+                    np.uint16,
+                    np.uint32,
+                    np.uint64,
+            ),
+    ):
+        return int(obj)
+    elif isinstance(obj, (np.float_, np.float16, np.float32, np.float64)):
+        return float(obj)
+    elif isinstance(obj, (np.ndarray,)):
+        return obj.tolist()

--- a/alibi/api/schemas.py
+++ b/alibi/api/schemas.py
@@ -133,6 +133,21 @@ class CounterFactualData(AlibiBaseModel):
 
 
 # CFProto
+class CounterFactualProtoDataCF(AlibiBaseModel):
+    X: Array
+    class_: int = Field(alias='class')
+    proba: Array[float, (1, -1)]
+    grads_graph: Array
+    grads_num: Array
+
+
+class CounterFactualProtoData(AlibiBaseModel):
+    cf: Optional[CounterFactualProtoDataCF] = None  # TODO: make non-optional?
+    all: Dict[int, List[Array]]  # NB: different from CounterFactual!
+    orig_class: int
+    orig_proba: Array[float, (1, -1)]
+    id_proto: Optional[int] = None  # None if prototype loss turned off
+
 
 # IntegratedGradients
 
@@ -142,7 +157,7 @@ class CounterFactualData(AlibiBaseModel):
 
 class ExplanationModel(AlibiBaseModel):
     meta: DefaultMeta
-    data: Union[AnchorData, ALEData, CEMData, CounterFactualData]
+    data: Union[AnchorData, ALEData, CEMData, CounterFactualData, CounterFactualProtoData]
     # What happens if the data is incorrect? The schema validation will fail for the correct type and
     # pydantic will attempt to check the other types in the Union which will also fail, but this results
     # in a relatively obscure message that the data of e.g. Anchor was not compatible in some fields in

--- a/alibi/api/schemas.py
+++ b/alibi/api/schemas.py
@@ -113,6 +113,11 @@ class AnchorData(AlibiBaseModel):
 class ExplanationModel(AlibiBaseModel):
     meta: DefaultMeta
     data: Union[AnchorData, ALEData]
+    # What happens if the data is incorrect? The schema validation will fail for the correct type and
+    # pydantic will attempt to check the other types in the Union which will also fail, but this results
+    # in a relatively obscure message that the data of e.g. Anchor was not compatible in some fields in
+    # e.g. ALE (but without actually specifying the classes tried in this Union). There should be a better
+    # way of doing this for developer experience and for changes between Alibi versions.
 
 
 def numpy_encoder(obj: Any) -> Any:

--- a/alibi/api/schemas.py
+++ b/alibi/api/schemas.py
@@ -10,6 +10,9 @@ ExpType = Literal['local', 'global']
 
 
 class AlibiBaseModel(BaseModel):
+    """
+    We subclass pydantic's BaseModel to override a custom json encoder which handles numpy arrays.
+    """
     class Config:
         json_encoders = {
             np.ndarray: lambda x: numpy_encoder(x)

--- a/alibi/api/schemas.py
+++ b/alibi/api/schemas.py
@@ -25,8 +25,6 @@ class DefaultMeta(AlibiBaseModel):
 
 # Anchors
 
-## Common
-
 class AnchorDataRawTabularExamples(AlibiBaseModel):
     covered_true: Array[Any, (-1, -1)]
     covered_false: Array[Any, (-1, -1)]
@@ -35,7 +33,7 @@ class AnchorDataRawTabularExamples(AlibiBaseModel):
 
 
 class AnchorDataRawImageExamples(AlibiBaseModel):
-    covered_true: Union[List[Array], Array]
+    covered_true: Union[List[Array], Array]  # TODO: need to fix this and only return Array
     covered_false: Union[List[Array], Array]
     uncovered_true: Union[List[Array], Array]
     uncovered_false: Union[List[Array], Array]
@@ -48,75 +46,47 @@ class AnchorDataRawTextExamples(AlibiBaseModel):
     uncovered_false: Array[str, (-1,)]
 
 
-class AnchorDataRawTabular(AlibiBaseModel):
+class AnchorDataRawCommon(AlibiBaseModel):
     feature: List[int]
     mean: List[float]
     precision: List[confloat(ge=0.0, le=1.0)]
     coverage: List[confloat(ge=0.0, le=1.0)]
-    examples: conlist(AnchorDataRawTabularExamples, min_items=2, max_items=2)
     all_precision: float
     num_preds: int
     success: bool
-    names: List[str]
     prediction: int
+
+
+class AnchorDataRawTabular(AnchorDataRawCommon):
+    examples: conlist(AnchorDataRawTabularExamples, min_items=2, max_items=2)
+    names: List[str]
     instance: Array[Any, (-1,)]
     instances: Array[Any, (-1, 1)]
 
 
-class AnchorDataRawImage(AlibiBaseModel):
-    feature: List[int]
-    mean: List[float]
-    precision: List[confloat(ge=0.0, le=1.0)]
-    coverage: List[confloat(ge=0.0, le=1.0)]
-    examples: List[AnchorDataRawImageExamples]
-    all_precision: float
-    num_preds: int
-    success: bool
-    prediction: int
+class AnchorDataRawImage(AnchorDataRawCommon):
+    examples: conlist(AnchorDataRawImageExamples, min_items=1, max_items=1)
     instance: Array
     instances: Array
 
 
-class AnchorDataRawText(AlibiBaseModel):
-    feature: List[int]
-    mean: List[float]
-    precision: List[confloat(ge=0.0, le=1.0)]
-    coverage: List[confloat(ge=0.0, le=1.0)]
-    examples: conlist(AnchorDataRawTextExamples, min_items=1, max_items=1)
-    all_precision: float
-    num_preds: int
-    success: bool
+class AnchorDataRawText(AnchorDataRawCommon):
+    examples: conlist(AnchorDataRawTextExamples, min_items=2, max_items=2)
     names: List[str]
-    prediction: int
     instance: str
     instances: List[str]
 
 
-class AnchorDataTabular(AlibiBaseModel):
-    anchor: List[str]
+class AnchorData(AlibiBaseModel):
+    anchor: Union[List[str], Array]  # Array for images, List[str] for tabular and text
     precision: confloat(ge=0.0, le=1.0)
-    coverage: confloat(ge=0.0, le=1.0)
-    raw: AnchorDataRawTabular
-
-
-class AnchorDataImage(AlibiBaseModel):
-    anchor: Array
-    precision: confloat(ge=0.0, le=1.0)
-    coverage: confloat(ge=0.0, le=1.0)
-    raw: AnchorDataRawImage
-    segments: Array
-
-
-class AnchorDataText(AlibiBaseModel):
-    anchor: List[str]
-    precision: confloat(ge=0.0, le=1.0)
-    coverage: confloat(ge=0.0, le=1.0)
-    raw: AnchorDataRawText
+    coverage: confloat(ge=-0.0, le=1.0)
+    raw: Union[AnchorDataRawTabular, AnchorDataRawText, AnchorDataRawImage]
 
 
 class ExplanationModel(AlibiBaseModel):
     meta: DefaultMeta
-    data: Union[AnchorDataTabular, AnchorDataText, AnchorDataImage]
+    data: AnchorData
 
 
 def numpy_encoder(obj: Any) -> Any:

--- a/alibi/api/schemas.py
+++ b/alibi/api/schemas.py
@@ -69,20 +69,20 @@ class AnchorDataRawCommon(AlibiBaseModel):
 
 
 class AnchorDataRawTabular(AnchorDataRawCommon):
-    examples: conlist(AnchorDataRawTabularExamples, min_items=2, max_items=2)
+    examples: List[AnchorDataRawTabularExamples]  # one for each partial anchor
     names: List[str]
     instance: Array[Any, (-1,)]
     instances: Array[Any, (-1, 1)]
 
 
 class AnchorDataRawImage(AnchorDataRawCommon):
-    examples: conlist(AnchorDataRawImageExamples, min_items=1, max_items=1)
+    examples: List[AnchorDataRawImageExamples]  # one for each partial anchor
     instance: Array
     instances: Array
 
 
 class AnchorDataRawText(AnchorDataRawCommon):
-    examples: conlist(AnchorDataRawTextExamples, min_items=2, max_items=2)
+    examples: List[AnchorDataRawTextExamples]  # one for each partial anchor
     names: List[str]
     instance: str
     instances: List[str]
@@ -109,7 +109,7 @@ class AnchorData(AlibiBaseModel):
 
 class ExplanationModel(AlibiBaseModel):
     meta: DefaultMeta
-    data: Union[ALEData, AnchorData]
+    data: Union[AnchorData, ALEData]
 
 
 def numpy_encoder(obj: Any) -> Any:

--- a/alibi/api/tests/test_interfaces.py
+++ b/alibi/api/tests/test_interfaces.py
@@ -91,7 +91,7 @@ def test_explanation():
         _ = exp['anchor']
     assert len(record) == 1
 
-
+# TODO: extend this to test with numpy arrays present, will likely need to define custom __eq__
 def test_serialize_deserialize_explanation():
     exp = Explanation(meta=valid_meta, data=valid_data)
     jrep = exp.to_json()

--- a/alibi/api/types.py
+++ b/alibi/api/types.py
@@ -3,6 +3,14 @@ from typing import Any
 
 
 class Array(np.ndarray):
+    """
+    A class implementing an Array type used for pydantic models. The type can take two parameters:
+    `dtype` and `shape`. In the current implementation, when `shape` is absent, an arbitrary dimensional
+    Array is permitted. Whenever `shape` is specified, the dimensionality is enforced to be len(shape).
+    The number of entries in each dimension can be arbitrary by specifying `-1` in the appropriate dimension.
+    # TODO: extension - can we contstrain the number of instances in some dimensions whilst allowing an
+    # arbitrary number of dimensions?
+    """
 
     def __class_getitem__(cls, params):
         try:

--- a/alibi/api/types.py
+++ b/alibi/api/types.py
@@ -4,6 +4,8 @@ from typing import Any
 
 class Array(np.ndarray):
     """
+    Adapted from https://github.com/samuelcolvin/pydantic/issues/380#issuecomment-620378743
+
     A class implementing an Array type used for pydantic models. The type can take two parameters:
     `dtype` and `shape`. In the current implementation, when `shape` is absent, an arbitrary dimensional
     Array is permitted. Whenever `shape` is specified, the dimensionality is enforced to be len(shape).
@@ -18,6 +20,7 @@ class Array(np.ndarray):
             if not isinstance(shape, tuple):
                 raise ValueError('Shape must be a tuple of integers.')
         except TypeError:
+            # no shape passed
             dtype = params
             shape = tuple()
         return type('Array', (Array,), {'__dtype__': dtype, '__shape__': shape})

--- a/alibi/api/types.py
+++ b/alibi/api/types.py
@@ -1,0 +1,34 @@
+import numpy as np
+from typing import Any
+
+
+class Array(np.ndarray):
+
+    def __class_getitem__(cls, params):
+        try:
+            dtype, shape = params
+            if not isinstance(shape, tuple):
+                raise ValueError('Shape must be a tuple of integers.')
+        except TypeError:
+            dtype = params
+            shape = tuple()
+        return type('Array', (Array,), {'__dtype__': dtype, '__shape__': shape})
+
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, val):
+        dtype = getattr(cls, '__dtype__', None)
+        if dtype == Any:
+            dtype = None
+        shape = getattr(cls, '__shape__', tuple())
+
+        result = np.array(val, dtype=dtype, copy=False, ndmin=len(shape))
+        assert not shape or len(shape) == len(result.shape)  # ndmin guarantees this
+
+        # TODO: this can result in unexpected shapes if shape is misspecified
+        if any((shape[i] != -1 and shape[i] != result.shape[i]) for i in range(len(shape))):
+            result = result.reshape(shape)
+        return result


### PR DESCRIPTION
This PR is a draft proposal for specifying the return schemas of `Explanation` objects resulting from calls to `explain` methods on `Explainer` objects.

# Motivation
Currently finding out the exact return schema of of any explainer is cumbersome as you either need to rely on documentation (which may be incomplete) or read the source code directly.
Moreover, in some instances the return type (an instance of `Explanation`) may have a slightly different schema for the same algorithm depending on which code branch was taken at runtime.
There is currently no method of enforcing the return type to adhere to a well-defined schema.

This proposal introduces schemas (`api/schemas.py`) for every explainer which codifies what to expect from each explainer.
This is primarily intended to make life easier for developers in the following ways:

1. For application developers building on top of `alibi` - a clear, single source of truth of what to expect from every explainer method.
2. For Alibi developers - a single place to define the return schema whilst developing a new explainer.
   Also, a single place to clear up inconsistencies in the current schema definitions (e.g. different attribute names for the same type of data across different explanations).

# Features
The return schemas are defined in `api/schemas.py` and are defined as `pydantic` data models.
The models are often hierarchical to reflect the rather complex return types of some methods.

The data types are defined in terms of Python native types, `pydantic` constrained types (e.g. `confloat` for a `float` with value constraints) and a custom `Array` type defined in `api/types.py` to model a `numpy` array.
The custom `Array` type is used to model more granular array types, e.g:
- `Array` - arbitrary array
- `Array[float]` - array of floats of arbitrary dimension and size
- `Array[int, (-1, 3)]` - a 2D array of ints with 3 columns and an arbitrary number of rows.

These schemas are used at runtime to ensure the return types adhere to the schemas, see `api.interfaces.Explanation`.
When a new `Explanation` model is initialized (which occurs before returning from `explain`), a private attribute `_explanation_model` is created which takes the `meta` and `data` dictionaries and validates the entries against the appropriate schema.
This is effectively a runtime check that ensures that what is returned adheres to the schema definition.
(The reason to not return `_explanation_model` directly to the user is to provide a form of encapsulation - we want to use our custom `Explanation` object as the return type with potentially custom methods to manipulate/display it etc.).

`Explanation` objects can be encoded to `json` (e.g. for persistence) by using the `to_json` method. This will use the custom `numpy` encoder in `_explanation_model` to convert arrays to nested lists.

When loading a persisted `Explanation` using the `from_json` class method, the persisted `Explanation` is again validated and coerced to the expected schema type.
A particulary useful consequence of this is that `numpy` arrays, which would be serialized to nested lists in `json` would be coerced to become `numpy` arrays when deserialized again so we can ensure that in Python you always have arrays where you expect them.


# Discussion points
1. Since we recognize that schemas will be iterated upon and `Explanation` objects can be persisted, it would be wise to include the version of `alibi` in the metadata of every `Explanation`.
   When reading a persisted `Explanation` we can read this field and ensure that the version of `alibi` being run is the same as the version used to produce the `Explanation`.
2. The usage of `Union` on the `data` field in `api.schemas.ExplanationModel` is not ideal.
   At runtime `pydantic` will attempt to match the returned `Explanation` to any of these schemas and pick the first one that matches.
   If there isn't a match (due to developer error), the error raised may be unrelated to the actual expcted schema (e.g. expect to satisfy the `ALEData` schema, but it fails, so `pydantic` tries all the others, which also fail with error messages).
   Even more worrying is the default behaviour of `pydantic` (perhaps this can be altered?) of matching an object to a partially satisfied schema and dropping the missing fields.
   This actually happened when a `TreeSHAP` explanation was matched to `KernelSHAP` as the fields of the latter are a subset of the former.
   I had to reverse the order of `TreeSHAP` and `KernelSHAP` declarations in the union to ensure that the more specific type comes first so it's matched first.
   A solution would be to instead have a separate `ExplanationModel` for each type of `Explainer` and do dynamic dispatch at runtime in `Explanation` based on the `meta.name` attribute.
   More generally, maybe this is another reason for thinking of moving away from an all-encompassing `Explanation` object towards more granularly defined objects, e.g. `AnchorExplanation` etc. as then there would be one class and one data model definition per explainer/explanation type.
   This would also be helpful in writing explanation specific methods in the future.
3. The validation of the return type according to the schema is enforced at runtime (Python's type checking is not powerful enough to validate the correct types with a static typechecker). This means that if we haven't modelled all possible return types of an `explain` call appropriately and haven't exercised all code branches in tests, the user may find the corner cases where the validation fails and throws an error.
   The solution is probably for developers of `alibi` to avoid introducing different return types in different branches of the code and make sure all code branches constructing `Explanation` objects are tested.
4. Exposing the `meta` and `data` attributes of `Explanation` via calls to `self._explanation_model.meta.dict()` duplicates the data due to converting the `pydantic` model to a `dict`.
   There should be a better way of doing this. Maybe turn `meta` and `data` into `property` attributes and call the `dict()` methods on demand?
5. The dictionaries in `api/defaults.py` so far have been used as a loose "schema" and as a factory of generating default dictionaries to be populated by data.
   With the schema definition moving to `api/schemas.py` I would propose moving the contents of `api/defaults.py` to each explainer specific module and turning them into factory functions.
   The idea here would be to use these as convenient factories for `alibi` developers when initializing default return data types.
   Note: it may be possible to re-use the `api/schemas.py` for this purpose, but it needs more investigating. Also it's trickier with some types (e.g. you may want to initialize `None` for an `Array` type as it's easier to create a new array than fill in an existing one, but the schema may not allow a `None` to be returned in the end.)
6. Whilst the schemas are primarily a developer tool, it would be nice if we could leverage this single source of truth as documentation for users as well. The alternative is to maintain separate documentation which may go out of sync.
7. The `Array` custom type allows us to refine the constraints on `numpy` arrays in the schemas, however the current implementation is a bit of a hack. The right implementation would be to inherit from `typing.Generic` and use two type variables (`typing.TypeVar`) - one for the `dtype` one for the `shape`. However, note that `Array[float, (2,3)]` has one type variable (`float`) and one concrete variable (the shape) which would fail in such an approach. So instead we opt for the `__class_getitem__` approach which is more flexible (although `api/schemas.py` doesn't pass the static typecheck as a result...).
8. We may need some more type aliases for `Array`-like types in the future, e.g. there is no way to define an `Array` of arbitrary dimensionality but with a fixed size of the first dimension.
9. We may need a type aliases for numeric types, e.g. `Numeric=Union[int, float]` to avoid some of the `Array[Any]` declarations.
   However, for consistency we need to decide if we should coerce any `float` type into the `Python` `float`. For example, there are `numpy.float64` etc. types, and perhaps more importantly, returns from `tensorflow` models will likely be `np.float32` - with a type declaration including only `float` these will always be coerced to 64bit.
10. One nice feature of `pydantic` is that given a model it can generate a `jsonschema`. This is not possible out of the box with custom types like `Array`, but it seems there may be ways to define extensions for this.