### PR TITLE
Implement reset_predictor method for explainers

### DIFF
--- a/alibi/api/interfaces.py
+++ b/alibi/api/interfaces.py
@@ -79,6 +79,10 @@ class Explainer(abc.ABC):
     def explain(self, X: Any) -> "Explanation":
         pass
 
+    @abc.abstractmethod
+    def reset_predictor(self, predictor: Any) -> None:
+        pass
+
     def _update_metadata(self, data_dict: dict, params: bool = False) -> None:
         """
         Updates the metadata of the explainer using the data from the `data_dict`. If the params option

--- a/alibi/api/interfaces.py
+++ b/alibi/api/interfaces.py
@@ -79,9 +79,8 @@ class Explainer(abc.ABC):
     def explain(self, X: Any) -> "Explanation":
         pass
 
-    @abc.abstractmethod
     def reset_predictor(self, predictor: Any) -> None:
-        pass
+        raise NotImplementedError
 
     def _update_metadata(self, data_dict: dict, params: bool = False) -> None:
         """

--- a/alibi/explainers/ale.py
+++ b/alibi/explainers/ale.py
@@ -192,6 +192,9 @@ class ALE(Explainer):
 
         return Explanation(meta=copy.deepcopy(self.meta), data=data)
 
+    def reset_predictor(self, predictor: Callable) -> None:
+        self.predictor = predictor
+
 
 def get_quantiles(values: np.ndarray, num_quantiles: int = 11, interpolation='linear') -> np.ndarray:
     """

--- a/alibi/explainers/anchor_image.py
+++ b/alibi/explainers/anchor_image.py
@@ -68,6 +68,7 @@ class AnchorImage(Explainer):
             )
 
         # set the predictor
+        self.image_shape = image_shape
         self.predictor = self._transform_predictor(predictor)
 
         # segmentation function is either a user-defined function or one of the values in
@@ -80,7 +81,6 @@ class AnchorImage(Explainer):
             self.segmentation_fn = partial(fn_options[segmentation_fn], **segmentation_kwargs)
 
         self.images_background = images_background
-        self.image_shape = image_shape
         # [H, W] int array; each int is a superpixel labels
         self.segments = None  # type: np.ndarray
         self.segment_labels = None  # type: list

--- a/alibi/explainers/anchor_image.py
+++ b/alibi/explainers/anchor_image.py
@@ -67,12 +67,8 @@ class AnchorImage(Explainer):
                 'the specified segmentation function will be used.'
             )
 
-        # check if predictor returns predicted class or prediction probabilities for each class
-        # if needed adjust predictor so it returns the predicted class
-        if np.argmax(predictor(np.zeros((1,) + image_shape)).shape) == 0:
-            self.predictor = predictor
-        else:
-            self.predictor = ArgmaxTransformer(predictor)
+        # set the predictor
+        self.predictor = self._transform_predictor(predictor)
 
         # segmentation function is either a user-defined function or one of the values in
         fn_options = {'felzenszwalb': felzenszwalb, 'slic': slic, 'quickshift': quickshift}
@@ -503,3 +499,15 @@ class AnchorImage(Explainer):
         masked_image = (image * np.expand_dims(mask, 2)).astype(int)
 
         return masked_image
+
+    def _transform_predictor(self, predictor: Callable) -> Callable:
+        # check if predictor returns predicted class or prediction probabilities for each class
+        # if needed adjust predictor so it returns the predicted class
+        if np.argmax(predictor(np.zeros((1,) + self.image_shape)).shape) == 0:
+            return predictor
+        else:
+            transformer = ArgmaxTransformer(predictor)
+            return transformer
+
+    def reset_predictor(self, predictor: Callable) -> None:
+        self.predictor = self._transform_predictor(predictor)

--- a/alibi/explainers/anchor_text.py
+++ b/alibi/explainers/anchor_text.py
@@ -143,12 +143,8 @@ class AnchorText(Explainer):
 
         self.nlp = _load_spacy_lexeme_prob(nlp)
 
-        # check if predictor returns predicted class or prediction probabilities for each class
-        # if needed adjust predictor so it returns the predicted class
-        if np.argmax(predictor(['Hello world']).shape) == 0:
-            self.predictor = predictor
-        else:
-            self.predictor = ArgmaxTransformer(predictor)
+        # set the predictor
+        self.predictor = self._transform_predictor(predictor)
 
         self._synonyms_generator = Neighbors(self.nlp)
         self.tokens, self.words, self.positions, self.punctuation = [], [], [], []  # type: List, List, List, List
@@ -641,3 +637,15 @@ class AnchorText(Explainer):
         # params passed to explain
         explanation.meta['params'].update(params)
         return explanation
+
+    def _transform_predictor(self, predictor: Callable) -> Callable:
+        # check if predictor returns predicted class or prediction probabilities for each class
+        # if needed adjust predictor so it returns the predicted class
+        if np.argmax(predictor(['Hello world']).shape) == 0:
+            return predictor
+        else:
+            transformer = ArgmaxTransformer(predictor)
+            return transformer
+
+    def reset_predictor(self, predictor: Callable) -> None:
+        self.predictor = self._transform_predictor(predictor)

--- a/alibi/explainers/cem.py
+++ b/alibi/explainers/cem.py
@@ -717,3 +717,6 @@ class CEM(Explainer, FitMixin):
         explanation = Explanation(meta=copy.deepcopy(self.meta), data=data)
 
         return explanation
+
+    def reset_predictor(self, predictor: Union[Callabl, tf.keras.Model, 'keras.Model']) -> None:
+        raise NotImplementedError('Resetting a predictor is currently not supported')

--- a/alibi/explainers/cem.py
+++ b/alibi/explainers/cem.py
@@ -718,5 +718,5 @@ class CEM(Explainer, FitMixin):
 
         return explanation
 
-    def reset_predictor(self, predictor: Union[Callabl, tf.keras.Model, 'keras.Model']) -> None:
+    def reset_predictor(self, predictor: Union[Callable, tf.keras.Model, 'keras.Model']) -> None:
         raise NotImplementedError('Resetting a predictor is currently not supported')

--- a/alibi/explainers/cfproto.py
+++ b/alibi/explainers/cfproto.py
@@ -1350,3 +1350,6 @@ class CounterFactualProto(Explainer, FitMixin):
         explanation = Explanation(meta=copy.deepcopy(self.meta), data=data)
 
         return explanation
+
+    def reset_predictor(self, predictor: Union[Callabl, tf.keras.Model, 'keras.Model']) -> None:
+        raise NotImplementedError('Resetting a predictor is currently not supported')

--- a/alibi/explainers/cfproto.py
+++ b/alibi/explainers/cfproto.py
@@ -1351,5 +1351,5 @@ class CounterFactualProto(Explainer, FitMixin):
 
         return explanation
 
-    def reset_predictor(self, predictor: Union[Callabl, tf.keras.Model, 'keras.Model']) -> None:
+    def reset_predictor(self, predictor: Union[Callable, tf.keras.Model, 'keras.Model']) -> None:
         raise NotImplementedError('Resetting a predictor is currently not supported')

--- a/alibi/explainers/counterfactual.py
+++ b/alibi/explainers/counterfactual.py
@@ -602,5 +602,5 @@ class CounterFactual(Explainer):
 
         self.return_dict['success'] = True
 
-    def reset_predictor(self, predictor: Union[Callabl, tf.keras.Model, 'keras.Model']) -> None:
+    def reset_predictor(self, predictor: Union[Callable, tf.keras.Model, 'keras.Model']) -> None:
         raise NotImplementedError('Resetting a predictor is currently not supported')

--- a/alibi/explainers/counterfactual.py
+++ b/alibi/explainers/counterfactual.py
@@ -601,3 +601,6 @@ class CounterFactual(Explainer):
             self._bisect_lambda(cf_found, l_step, lam, lam_lb, lam_ub)
 
         self.return_dict['success'] = True
+
+    def reset_predictor(self, predictor: Union[Callabl, tf.keras.Model, 'keras.Model']) -> None:
+        raise NotImplementedError('Resetting a predictor is currently not supported')

--- a/alibi/explainers/integrated_gradients.py
+++ b/alibi/explainers/integrated_gradients.py
@@ -617,3 +617,6 @@ class IntegratedGradients(Explainer):
         data.update(deltas=deltas)
 
         return Explanation(meta=copy.deepcopy(self.meta), data=data)
+
+    def reset_predictor(self, predictor: Union[tf.keras.Model, 'keras.Model']) -> None:
+        raise NotImplementedError('Resetting a predictor is currently not supported')

--- a/alibi/explainers/shap_wrappers.py
+++ b/alibi/explainers/shap_wrappers.py
@@ -980,6 +980,12 @@ class KernelShap(Explainer, FitMixin):
                 )
                 self.summarise_result = False
 
+    def reset_predictor(self, predictor: Callable) -> None:
+        self.predictor = predictor
+        # TODO: check if we need to reinitialize self._explainer (potentially not, as it should hold a reference to self.predictor)
+        # however, the shap.KernelExplainer may utilize the Callable to set some attributes
+        # TODO: check if we need to do more for the distributed case
+
 
 # TODO: Look into pyspark support requirements if requested
 # TODO: catboost.Pool not supported for fit stage (due to summarisation) but can do if there is a user need
@@ -1586,3 +1592,6 @@ class TreeShap(Explainer, FitMixin):
                 "the encoding dimensions were not passed!"
             )
             self.summarise_result = False
+
+    def reset_predictor(self, predictor: Any) -> None:
+        raise NotImplementedError('Resetting a predictor is currently not supported')

--- a/alibi/explainers/shap_wrappers.py
+++ b/alibi/explainers/shap_wrappers.py
@@ -982,8 +982,8 @@ class KernelShap(Explainer, FitMixin):
 
     def reset_predictor(self, predictor: Callable) -> None:
         self.predictor = predictor
-        # TODO: check if we need to reinitialize self._explainer (potentially not, as it should hold a reference to self.predictor)
-        # however, the shap.KernelExplainer may utilize the Callable to set some attributes
+        # TODO: check if we need to reinitialize self._explainer (potentially not, as it should hold a reference
+        #  to self.predictor) however, the shap.KernelExplainer may utilize the Callable to set some attributes
         # TODO: check if we need to do more for the distributed case
 
 


### PR DESCRIPTION
This PR aims to address #133 .

It adds a method `reset_predictor` for every `Explainer` allowing to swap the predictor of an already initialized and/or fitted explainer. The main use case for this is when deploying an explainer for use with a remote endpoint instead of the local predictor used in development.

For this first iteration there are some restrictions:
- `NotImplementedError` for white-box explainers (`CEM`, `CounterFactual`, `CounterFactualProto`, `IntegratedGradients`, `TreeShap`) as it is unclear how this should be done, especially in the case of TensorFlow. This should not be a major shortcoming as I can't see an immediate use case for being able to reset a white-box predictor (for a serialized explainer, the predictor would also be serialized and ready to be reused).
- `NotImplementedError` or not tested for distributed explainers (i.e. `DistributedAnchorTabular` and `KernelShap` respectively) due to having to potentially re-initialize remote ray objects
- Not tested for `KernelShap` as resetting the predictor may involve re-initializing the private `shap._KernelExplainer` class (may not be necessary if it just holds a reference to `self.predictor`)