### PR TITLE
Make shap an extra dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           pip install -r requirements/dev.txt
           python -m spacy download en_core_web_md
           pip install -e .
+          pip install -e .[shap]
           pip freeze
       - name: Lint with flake8
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools
-          pip install -r requirements/dev.txt
+          pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt
           python -m spacy download en_core_web_md
-          pip install -e .
-          pip install -e .[shap]
+          pip install --upgrade --upgrade-strategy eager -e .
+          pip install --upgrade --upgrade-strategy eager -e .[shap]
           pip freeze
       - name: Lint with flake8
         run: |

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ To take advantage of distributed computation of explanations, install `alibi` wi
 pip install alibi[ray]
 ```
 
+For SHAP support, install `alibi` as follows:
+```bash
+pip install alibi
+pip install alibi[shap]
+```
+
 The alibi explanation API takes inspiration from `scikit-learn`, consisting of distinct initialize,
 fit and explain steps. We will use the [AnchorTabular](https://docs.seldon.io/projects/alibi/en/latest/methods/Anchors.html)
 explainer to illustrate the API:

--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ pip install alibi[ray]
 
 For SHAP support, install `alibi` as follows:
 ```bash
-pip install alibi
-pip install alibi[shap]
+pip install alibi && pip install alibi[shap]
 ```
 
 The alibi explanation API takes inspiration from `scikit-learn`, consisting of distinct initialize,

--- a/alibi/explainers/__init__.py
+++ b/alibi/explainers/__init__.py
@@ -9,7 +9,6 @@ from .anchor_image import AnchorImage
 from .cem import CEM
 from .cfproto import CounterFactualProto
 from .counterfactual import CounterFactual
-from .shap_wrappers import KernelShap, TreeShap
 from .integrated_gradients import IntegratedGradients
 
 __all__ = ["ALE",
@@ -20,8 +19,12 @@ __all__ = ["ALE",
            "CEM",
            "CounterFactual",
            "CounterFactualProto",
-           "KernelShap",
-           "TreeShap",
            "plot_ale",
            "IntegratedGradients"
            ]
+
+try:
+    from .shap_wrappers import KernelShap, TreeShap
+    __all__ += ["KernelShap", "TreeShap"]
+except ImportError:
+    pass

--- a/doc/source/methods/KernelSHAP.ipynb
+++ b/doc/source/methods/KernelSHAP.ipynb
@@ -18,6 +18,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-info\">\n",
+    "To enable SHAP support, you may need to run\n",
+    "    \n",
+    "```bash\n",
+    "pip install alibi[shap]\n",
+    "```\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Overview"
    ]
   },

--- a/doc/source/methods/TreeSHAP.ipynb
+++ b/doc/source/methods/TreeSHAP.ipynb
@@ -18,6 +18,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-info\">\n",
+    "To enable SHAP support, you may need to run\n",
+    "    \n",
+    "```bash\n",
+    "pip install alibi[shap]\n",
+    "```\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Overview"
    ]
   },

--- a/examples/interventional_tree_shap_adult_xgb.ipynb
+++ b/examples/interventional_tree_shap_adult_xgb.ipynb
@@ -11,6 +11,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-info\">\n",
+    "To enable SHAP support, you may need to run\n",
+    "    \n",
+    "```bash\n",
+    "pip install alibi[shap]\n",
+    "```\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Introduction"
    ]
   },
@@ -1369,7 +1383,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/examples/kernel_shap_adult_categorical_preproc.ipynb
+++ b/examples/kernel_shap_adult_categorical_preproc.ipynb
@@ -11,6 +11,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-info\">\n",
+    "To enable SHAP support, you may need to run\n",
+    "    \n",
+    "```bash\n",
+    "pip install alibi[shap]\n",
+    "```\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Introduction"
    ]
   },
