### PR TITLE
Docs build improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          sudo apt-get install pandoc
           pip install --upgrade pip setuptools
-          pip install -r requirements/dev.txt -r requirements/docs.txt
+          pip install -r requirements/dev.txt
           python -m spacy download en_core_web_md
           pip install -e .
           pip freeze
@@ -56,6 +55,22 @@ jobs:
       - name: Build Python package
         run: |
           make build_pypi
+
+  docs:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+      - name: Install dependencies
+        run: |
+          sudo apt-get install pandoc
+          pip install -r requirements/docs.txt
+          pip freeze
       - name: Build documentation
         run: |
           make build_docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,20 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: doc/source/conf.py
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+   - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+   version: 3.8
+   install:
+   - requirements: requirements/docs.txt

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ If you're interested in outlier detection, concept drift or adversarial instance
   * [Model Explanations](#model-explanations)
   * [Model Confidence](#model-confidence)
   * [References and Examples](#references-and-examples)
-* [Dependencies](#dependencies)
 * [Citations](#citations)
 
 ## Installation and Usage

--- a/alibi/explainers/ale.py
+++ b/alibi/explainers/ale.py
@@ -7,7 +7,7 @@ from functools import partial
 from typing import Callable, List, Optional, Tuple, Union, TYPE_CHECKING, no_type_check
 
 try:
-    from typing import Literal
+    from typing import Literal  # type: ignore
 except ImportError:
     from typing_extensions import Literal
 

--- a/alibi/explainers/ale.py
+++ b/alibi/explainers/ale.py
@@ -5,7 +5,11 @@ import pandas as pd
 from itertools import count
 from functools import partial
 from typing import Callable, List, Optional, Tuple, Union, TYPE_CHECKING, no_type_check
-from typing_extensions import Literal
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from alibi.api.interfaces import Explainer, Explanation
 from alibi.api.defaults import DEFAULT_META_ALE, DEFAULT_DATA_ALE

--- a/alibi/explainers/ale.py
+++ b/alibi/explainers/ale.py
@@ -6,9 +6,11 @@ from itertools import count
 from functools import partial
 from typing import Callable, List, Optional, Tuple, Union, TYPE_CHECKING, no_type_check
 
-try:
-    from typing import Literal  # type: ignore
-except ImportError:
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
     from typing_extensions import Literal
 
 from alibi.api.interfaces import Explainer, Explanation

--- a/doc/source/methods/TreeSHAP.ipynb
+++ b/doc/source/methods/TreeSHAP.ipynb
@@ -356,7 +356,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```pyhton\n",
+    "```python\n",
     "explanation = explainer.explain(X)\n",
     "```"
    ]
@@ -859,7 +859,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.5"
   },
   "varInspector": {
    "cols": {

--- a/examples/cfproto_cat_adult_ohe.ipynb
+++ b/examples/cfproto_cat_adult_ohe.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Real world machine learning applications often handle data with categorical variables. Explanation methods which rely on perturbations of the input features need to make sure those perturbations are meaningful and capture the underlying structure of the data. This becomes tricky for categorical features. For instance random perturbations across possible categories or enforcing a ranking between categories based on frequency of occurrence in the training data do not capture this structure. Our method captures the relation between categories of a variable numerically through the context given by the other features in the data and/or the predictions made by the model. First it captures the pairwise distances between categories and then applies multi-dimensional scaling. More details about the method can be found in the [documentation](../doc/source/methods/CFProto.ipynb). The example notebook illustrates this approach on the *adult* dataset, which contains a mixture of categorical and numerical features used to predict whether a person's income is above or below $50k."
+    "Real world machine learning applications often handle data with categorical variables. Explanation methods which rely on perturbations of the input features need to make sure those perturbations are meaningful and capture the underlying structure of the data. This becomes tricky for categorical features. For instance random perturbations across possible categories or enforcing a ranking between categories based on frequency of occurrence in the training data do not capture this structure. Our method captures the relation between categories of a variable numerically through the context given by the other features in the data and/or the predictions made by the model. First it captures the pairwise distances between categories and then applies multi-dimensional scaling. More details about the method can be found in the [documentation](https://docs.seldon.io/projects/alibi/en/latest/methods/CFProto.html). The example notebook illustrates this approach on the *adult* dataset, which contains a mixture of categorical and numerical features used to predict whether a person's income is above or below $50k."
    ]
   },
   {
@@ -472,7 +472,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Fit explainer. `d_type` refers to the distance metric used to convert the categorical to numerical values. Valid options are `abdm`, `mvdm` and `abdm-mvdm`. `abdm` infers the distance between categories of the same variable from the context provided by the other variables. This requires binning of the numerical features as well. `mvdm` computes the distance using the model predictions, and `abdm-mvdm` combines both methods. More info on both distance measures can be found in the [documentation](../doc/source/methods/CFProto.ipynb)."
+    "Fit explainer. `d_type` refers to the distance metric used to convert the categorical to numerical values. Valid options are `abdm`, `mvdm` and `abdm-mvdm`. `abdm` infers the distance between categories of the same variable from the context provided by the other variables. This requires binning of the numerical features as well. `mvdm` computes the distance using the model predictions, and `abdm-mvdm` combines both methods. More info on both distance measures can be found in the [documentation](https://docs.seldon.io/projects/alibi/en/latest/methods/CFProto.html)."
    ]
   },
   {
@@ -1000,7 +1000,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/examples/cfproto_cat_adult_ord.ipynb
+++ b/examples/cfproto_cat_adult_ord.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This example notebook illustrates how to obtain [counterfactual explanations](../doc/source/methods/CFProto.ipynb) for instances with a mixture of ordinally encoded categorical and numerical variables. A more elaborate notebook highlighting additional functionality can be found [here](./cfproto_cat_adult_ohe.ipynb). We generate counterfactuals for instances in the *adult* dataset where we predict whether a person's income is above or below $50k."
+    "This example notebook illustrates how to obtain [counterfactual explanations](https://docs.seldon.io/projects/alibi/en/latest/methods/CFProto.html) for instances with a mixture of ordinally encoded categorical and numerical variables. A more elaborate notebook highlighting additional functionality can be found [here](./cfproto_cat_adult_ohe.ipynb). We generate counterfactuals for instances in the *adult* dataset where we predict whether a person's income is above or below $50k."
    ]
   },
   {
@@ -506,7 +506,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Fit explainer. Please check the [documentation](../doc/source/methods/CFProto.ipynb) for more info about the optional arguments."
+    "Fit explainer. Please check the [documentation](https://docs.seldon.io/projects/alibi/en/latest/methods/CFProto.html) for more info about the optional arguments."
    ]
   },
   {
@@ -625,7 +625,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR does 2 things:

- Split out the docs build step in CI as it doesn't have to be done for every Python version and also separates the requirements from the test environment more cleanly
- Add a config file for readthedocs so the builds are configured directly in the repo instead of via their console