### PR TITLE
WIP: Explainer serialization v1

### DIFF
--- a/alibi/api/interfaces.py
+++ b/alibi/api/interfaces.py
@@ -82,8 +82,6 @@ class Explainer(abc.ABC):
 
     @classmethod
     def load(cls, path: PathLike, predictor: Any) -> "Explainer":
-        # TODO: discuss: when called as AnchorTabular.load(...) can use class information to
-        #  do explainer-specific loading if needed
         return load_explainer(path, predictor)
 
     def reset_predictor(self, predictor: Any) -> None:

--- a/alibi/explainers/ale.py
+++ b/alibi/explainers/ale.py
@@ -74,9 +74,6 @@ class ALE(Explainer):
         """
         super().__init__(meta=copy.deepcopy(DEFAULT_META_ALE))
 
-        init_kwargs = locals()
-        init_kwargs.pop('predictor')
-
         self.predictor = predictor
         self.feature_names = feature_names
         self.target_names = target_names
@@ -86,7 +83,13 @@ class ALE(Explainer):
         self.extrapolate_constant_perc = extrapolate_constant_perc
         self.extrapolate_constant_min = extrapolate_constant_min
 
-        self.meta['params'].update(init_kwargs=init_kwargs)
+        self.meta['params'].update(feature_names=feature_names,
+                                   target_names=target_names,
+                                   check_feature_resolution=check_feature_resolution,
+                                   low_resolution_threshold=low_resolution_threshold,
+                                   extrapolate_constant=extrapolate_constant,
+                                   extrapolate_constant_perc=extrapolate_constant_perc,
+                                   extrapolate_constant_min=extrapolate_constant_min)
 
     def explain(self, X: np.ndarray, features: List[int] = None, min_bin_points: int = 4) -> Explanation:
         """

--- a/alibi/explainers/ale.py
+++ b/alibi/explainers/ale.py
@@ -74,6 +74,9 @@ class ALE(Explainer):
         """
         super().__init__(meta=copy.deepcopy(DEFAULT_META_ALE))
 
+        init_kwargs = locals()
+        init_kwargs.pop('predictor')
+
         self.predictor = predictor
         self.feature_names = feature_names
         self.target_names = target_names
@@ -82,6 +85,8 @@ class ALE(Explainer):
         self.extrapolate_constant = extrapolate_constant
         self.extrapolate_constant_perc = extrapolate_constant_perc
         self.extrapolate_constant_min = extrapolate_constant_min
+
+        self.meta['params'].update(init_kwargs=init_kwargs)
 
     def explain(self, X: np.ndarray, features: List[int] = None, min_bin_points: int = 4) -> Explanation:
         """

--- a/alibi/explainers/anchor_image.py
+++ b/alibi/explainers/anchor_image.py
@@ -94,7 +94,8 @@ class AnchorImage(Explainer):
             segmentation_kwargs=segmentation_kwargs,
             p_sample=self.p_sample,
             seed=seed,
-            image_shape=image_shape
+            image_shape=self.image_shape,
+            images_background=self.images_background
         )
         if not self.custom_segmentation:
             self.meta['params'].update(segmentation_fn=segmentation_fn)

--- a/alibi/explainers/anchor_tabular.py
+++ b/alibi/explainers/anchor_tabular.py
@@ -694,7 +694,12 @@ class AnchorTabular(Explainer, FitMixin):
         self.instance_label = None
 
         # update metadata
-        self.meta['params'].update(seed=seed)
+        # TODO: adding all these to meta['params'] makes the __repr__ quite unsightly
+        #  maybe it makes sense to keep private attributes `_init_kwargs`, `_fit_kwargs`
+        #  purely for serialization purposes and outside of general metadata?
+        self.meta['params'].update(feature_names=feature_names,
+                                   categorical_names=categorical_names,
+                                   seed=seed)
 
     def fit(self, train_data: np.ndarray, disc_perc: Tuple[Union[int, float], ...] = (25, 50, 75),  # type:ignore
             **kwargs) -> "AnchorTabular":