@@ -968,7 +982,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/examples/kernel_shap_adult_lr.ipynb
+++ b/examples/kernel_shap_adult_lr.ipynb
@@ -11,6 +11,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-info\">\n",
+    "To enable SHAP support, you may need to run\n",
+    "    \n",
+    "```bash\n",
+    "pip install alibi[shap]\n",
+    "```\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Introduction"
    ]
   },
@@ -2462,7 +2476,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/examples/kernel_shap_wine_intro.ipynb
+++ b/examples/kernel_shap_wine_intro.ipynb
@@ -11,6 +11,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-info\">\n",
+    "To enable SHAP support, you may need to run\n",
+    "    \n",
+    "```bash\n",
+    "pip install alibi[shap]\n",
+    "```\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Introduction"
    ]
   },
@@ -1197,7 +1211,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/examples/kernel_shap_wine_lr.ipynb
+++ b/examples/kernel_shap_wine_lr.ipynb
@@ -11,6 +11,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-info\">\n",
+    "To enable SHAP support, you may need to run\n",
+    "    \n",
+    "```bash\n",
+    "pip install alibi[shap]\n",
+    "```\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Introduction"
    ]
   },
@@ -937,7 +951,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/examples/path_dependent_tree_shap_adult_xgb.ipynb
+++ b/examples/path_dependent_tree_shap_adult_xgb.ipynb
@@ -11,6 +11,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-info\">\n",
+    "To enable SHAP support, you may need to run\n",
+    "    \n",
+    "```bash\n",
+    "pip install alibi[shap]\n",
+    "```\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Introduction"
    ]
   },
@@ -1454,7 +1468,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ deps =
   dataclasses # required with py36
   contextvars # required with py36
   immutables # required with py36
-extras = all
+extras = shap
 commands =
   pip-licenses \
     --from=mixed \

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ exec(open('alibi/version.py').read())
 extras_require = {
     'examples': ['seaborn>=0.9.0', 'xgboost>=0.90'],
     'ray': ['ray>=0.8.7, <2.0.0'],  # from requirements/dev.txt
+    # shap is separated due to build issues, see https://github.com/slundberg/shap/pull/1802
+    'shap': ['shap>=0.36.0, !=0.38.1, <0.40.0'],  # versioning: https://github.com/SeldonIO/alibi/issues/333
 }
 
 setup(name='alibi',
@@ -37,7 +39,6 @@ setup(name='alibi',
           'Pillow>=5.4.1, <9.0',
           'tensorflow>=2.0.0, <2.5.0',
           'attrs>=19.2.0, <21.0.0',
-          'shap>=0.36.0, !=0.38.1, <0.40.0',  # https://github.com/SeldonIO/alibi/issues/333
           'scipy>=1.1.0, <2.0.0',
           'matplotlib>=3.0.0, <4.0.0',
           'typing-extensions>=3.7.2; python_version < "3.8"',  # https://github.com/SeldonIO/alibi/pull/248


### PR DESCRIPTION
This PR is meant to (temporarily) make `shap` an optional dependency. The reason is because the build process of `shap` currently is not optimal and will result in `RuntimeError` when packages have a different runtime dependency on `numpy` than the build dependency of `numpy` used for `shap`.

Concretely, `shap` on linux is built with the latest available version of `numpy` (currently `1.20`), whilst `tensorflow` has a `numpy` pin of `1.19.5`. This means that `pip install alibi` results in a broken installation as `shap` is still built against `1.20`. As far as I've looked, it is not possible to specify a different version of `numpy` to build `shap` against in a "one-pass" install of `alibi` (e.g. if `numpy` is not present, shap will be built against `1.20` regardless, if `numpy` is present it will be built against that version).

As a result, this PR proposes installing `alibi` with `shap` support in two steps:
```bash
pip install alibi
pip install alibi[shap]
```
I have added the above instructions to the README as well as at the top of the shap-specific notebooks.

This workaround should be resolved once `shap` specifies `oldest-supported-numpy` as a build dependency instead. For more information see here: https://github.com/slundberg/shap/pull/1802