### PR TITLE
Update type hints to work with numpy 1.20

### DIFF
--- a/alibi/api/defaults.py
+++ b/alibi/api/defaults.py
@@ -37,7 +37,6 @@ DEFAULT_META_CEM = {"name": None,
 """
 Default CEM metadata.
 """
-
 DEFAULT_DATA_CEM = {"PN": None,
                     "PP": None,
                     "PN_pred": None,
@@ -46,7 +45,7 @@ DEFAULT_DATA_CEM = {"PN": None,
                     "grads_num": None,
                     "X": None,
                     "X_pred": None
-                    }
+                    }  # type: dict
 """
 Default CEM data.
 """

--- a/alibi/confidence/model_linearity.py
+++ b/alibi/confidence/model_linearity.py
@@ -215,9 +215,7 @@ def _sample_knn(x: np.ndarray, X_train: np.ndarray, nb_samples: int = 10) -> np.
         X_sampled_tmp = X_train[indices]
         X_sampled.append(X_sampled_tmp)
 
-    X_sampled = np.array(X_sampled)  # shape=(nb_instances, nb_samples, nb_features)
-
-    return X_sampled
+    return np.asarray(X_sampled)  # shape=(nb_instances, nb_samples, nb_features)
 
 
 def _sample_grid(x: np.ndarray, feature_range: np.ndarray = None, epsilon: float = 0.04,
@@ -422,8 +420,7 @@ class LinearityMeasure(object):
                                      model_type=self.model_type, agg=self.agg)
         elif self.method == 'grid':
             if not self.is_fit:
-                self.feature_range = [[0, 1] for _ in x.shape[1]]  # hardcoded (e.g. from 0 to 1)
-
+                self.feature_range = np.asarray([[0, 1]] * x.shape[1])  # hardcoded (e.g. from 0 to 1)
             lin = _linearity_measure(predict_fn, x, X_train=None, feature_range=self.feature_range,
                                      method=self.method, nb_samples=self.nb_samples, res=self.res, epsilon=self.epsilon,
                                      alphas=self.alphas, model_type=self.model_type, agg=self.agg)
@@ -476,7 +473,7 @@ def linearity_measure(predict_fn: Callable, x: np.ndarray, feature_range: Union[
                                  model_type=model_type, agg=agg)
     elif method == 'grid':
         assert feature_range is not None or X_train is not None, "Method 'grid' requires " \
-                                                                  "feature_range != None or X_train != None"
+                                                                 "feature_range != None or X_train != None"
         if X_train is not None and feature_range is None:
             feature_range = _infer_feature_range(X_train)  # infer from dataset
         elif feature_range is not None:

--- a/alibi/confidence/trustscore.py
+++ b/alibi/confidence/trustscore.py
@@ -118,7 +118,7 @@ class TrustScore(object):
 
         # make sure Y represents predicted classes, not one-hot encodings
         if len(Y.shape) > 1:
-            Y = np.argmax(Y, axis=1)
+            Y = np.argmax(Y, axis=1)  # type: ignore
 
         if self.filter == 'probability_knn':
             X_filter, Y_filter = self.filter_by_probability_knn(X, Y)
@@ -165,7 +165,7 @@ class TrustScore(object):
         """
         # make sure Y represents predicted classes, not probabilities
         if len(Y.shape) > 1:
-            Y = np.argmax(Y, axis=1)
+            Y = np.argmax(Y, axis=1)  # type: ignore
 
         # KDTree needs 2D data
         if len(X.shape) > 2:

--- a/alibi/datasets.py
+++ b/alibi/datasets.py
@@ -7,7 +7,7 @@ import requests
 from requests import RequestException
 from sklearn.preprocessing import LabelEncoder
 import tarfile
-from typing import Tuple, Union
+from typing import Any, Tuple, Union
 import logging
 from alibi.utils.data import Bunch
 

--- a/alibi/datasets.py
+++ b/alibi/datasets.py
@@ -7,7 +7,7 @@ import requests
 from requests import RequestException
 from sklearn.preprocessing import LabelEncoder
 import tarfile
-from typing import Any, Tuple, Union
+from typing import Tuple, Union
 import logging
 from alibi.utils.data import Bunch
 

--- a/alibi/explainers/ale.py
+++ b/alibi/explainers/ale.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 from itertools import count
 from functools import partial
-from typing import Callable, List, Optional, Tuple, Union, TYPE_CHECKING, no_type_check
+from typing import Any, Callable, List, Optional, Tuple, Union, TYPE_CHECKING, no_type_check
 
 import sys
 
@@ -75,8 +75,8 @@ class ALE(Explainer):
         super().__init__(meta=copy.deepcopy(DEFAULT_META_ALE))
 
         self.predictor = predictor
-        self.feature_names = feature_names
-        self.target_names = target_names
+        self.feature_names = np.array(feature_names)
+        self.target_names = np.array(feature_names)
         self.check_feature_resolution = check_feature_resolution
         self.low_resolution_threshold = low_resolution_threshold
         self.extrapolate_constant = extrapolate_constant
@@ -111,13 +111,11 @@ class ALE(Explainer):
 
         # set feature and target names, this is done here as we don't know n_features at init time
         if self.feature_names is None:
-            self.feature_names = [f'f_{i}' for i in range(n_features)]
+            self.feature_names = np.array([f'f_{i}' for i in range(n_features)])
         if self.target_names is None:
             pred = np.atleast_2d(self.predictor(X[0].reshape(1, -1)))
             n_targets = pred.shape[1]
-            self.target_names = [f'c_{i}' for i in range(n_targets)]
-        self.feature_names = np.array(self.feature_names)
-        self.target_names = np.array(self.target_names)
+            self.target_names = np.array([f'c_{i}' for i in range(n_targets)])
 
         # only calculate ALE for the specified features and return the explanation for this subset
         if features:

--- a/alibi/explainers/ale.py
+++ b/alibi/explainers/ale.py
@@ -116,8 +116,8 @@ class ALE(Explainer):
             pred = np.atleast_2d(self.predictor(X[0].reshape(1, -1)))
             n_targets = pred.shape[1]
             self.target_names = [f'c_{i}' for i in range(n_targets)]
-        self.feature_names = np.array(self.feature_names)
-        self.target_names = np.array(self.target_names)
+        self.feature_names = np.array(self.feature_names)  # type: ignore
+        self.target_names = np.array(self.target_names)  # type: ignore
 
         # only calculate ALE for the specified features and return the explanation for this subset
         if features:

--- a/alibi/explainers/ale.py
+++ b/alibi/explainers/ale.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 from itertools import count
 from functools import partial
-from typing import Any, Callable, List, Optional, Tuple, Union, TYPE_CHECKING, no_type_check
+from typing import Callable, List, Optional, Tuple, Union, TYPE_CHECKING, no_type_check
 
 import sys
 

--- a/alibi/explainers/ale.py
+++ b/alibi/explainers/ale.py
@@ -75,8 +75,8 @@ class ALE(Explainer):
         super().__init__(meta=copy.deepcopy(DEFAULT_META_ALE))
 
         self.predictor = predictor
-        self.feature_names = np.array(feature_names)
-        self.target_names = np.array(feature_names)
+        self.feature_names = feature_names
+        self.target_names = target_names
         self.check_feature_resolution = check_feature_resolution
         self.low_resolution_threshold = low_resolution_threshold
         self.extrapolate_constant = extrapolate_constant
@@ -111,11 +111,13 @@ class ALE(Explainer):
 
         # set feature and target names, this is done here as we don't know n_features at init time
         if self.feature_names is None:
-            self.feature_names = np.array([f'f_{i}' for i in range(n_features)])
+            self.feature_names = [f'f_{i}' for i in range(n_features)]
         if self.target_names is None:
             pred = np.atleast_2d(self.predictor(X[0].reshape(1, -1)))
             n_targets = pred.shape[1]
-            self.target_names = np.array([f'c_{i}' for i in range(n_targets)])
+            self.target_names = [f'c_{i}' for i in range(n_targets)]
+        self.feature_names = np.array(self.feature_names)
+        self.target_names = np.array(self.target_names)
 
         # only calculate ALE for the specified features and return the explanation for this subset
         if features:

--- a/alibi/explainers/anchor_explanation.py
+++ b/alibi/explainers/anchor_explanation.py
@@ -1,4 +1,5 @@
 import numpy as np
+from typing import Union
 
 
 class AnchorExplanation:
@@ -96,7 +97,7 @@ class AnchorExplanation:
             return coverage[-1]
 
     def examples(self, only_different_prediction: bool = False,
-                 only_same_prediction: bool = False, partial_index: int = None) -> np.ndarray:
+                 only_same_prediction: bool = False, partial_index: int = None) -> Union[list, np.ndarray]:
         """
         Parameters
         ----------

--- a/alibi/explainers/anchor_image.py
+++ b/alibi/explainers/anchor_image.py
@@ -210,7 +210,7 @@ class AnchorImage(Explainer):
             covered_false = [self._scale(img) for img in covered_false]
             # coverage set to -1.0 as we can't compute 'true'coverage for this model
 
-            return [covered_true, covered_false, labels.astype(int), data, -1.0, anchor[0]]
+            return [covered_true, covered_false, labels.astype(int), data, -1.0, anchor[0]]  # type: ignore
 
         else:
             data = self._choose_superpixels(num_samples)

--- a/alibi/explainers/anchor_tabular.py
+++ b/alibi/explainers/anchor_tabular.py
@@ -60,7 +60,7 @@ class TabularSampler:
         self.ord_lookup = {}  # type: Dict[int, set]
         self.enc2feat_idx = {}  # type: Dict[int, int]
 
-    def deferred_init(self, train_data: Union[np.ndarray, Any], d_train_data: Union[np.array, Any]) -> Any:
+    def deferred_init(self, train_data: Union[np.ndarray, Any], d_train_data: Union[np.ndarray, Any]) -> Any:
         """
         Initialise the Tabular sampler object with data, discretizer, feature statistics and
         build an index from feature values and bins to database rows for each feature.
@@ -85,7 +85,7 @@ class TabularSampler:
 
         return self
 
-    def _set_data(self, train_data: Union[np.ndarray, Any], d_train_data: Union[np.array, Any]) -> None:
+    def _set_data(self, train_data: Union[np.ndarray, Any], d_train_data: Union[np.ndarray, Any]) -> None:
         """
         Initialise sampler training set and discretized training set, set number of records.
         """
@@ -373,7 +373,7 @@ class TabularSampler:
 
         # replace partial anchors with partial anchors drawn from the training dataset
         # samp_idxs are arrays of training set row indices from where partial anchors are extracted for replacement
-        for idx, n_samp in enumerate(nb_partial_anchors[start_idx:end_idx + 1], start=start_idx):
+        for idx, n_samp in enumerate(nb_partial_anchors[start_idx:end_idx + 1], start=start_idx):  # type: ignore
             if num_samples >= n_samp:
                 samp_idxs = partial_anchor_rows[n_anchor_feats - idx - 1]
                 num_samples -= n_samp

--- a/alibi/explainers/cem.py
+++ b/alibi/explainers/cem.py
@@ -6,7 +6,7 @@ import logging
 import numpy as np
 import sys
 import tensorflow.compat.v1 as tf
-from typing import Callable, Tuple, Union, TYPE_CHECKING
+from typing import Any, Callable, Tuple, Union, TYPE_CHECKING
 from alibi.utils.tf import _check_keras_or_tf
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -494,10 +494,10 @@ class CEM(Explainer, FitMixin):
             if not isinstance(x, (float, int, np.int64)):
                 x = np.copy(x)
                 if self.mode == "PP":
-                    x[y] -= self.kappa
+                    x[y] -= self.kappa  # type:ignore
                 elif self.mode == "PN":
-                    x[y] += self.kappa
-                x = np.argmax(x)
+                    x[y] += self.kappa  # type:ignore
+                x = np.argmax(x)  # type:ignore
             if self.mode == "PP":
                 return x == y
             else:
@@ -532,7 +532,7 @@ class CEM(Explainer, FitMixin):
                                        self.assign_adv_s: X,
                                        self.assign_no_info: self.no_info_val})
 
-            X_der_batch, X_der_batch_s = [], []
+            X_der_batch, X_der_batch_s = [], []  # type: Any, Any
 
             for i in range(self.max_iterations):
 
@@ -557,8 +557,8 @@ class CEM(Explainer, FitMixin):
                         grads_num = self.get_gradients(X_der_batch, Y) * c
                         grads_num_s = self.get_gradients(X_der_batch_s, Y) * c
                         # clip gradients
-                        grads_num = np.clip(grads_num, self.clip[0], self.clip[1])
-                        grads_num_s = np.clip(grads_num_s, self.clip[0], self.clip[1])
+                        grads_num = np.clip(grads_num, self.clip[0], self.clip[1])  # type:ignore
+                        grads_num_s = np.clip(grads_num_s, self.clip[0], self.clip[1])  # type: ignore
                         X_der_batch, X_der_batch_s = [], []
 
                 # compute and clip gradients defined in graph
@@ -603,13 +603,13 @@ class CEM(Explainer, FitMixin):
                     print('Target proba: {:.2f}, max non target proba: {:.2f}'.format(target_proba,
                                                                                       nontarget_proba_max))
                     print('Gradient graph min/max: {:.3f}/{:.3f}'.format(grads_graph.min(), grads_graph.max()))
-                    print('Gradient graph mean/abs mean: {:.3f}/{:.3f}'.format(np.mean(grads_graph),
-                                                                               np.mean(np.abs(grads_graph))))
+                    print('Gradient graph mean/abs mean: {:.3f}/{:.3f}' \
+                          .format(np.mean(grads_graph), np.mean(np.abs(grads_graph))))  # type: ignore
                     if not self.model:
-                        print('Gradient numerical attack min/max: {:.3f}/{:.3f}'.format(grads_num.min(),
-                                                                                        grads_num.max()))
-                        print('Gradient numerical mean/abs mean: {:.3f}/{:.3f}'.format(np.mean(grads_num),
-                                                                                       np.mean(np.abs(grads_num))))
+                        print('Gradient numerical attack min/max: {:.3f}/{:.3f}' \
+                              .format(grads_num.min(), grads_num.max()))  # type: ignore
+                        print('Gradient numerical mean/abs mean: {:.3f}/{:.3f}' \
+                              .format(np.mean(grads_num), np.mean(np.abs(grads_num))))  # type: ignore
                     sys.stdout.flush()
 
                 # update best perturbation (distance) and class probabilities
@@ -617,12 +617,12 @@ class CEM(Explainer, FitMixin):
                 # different from the initial label (for PN); update best current step or global perturbations
                 for batch_idx, (dist, proba, adv_idx) in enumerate(zip(loss_l1_l2, pred_proba, adv)):
                     # current step
-                    if dist < current_best_dist[batch_idx] and compare(proba, np.argmax(Y[batch_idx])):
+                    if dist < current_best_dist[batch_idx] and compare(proba, np.argmax(Y[batch_idx])):  # type: ignore
                         current_best_dist[batch_idx] = dist
-                        current_best_proba[batch_idx] = np.argmax(proba)
+                        current_best_proba[batch_idx] = np.argmax(proba)  # type: ignore
 
                     # global
-                    if dist < overall_best_dist[batch_idx] and compare(proba, np.argmax(Y[batch_idx])):
+                    if dist < overall_best_dist[batch_idx] and compare(proba, np.argmax(Y[batch_idx])):  # type: ignore
                         if verbose:
                             print('\nNew best {} found!'.format(self.mode))
                         overall_best_dist[batch_idx] = dist
@@ -632,7 +632,7 @@ class CEM(Explainer, FitMixin):
 
             # adjust the 'c' constant for the first loss term
             for batch_idx in range(self.batch_size):
-                if (compare(current_best_proba[batch_idx], np.argmax(Y[batch_idx])) and
+                if (compare(current_best_proba[batch_idx], np.argmax(Y[batch_idx])) and  # type: ignore
                         current_best_proba[batch_idx] != -1):
                     # want to refine the current best solution by putting more emphasis on the regularization terms
                     # of the loss by reducing 'c'; aiming to find a perturbation closer to the original instance

--- a/alibi/explainers/integrated_gradients.py
+++ b/alibi/explainers/integrated_gradients.py
@@ -587,10 +587,10 @@ class IntegratedGradients(Explainer):
         # define paths in features' space
         paths = []
         for i in range(len(X)):
-            x, baseline = X[i], baselines[i]
+            x, baseline = X[i], baselines[i]  # type: ignore
             # format and check baselines
             baseline = _format_input_baseline(x, baseline)
-            baselines[i] = baseline
+            baselines[i] = baseline  # type: ignore
 
             # construct paths
             path = np.concatenate([baseline + alphas[i] * (x - baseline) for i in range(self.n_steps)], axis=0)
@@ -664,7 +664,7 @@ class IntegratedGradients(Explainer):
                                              target, target_paths,
                                              self.n_steps, nb_samples,
                                              step_sizes, j)
-                norm = X[j] - baselines[j]
+                norm = X[j] - baselines[j]  # type: ignore
 
                 attribution = norm * sum_int
                 attributions.append(attribution)

--- a/alibi/explainers/shap_wrappers.py
+++ b/alibi/explainers/shap_wrappers.py
@@ -74,7 +74,7 @@ def rank_by_importance(shap_values: List[np.ndarray],
             logger.warning(msg.format(len(feature_names), shap_values[0].shape[1]))
             feature_names = ['feature_{}'.format(i) for i in range(shap_values[0].shape[1])]
 
-    importances = {}  # type: Dict[str, Dict[str, np.ndarray]]
+    importances = {}  # type: Dict[str, Dict[str, Union[np.ndarray, List[str]]]]
     avg_mag = []  # type: List
 
     # rank the features by average shap value for each class in turn
@@ -920,7 +920,7 @@ class KernelShap(Explainer, FitMixin):
         if self.task != 'regression':
             argmax_pred = np.argmax(np.atleast_2d(raw_predictions), axis=1)
         else:
-            argmax_pred = []
+            argmax_pred = []  # type: ignore
         importances = rank_by_importance(shap_values, feature_names=self.feature_names)
 
         if isinstance(X, sparse.spmatrix):
@@ -1497,13 +1497,13 @@ class TreeShap(Explainer, FitMixin):
             shap_values = [interactions.sum(axis=2) for interactions in shap_output]
         else:
             shap_interaction_values = [np.array([])]
-            shap_values = shap_output
+            shap_values = shap_output  # type: ignore
         if summarise_result:
             self._check_result_summarisation(summarise_result, cat_vars_start_idx, cat_vars_enc_dim)
         if self.summarise_result:
             summarised_shap = []
             for shap_array in shap_values:
-                summarised_shap.append(sum_categories(shap_array, cat_vars_start_idx, cat_vars_enc_dim))
+                summarised_shap.append(sum_categories(shap_array, cat_vars_start_idx, cat_vars_enc_dim))  # type: ignore
             shap_values = summarised_shap
             if shap_interaction_values[0].size != 0:
                 summarised_shap_interactions = []
@@ -1518,7 +1518,7 @@ class TreeShap(Explainer, FitMixin):
         # NB: raw output of a regression or classification task will not work for pyspark (predict not implemented)
         if self.model_output == 'log_loss':
             loss = self._explainer.model.predict(X, y, tree_limit=self.tree_limit)
-            raw_predictions = []  # type: Union[List, np.ndarray]
+            raw_predictions = []  # type: Any
         else:
             loss = []
             raw_predictions = self._explainer.model.predict(X, tree_limit=self.tree_limit)
@@ -1527,7 +1527,7 @@ class TreeShap(Explainer, FitMixin):
                 raw_predictions = raw_predictions.squeeze(-1)
 
         # predicted class
-        argmax_pred = []  # type: Union[List, np.ndarray]
+        argmax_pred = []  # type: Any
         if self.task != 'regression':
             if not isinstance(raw_predictions, list):
                 if self.scalar_output:
@@ -1539,7 +1539,7 @@ class TreeShap(Explainer, FitMixin):
                 else:
                     argmax_pred = np.argmax(np.atleast_2d(raw_predictions), axis=1)
 
-        importances = rank_by_importance(shap_values, feature_names=self.feature_names)
+        importances = rank_by_importance(shap_values, feature_names=self.feature_names)  # type: ignore
 
         if self._explainer.model.model_type == 'catboost':
             import catboost  # noqa: F811

--- a/alibi/utils/approximation_methods.py
+++ b/alibi/utils/approximation_methods.py
@@ -24,7 +24,7 @@ SUPPORTED_METHODS = SUPPORTED_RIEMANN_METHODS + ["gausslegendre"]
 
 
 def approximation_parameters(
-    method: str,
+        method: str,
 ) -> Tuple[Callable[[int], List[float]], Callable[[int], List[float]]]:
     """Retrieves parameters for the input approximation `method`
 
@@ -41,7 +41,7 @@ def approximation_parameters(
 
 
 def riemann_builders(
-    method: Riemann = Riemann.trapezoid,
+        method: Riemann = Riemann.trapezoid,
 ) -> Tuple[Callable[[int], List[float]], Callable[[int], List[float]]]:
     """Step sizes are identical and alphas are scaled in [0, 1]
 
@@ -132,11 +132,11 @@ def gauss_legendre_builders() -> Tuple[
     def step_sizes(n: int) -> List[float]:
         assert n > 0, "The number of steps has to be larger than zero"
         # Scaling from 2 to 1
-        return list(0.5 * np.polynomial.legendre.leggauss(n)[1])
+        return list(0.5 * np.polynomial.legendre.leggauss(n)[1])  # type: ignore
 
     def alphas(n: int) -> List[float]:
         assert n > 0, "The number of steps has to be larger than zero"
         # Scaling from [-1, 1] to [0, 1]
-        return list(0.5 * (1 + np.polynomial.legendre.leggauss(n)[0]))
+        return list(0.5 * (1 + np.polynomial.legendre.leggauss(n)[0]))  # type: ignore
 
     return step_sizes, alphas

--- a/alibi/utils/distance.py
+++ b/alibi/utils/distance.py
@@ -34,7 +34,7 @@ def cityblock_batch(X: np.ndarray,
 def mvdm(X: np.ndarray,
          y: np.ndarray,
          cat_vars: dict,
-         alpha: int = 1) -> np.ndarray:
+         alpha: int = 1) -> Dict[int, np.ndarray]:
     """
     Calculate the pair-wise distances between categories of a categorical variable using
     the Modified Value Difference Measure based on Cost et al (1993).

--- a/alibi/utils/distributed.py
+++ b/alibi/utils/distributed.py
@@ -30,7 +30,6 @@ RAY_INSTALLED = check_ray()
 
 
 class ActorPool(object):
-
     # TODO: JANIS: IF YOU DECIDE TO TAKE A DEPENDENCY ON RAY CORE, THEN THIS CLASS SHOULD INHERIT FROM
     #  RAY.UTIL.ACTORPOOL, OVERRIDE MAP AND MAP_UNORDERED AND ADD _CHUNK STATIC METHOD.
 
@@ -346,7 +345,7 @@ def concatenate_minibatches(minibatch_results: Union[List[np.ndarray], List[List
     if isinstance(minibatch_results[0], np.ndarray):
         return np.concatenate(minibatch_results, axis=0)
     elif isinstance(minibatch_results[0], list) and isinstance(minibatch_results[0][0], np.ndarray):
-        return _array_list_concatenator(minibatch_results)
+        return _array_list_concatenator(minibatch_results)  # type: ignore
     else:
         raise TypeError(
             "Minibatch concatenation function is defined only for List[np.ndarray] and List[List[np.ndarray]]"
@@ -676,7 +675,7 @@ class PoolCollection:
             If the number of CPUs specified by the user is smaller than the number of distributed explainers.
         ValueError
             If the number of entries in the explainers args/kwargs list differ.
-        """ # noqa W605
+        """  # noqa W605
 
         available_cpus = distributed_opts['n_cpus']
         if len(explainer_init_args) != len(explainer_init_kwargs):

--- a/alibi/utils/visualization.py
+++ b/alibi/utils/visualization.py
@@ -62,7 +62,7 @@ def _normalize_image_attr(
         threshold = _cumulative_sum_threshold(np.abs(attr_combined), 100 - outlier_perc)
     elif VisualizeSign[sign] == VisualizeSign.positive:
         attr_combined = (attr_combined > 0) * attr_combined
-        threshold = _cumulative_sum_threshold(attr_combined, 100 - outlier_perc)
+        threshold = _cumulative_sum_threshold(attr_combined, 100 - outlier_perc)  # type: ignore
     elif VisualizeSign[sign] == VisualizeSign.negative:
         attr_combined = (attr_combined < 0) * attr_combined
         threshold = -1 * _cumulative_sum_threshold(
@@ -70,10 +70,10 @@ def _normalize_image_attr(
         )
     elif VisualizeSign[sign] == VisualizeSign.absolute_value:
         attr_combined = np.abs(attr_combined)
-        threshold = _cumulative_sum_threshold(attr_combined, 100 - outlier_perc)
+        threshold = _cumulative_sum_threshold(attr_combined, 100 - outlier_perc)  # type: ignore
     else:
         raise AssertionError("Visualize Sign type is not valid.")
-    return _normalize_scale(attr_combined, threshold)
+    return _normalize_scale(attr_combined, threshold)  # type: ignore
 
 
 def visualize_image_attr(


### PR DESCRIPTION
Numpy 1.20 release introduced typing support which raised quite a few `mypy` errors. A couple of these recovered actual runtime bugs (!) whilst the majority required modifying the type hints in some places. Because it looks like in some places the `numpy` types are quite broad (see here: https://github.com/numpy/numpy/issues/18305#issuecomment-786730539), I've used `type: ignore` in quite a few places.

The best way to review this is to probably install `numpy==1.20` locally and run `mypy` on master to see which errors this PR fixes. Note that currently CI runs `numpy 1.19` because of a pin by `tensorflow`.