--- a/alibi/explainers/anchor_text.py
+++ b/alibi/explainers/anchor_text.py
@@ -153,6 +153,9 @@ class AnchorText(Explainer):
         # the method used to generate samples
         self.perturbation = None  # type: Union[Callable, None]
 
+        # update metadata
+        self.meta['params'].update(seed=seed)
+
     def set_words_and_pos(self, text: str) -> None:
         """
         Process the sentence to be explained into spaCy token objects, a list of words,

--- a/alibi/saving.py
+++ b/alibi/saving.py
@@ -1,0 +1,138 @@
+import json
+from os import PathLike
+from pathlib import Path
+import sys
+from typing import Callable, TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from alibi.api.interfaces import Explainer
+    from alibi.explainers import ALE
+
+thismodule = sys.modules[__name__]
+# https://www.python.org/dev/peps/pep-0519/#provide-specific-type-hinting-support
+# PathLike = Union[str, bytes, os.PathLike]
+
+NOT_SUPPORTED = ["AnchorTabular",
+                 "DistributedAnchorTabular",
+                 "AnchorText",
+                 "AnchorImage",
+                 "CEM",
+                 "CounterFactual",
+                 "CounterFactualProto",
+                 "plot_ale",
+                 "IntegratedGradients",
+                 "KernelShap",
+                 "TreeShap"]
+
+
+# TODO: tricky to use singledispatch and explainer types due to circular imports,
+#  manual dispatch on name instead
+# @singledispatch
+# def save_explainer(explainer, path) -> None:
+#    pass
+#
+# @save_explainer.register
+# def _(explainer: explainers.AnchorTabular, path: PathLike) -> None:
+#    raise NotImplementedError(f'Saving not implemented for {explainer.name}')
+
+def load_explainer(path: PathLike, predictor) -> 'Explainer':
+    # load metadata
+    with open(Path(path, 'meta.json'), 'r') as f:
+        meta = json.load(f)
+
+    # get the explainer specific load function
+    name = meta['name']
+    load_fn = getattr(thismodule, '_load_' + name)
+    return load_fn(path, predictor, meta)
+
+
+def save_explainer(explainer: 'Explainer', path: PathLike) -> None:
+    name = explainer.meta['name']
+    if name in NOT_SUPPORTED:
+        raise NotImplementedError(f'Saving for {name} not yet supported')
+
+    path = Path(path)
+
+    # create directory
+    path.mkdir(parents=True, exist_ok=True)
+
+    # save metadata
+    meta = explainer.meta
+    with open(Path(path, 'meta.json'), 'w') as f:
+        json.dump(meta, f, cls=NumpyEncoder)
+
+    # get explainer specific save function
+    save_fn = getattr(thismodule, '_save_' + name)
+
+    # save
+    save_fn(explainer, path)
+
+
+def _load_ALE(path: PathLike, predictor: Callable, meta: dict) -> 'ALE':
+    from alibi.explainers import ALE
+    ale = ALE(predictor, **meta['params']['init_kwargs'])
+    return ale
+
+
+def _save_ALE(explainer: 'Explainer', path: PathLike) -> None:
+    # ALE state is contained in metadata which is already saved
+    pass
+
+
+# def save_explainer(explainer: 'Explainer', path: PathLike) -> None:
+#    # TODO: allow specifying deep or shallow copy instead of try/except?
+#    if explainer.name in NOT_SUPPORTED:
+#        raise NotImplementedError(f'Saving not yet supported for {explainer.name}')
+#    try:
+#        # try to recurse and save the white-box explainer referenced by the black-box predictor function
+#        with open(path, 'wb') as f:
+#            dill.dump(explainer, f, recurse=True)
+#    except TypeError:
+#        # need to close file before attempting to save again
+#        with open(path, 'wb') as f:
+#            dill.dump(explainer, f, recurse=False)
+#            import warnings
+#            warnings.warn('Could not save a deep copy of the explainer. '
+#                          'This is most likely due to the type of the model used. '
+#                          'You may need to call `explainer.reset_predictor(predictor)`'
+#                          'after loading the saved explainer.')
+
+
+# Older prototype dispatching manually on name
+# try:
+#    save_fun = getattr(thismodule, '_save_' + explainer.name)
+#    save_fun(explainer, path)
+# except AttributeError:
+#    raise NotImplementedError(f'Saving not implemented for {explainer.name}')
+
+
+# def _save_AnchorTabular(explainer: 'AnchorTabular', path: PathLike) -> None:
+#    with open(path, 'wb') as f:
+#        dill.dump(explainer, f, recurse=True)
+
+class NumpyEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(
+                obj,
+                (
+                        np.int_,
+                        np.intc,
+                        np.intp,
+                        np.int8,
+                        np.int16,
+                        np.int32,
+                        np.int64,
+                        np.uint8,
+                        np.uint16,
+                        np.uint32,
+                        np.uint64,
+                ),
+        ):
+            return int(obj)
+        elif isinstance(obj, (np.float_, np.float16, np.float32, np.float64)):
+            return float(obj)
+        elif isinstance(obj, (np.ndarray,)):
+            return obj.tolist()
+        return json.JSONEncoder.default(self, obj)

--- a/alibi/saving.py
+++ b/alibi/saving.py
@@ -120,6 +120,9 @@ def _load_AnchorImage(path: PathLike, predictor: Callable, meta: dict) -> 'Ancho
     else:
         segmentation_fn = meta['params']['segmentation_fn']
 
+    # image-shape should be a tuple
+    meta['params']['image_shape'] = tuple(meta['params']['image_shape'])
+
     ai = AnchorImage(predictor=predictor,
                      image_shape=meta['params']['image_shape'],
                      segmentation_fn=segmentation_fn,

--- a/alibi/saving.py
+++ b/alibi/saving.py
@@ -205,6 +205,7 @@ def _load_KernelShap(path: PathLike, predictor: Callable, meta: dict) -> 'Kernel
         background_data = dill.load(f)
 
     # load the state
+    # TODO: deal with numpy arrays in state
     with open(Path(path, 'state.json'), 'r') as f:
         state = json.load(f)
 

--- a/alibi/saving.py
+++ b/alibi/saving.py
@@ -2,13 +2,15 @@ import json
 from os import PathLike
 from pathlib import Path
 import sys
-from typing import Callable, TYPE_CHECKING
+from typing import Callable, TYPE_CHECKING, Union
 
 import numpy as np
+import tensorflow as tf
 
 if TYPE_CHECKING:
     from alibi.api.interfaces import Explainer
-    from alibi.explainers import ALE
+    from alibi.explainers import ALE, IntegratedGradients
+    import keras
 
 thismodule = sys.modules[__name__]
 # https://www.python.org/dev/peps/pep-0519/#provide-specific-type-hinting-support
@@ -21,8 +23,6 @@ NOT_SUPPORTED = ["AnchorTabular",
                  "CEM",
                  "CounterFactual",
                  "CounterFactualProto",
-                 "plot_ale",
-                 "IntegratedGradients",
                  "KernelShap",
                  "TreeShap"]
 
@@ -76,8 +76,30 @@ def _load_ALE(path: PathLike, predictor: Callable, meta: dict) -> 'ALE':
     return ale
 
 
-def _save_ALE(explainer: 'Explainer', path: PathLike) -> None:
+def _save_ALE(explainer: 'ALE', path: PathLike) -> None:
     # ALE state is contained in metadata which is already saved
+    pass
+
+
+def _load_IntegratedGradients(path: PathLike, predictor: Union[tf.keras.Model, 'keras.Model'],
+                              meta: dict) -> 'IntegratedGradients':
+    from alibi.explainers import IntegratedGradients
+    layer_num = meta['params']['layer']
+    if layer_num == 0:
+        layer = None
+    else:
+        layer = predictor.layers[layer_num]
+
+    ig = IntegratedGradients(model=predictor,
+                             layer=layer,
+                             method=meta['params']['method'],
+                             n_steps=meta['params']['n_steps'],
+                             internal_batch_size=meta['params']['internal_batch_size'])
+    return ig
+
+
+def _save_IntegratedGradients(explainer: 'IntegratedGradients', path: PathLike) -> None:
+    # IG state is contained in the metadata which is already saved
     pass
 
 

--- a/alibi/saving.py
+++ b/alibi/saving.py
@@ -27,7 +27,6 @@ NOT_SUPPORTED = ["DistributedAnchorTabular",
                  "CEM",
                  "CounterFactual",
                  "CounterFactualProto",
-                 "KernelShap",
                  "TreeShap"]
 
 
@@ -167,8 +166,9 @@ def _load_AnchorTabular(path: PathLike, predictor: Callable, meta: dict) -> 'Anc
 
     # TODO: HACK: `categorical_names` should have integer keys, but json saves them as strings
     cmap = meta['params']['categorical_names']
-    cmap = {int(k): v for k, v in cmap.items()}
-    meta['params']['categorical_names'] = cmap
+    if cmap is not None:
+        cmap = {int(k): v for k, v in cmap.items()}
+        meta['params']['categorical_names'] = cmap
 
     # disc_perc should be a tuple
     meta['params']['disc_perc'] = tuple(meta['params']['disc_perc'])

--- a/alibi/saving.py
+++ b/alibi/saving.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from alibi.explainers import (
         ALE,
         AnchorImage,
+        AnchorText,
         IntegratedGradients
     )
     import keras
@@ -23,7 +24,6 @@ thismodule = sys.modules[__name__]
 
 NOT_SUPPORTED = ["AnchorTabular",
                  "DistributedAnchorTabular",
-                 "AnchorText",
                  "CEM",
                  "CounterFactual",
                  "CounterFactualProto",
@@ -133,6 +133,28 @@ def _save_AnchorImage(explainer: 'AnchorImage', path: PathLike) -> None:
     if explainer.meta['params']['custom_segmentation']:
         with open(Path(path, 'segmentation_fn.dill'), 'wb') as f:
             dill.dump(explainer.segmentation_fn, f, recurse=True)
+
+
+def _load_AnchorText(path: PathLike, predictor: Callable, meta: dict) -> 'AnchorText':
+    from alibi.explainers import AnchorText
+    import spacy
+
+    # load the spacy model
+    nlp = spacy.load(Path(path, 'nlp'))
+
+    # TODO: re-initialization takes some time due initializing Neighbours, this should be saved as part
+    #  of the state in the future, see also https://github.com/SeldonIO/alibi/issues/251#issuecomment-649484225
+    atext = AnchorText(nlp=nlp,
+                       predictor=predictor,
+                       seed=meta['params']['seed'])
+
+    return atext
+
+
+def _save_AnchorText(explainer: 'AnchorText', path: PathLike) -> None:
+    # save the spacy model
+    nlp = explainer.nlp
+    nlp.to_disk(Path(path, 'nlp'))
 
 
 # def save_explainer(explainer: 'Explainer', path: PathLike) -> None:

--- a/alibi/saving.py
+++ b/alibi/saving.py
@@ -253,37 +253,6 @@ def _save_KernelShap(explainer: 'KernelShap', path: PathLike) -> None:
         json.dump(explainer._state, f, cls=NumpyEncoder)
 
 
-# def save_explainer(explainer: 'Explainer', path: PathLike) -> None:
-#    # TODO: allow specifying deep or shallow copy instead of try/except?
-#    if explainer.name in NOT_SUPPORTED:
-#        raise NotImplementedError(f'Saving not yet supported for {explainer.name}')
-#    try:
-#        # try to recurse and save the white-box explainer referenced by the black-box predictor function
-#        with open(path, 'wb') as f:
-#            dill.dump(explainer, f, recurse=True)
-#    except TypeError:
-#        # need to close file before attempting to save again
-#        with open(path, 'wb') as f:
-#            dill.dump(explainer, f, recurse=False)
-#            import warnings
-#            warnings.warn('Could not save a deep copy of the explainer. '
-#                          'This is most likely due to the type of the model used. '
-#                          'You may need to call `explainer.reset_predictor(predictor)`'
-#                          'after loading the saved explainer.')
-
-
-# Older prototype dispatching manually on name
-# try:
-#    save_fun = getattr(thismodule, '_save_' + explainer.name)
-#    save_fun(explainer, path)
-# except AttributeError:
-#    raise NotImplementedError(f'Saving not implemented for {explainer.name}')
-
-
-# def _save_AnchorTabular(explainer: 'AnchorTabular', path: PathLike) -> None:
-#    with open(path, 'wb') as f:
-#        dill.dump(explainer, f, recurse=True)
-
 class NumpyEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(

--- a/alibi/saving.py
+++ b/alibi/saving.py
@@ -76,7 +76,9 @@ def save_explainer(explainer: 'Explainer', path: PathLike) -> None:
 
 def _load_ALE(path: PathLike, predictor: Callable, meta: dict) -> 'ALE':
     from alibi.explainers import ALE
-    ale = ALE(predictor, **meta['params']['init_kwargs'])
+    init_kwargs = meta['params']
+    init_kwargs.pop('min_bin_points')
+    ale = ALE(predictor, **init_kwargs)
     return ale
 
 

--- a/alibi/tests/test_saving.py
+++ b/alibi/tests/test_saving.py
@@ -1,0 +1,49 @@
+import numpy as np
+import pytest
+from pytest_lazyfixture import lazy_fixture
+from sklearn.linear_model import LogisticRegression
+import tempfile
+
+from alibi.explainers import ALE
+from alibi.saving import load_explainer
+from alibi_testing.data import get_iris_data
+
+
+@pytest.fixture(scope='module')
+def iris_data():
+    return get_iris_data()
+
+
+@pytest.fixture(scope='module')
+def lr_classifier(request):
+    data = request.param
+    clf = LogisticRegression()
+    clf.fit(data['X_train'], data['y_train'])
+    return clf
+
+
+@pytest.fixture(scope='module')
+def ale_explainer(iris_data, lr_classifier):
+    ale = ALE(predictor=lr_classifier.predict_proba,
+              feature_names=iris_data['metadata']['feature_names'])
+    return ale
+
+
+@pytest.mark.parametrize('lr_classifier', [lazy_fixture('iris_data')], indirect=True)
+def test_save_ALE(ale_explainer, lr_classifier, iris_data):
+    X = iris_data['X_test']
+    exp0 = ale_explainer.explain(X)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        ale_explainer.save(temp_dir)
+        ale_explainer1 = load_explainer(temp_dir, predictor=lr_classifier.predict_proba)
+
+        assert isinstance(ale_explainer1, ALE)
+        # assert ale_explainer.meta == ale_explainer1.meta # cannot pass as meta updated after explain TODO: fix
+        exp1 = ale_explainer1.explain(X)
+
+        # ALE explanations are deterministic
+        assert exp0.meta == exp1.meta
+        # assert exp0.data == exp1.data # cannot compare as many types instide TODO: define equality for explanations?
+        # or compare pydantic schemas?
+        assert np.all(exp0.ale_values[0] == exp1.ale_values[0])

--- a/alibi/tests/test_saving.py
+++ b/alibi/tests/test_saving.py
@@ -142,7 +142,8 @@ def test_save_ALE(ale_explainer, lr_classifier, iris_data):
         ale_explainer1 = load_explainer(temp_dir, predictor=lr_classifier.predict_proba)
 
         assert isinstance(ale_explainer1, ALE)
-        # assert ale_explainer.meta == ale_explainer1.meta # cannot pass as meta updated after explain TODO: fix
+        # TODO: cannot pass as meta updated after explain
+        # assert ale_explainer.meta == ale_explainer1.meta
         exp1 = ale_explainer1.explain(X)
 
         # ALE explanations are deterministic
@@ -167,6 +168,7 @@ def test_save_IG(ig_explainer, ffn_classifier, iris_data):
         ig_explainer1 = load_explainer(temp_dir, predictor=ffn_classifier)
 
         assert isinstance(ig_explainer1, IntegratedGradients)
+        assert ig_explainer.meta == ig_explainer1.meta
 
         exp1 = ig_explainer.explain(X, target=target)
         assert exp0.meta == exp1.meta
@@ -187,6 +189,7 @@ def test_save_AnchorImage(ai_explainer, mnist_predictor):
         ai_explainer1 = load_explainer(temp_dir, predictor=mnist_predictor)
 
         assert isinstance(ai_explainer1, AnchorImage)
+        assert ai_explainer.meta == ai_explainer1.meta
 
         exp1 = ai_explainer1.explain(X)
         assert exp0.meta == exp1.meta
@@ -206,6 +209,7 @@ def test_save_AnchorText(atext_explainer, lr_classifier, movie_sentiment_data):
         atext_explainer1 = load_explainer(temp_dir, predictor=predictor)
 
         assert isinstance(atext_explainer1, AnchorText)
+        atext_explainer.meta == atext_explainer1.meta
 
         exp1 = atext_explainer1.explain(X)
         assert exp0.meta == exp1.meta

--- a/alibi/tests/test_saving.py
+++ b/alibi/tests/test_saving.py
@@ -209,7 +209,7 @@ def test_save_AnchorText(atext_explainer, lr_classifier, movie_sentiment_data):
         atext_explainer1 = load_explainer(temp_dir, predictor=predictor)
 
         assert isinstance(atext_explainer1, AnchorText)
-        atext_explainer.meta == atext_explainer1.meta
+        assert atext_explainer.meta == atext_explainer1.meta
 
         exp1 = atext_explainer1.explain(X)
         assert exp0.meta == exp1.meta

--- a/alibi/tests/test_saving.py
+++ b/alibi/tests/test_saving.py
@@ -3,8 +3,9 @@ import pytest
 from pytest_lazyfixture import lazy_fixture
 from sklearn.linear_model import LogisticRegression
 import tempfile
+import tensorflow as tf
 
-from alibi.explainers import ALE
+from alibi.explainers import ALE, IntegratedGradients
 from alibi.saving import load_explainer
 from alibi_testing.data import get_iris_data
 
@@ -23,10 +24,29 @@ def lr_classifier(request):
 
 
 @pytest.fixture(scope='module')
+def ffn_classifier(request):
+    data = request.param
+    inputs = tf.keras.Input(shape=data['X_train'].shape[1:])
+    x = tf.keras.layers.Dense(20, activation='relu')(inputs)
+    x = tf.keras.layers.Dense(20, activation='relu')(x)
+    outputs = tf.keras.layers.Dense(config['output_dim'], activation=config['activation'])(x)
+    model = tf.keras.Model(inputs=inputs, outputs=outputs)
+    model.compile(loss=config['loss'], optimizer='adam')
+    model.fit(data['X_train'], tf.keras.utils.to_categorical(data['y_train']), epochs=1)
+    return model
+
+
+@pytest.fixture(scope='module')
 def ale_explainer(iris_data, lr_classifier):
     ale = ALE(predictor=lr_classifier.predict_proba,
               feature_names=iris_data['metadata']['feature_names'])
     return ale
+
+
+@pytest.fixture(scope='module')
+def ig_explainer(iris_data, ffn_classifier):
+    ig = IntegratedGradients(model=ffn_classifier)
+    return ig
 
 
 @pytest.mark.parametrize('lr_classifier', [lazy_fixture('iris_data')], indirect=True)
@@ -47,3 +67,25 @@ def test_save_ALE(ale_explainer, lr_classifier, iris_data):
         # assert exp0.data == exp1.data # cannot compare as many types instide TODO: define equality for explanations?
         # or compare pydantic schemas?
         assert np.all(exp0.ale_values[0] == exp1.ale_values[0])
+
+
+config = {'output_dim': 3, 'loss': 'categorical_crossentropy', 'activation': 'softmax'}
+
+# TODO: figure out a way to pass both lazy_fixture('iris_data') and config...
+@pytest.mark.parametrize('ffn_classifier', [lazy_fixture('iris_data')], indirect=True)
+def test_save_IG(ig_explainer, ffn_classifier, iris_data):
+    X = iris_data['X_test']
+    target = iris_data['y_test']
+    exp0 = ig_explainer.explain(X, target=target)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        ig_explainer.save(temp_dir)
+        ig_explainer1 = load_explainer(temp_dir, predictor=ffn_classifier)
+
+        assert isinstance(ig_explainer1, IntegratedGradients)
+
+        exp1 = ig_explainer.explain(X, target=target)
+        assert exp0.meta == exp1.meta
+
+        # IG is deterministic
+        assert np.all(exp0.attributions[0] == exp1.attributions[0])


### PR DESCRIPTION
Proposed implementation of initial support for explainer persistence.

# API
Given an explainer, it can be saved by calling `explainer.save(path)`, where `path` is a directory which is created if it doesn't exist. Alternatively:
```python
from alibi.saving import save_explainer
save_explainer(explainer, path)
```

To load an explainer:
```python
from alibi.saving import load_explainer
explainer = load_explainer('path', predictor=predictor)
```
Note that we require the user to pass the `predictor` specifically as we decided not to handle serialization of arbitrary white-box and black-box models.

Alternatively, one can call a `classmethod` as follows:
```python
from alibi.api.interfaces import Explainer
from alibi.explainers import AnchorTabular  # e.g.

explainer = Explainer.load('path', predictor=predictor)
explainer = AnchorTabular.load('path', predictor=predictor)
```

# Implementation
The saving and loading functionality is defined in a new module `alibi.saving`, tests are provided in `alibi.tests.test_saving`.

There is a save/load function per explainer type which is determined at runtime based on the `name` attribute in `meta`. The reason for not using `singledispatch` is because of circular references due to importing `save_explainer` into `alibi.api.interfaces` to create the bound method `save`.

The saved format is different depending on the explainer. All explainers save their `meta` attribute as `json` which is used to re-initialize a new (identical) explainer. Further, some explainers save additional binaries (e.g. `numpy` formats, `spacy` models, user supplied `Callable` functions).

Currently all explainers are loaded by simply creating identical ones with appropriate `init_kwargs` stored in `meta` and also calling `fit` if required (e.g. `AnchorTabular` stores the data as an attribute, so we can dump this and load back to call `fit` again, though this won't be possible with `KernelShap` and `TreeShap` (see below).

# Discussion
- Using `json` to save metadata is a bit tricky as we need to make sure types are deserialized properly, e.g. a list in `json` is sometimes a `tuple` in Python, a list of lists is probably a `np.ndarray` originally. Currently these are manual steps in each `_load_...` function. One option may be to use a Pydantic definition of the `meta` data which could attempt to parse it to the correct objects (though this may not always result in the expected object if there are several options). This suggests that using `dill` may still be preferable...
- Putting initialization kwargs into the `meta` field is messy both due to the polluted `__repr__` but also for bookeeping purposes. It may make sense to save these `init` and `fit` kwargs into separate private attributes used only for saving/loading. This is related but not identical to designing a "state" attribute which can be used to re-create an explainer without having to call `init` and/or `fit`.

# TODO
- `KernelShap` and `TreeShap` require some small refactorings to be provide state to be saved/loaded to be able to serialize these without access to training data. The `shap` library actually provides serialization although it is `pickle` based so unclear if beneficial.
- when saving, also save the `alibi` version used which can then be used to raise a warning if versions mismatch when loading
- `CEM`, `CounterFactual` and `CFProto` not supported yet as the implementation would change significantly after the Tensorflow 2.x rewrite.