### PR TITLE
Remove global flake8 noqa ignores

### DIFF
--- a/alibi/explainers/cem.py
+++ b/alibi/explainers/cem.py
@@ -1,4 +1,3 @@
-# flake8: noqa F841
 from alibi.api.interfaces import Explainer, Explanation, FitMixin
 from alibi.api.defaults import DEFAULT_META_CEM, DEFAULT_DATA_CEM
 import copy
@@ -603,12 +602,12 @@ class CEM(Explainer, FitMixin):
                     print('Target proba: {:.2f}, max non target proba: {:.2f}'.format(target_proba,
                                                                                       nontarget_proba_max))
                     print('Gradient graph min/max: {:.3f}/{:.3f}'.format(grads_graph.min(), grads_graph.max()))
-                    print('Gradient graph mean/abs mean: {:.3f}/{:.3f}' \
+                    print('Gradient graph mean/abs mean: {:.3f}/{:.3f}'
                           .format(np.mean(grads_graph), np.mean(np.abs(grads_graph))))  # type: ignore
                     if not self.model:
-                        print('Gradient numerical attack min/max: {:.3f}/{:.3f}' \
+                        print('Gradient numerical attack min/max: {:.3f}/{:.3f}'
                               .format(grads_num.min(), grads_num.max()))  # type: ignore
-                        print('Gradient numerical mean/abs mean: {:.3f}/{:.3f}' \
+                        print('Gradient numerical mean/abs mean: {:.3f}/{:.3f}'
                               .format(np.mean(grads_num), np.mean(np.abs(grads_num))))  # type: ignore
                     sys.stdout.flush()
 

--- a/alibi/explainers/cfproto.py
+++ b/alibi/explainers/cfproto.py
@@ -1,11 +1,9 @@
-# flake8: noqa F841
-
 import copy
 import logging
 import numpy as np
 import sys
 import tensorflow.compat.v1 as tf
-from typing import Any, Callable, Dict, List, Tuple, Union, TYPE_CHECKING, Sequence
+from typing import Any, Callable, Dict, Tuple, Union, TYPE_CHECKING, Sequence
 
 from alibi.api.interfaces import Explainer, Explanation, FitMixin
 from alibi.api.defaults import DEFAULT_META_CFP, DEFAULT_DATA_CFP
@@ -280,8 +278,8 @@ class CounterFactualProto(Explainer, FitMixin):
                 def true_fn():
                     try:
                         return self.map_cat_to_num[icat][adv_to_map[0, icol]]
-                    except:  # the value of adv_to_map[0, icol] is a float
-                        # TODO: add error type
+                    except TypeError:  # the value of adv_to_map[0, icol] is a float
+                        # TODO: check error type
                         idx = round_grad(adv_to_map[0, icol])
                         return self.map_cat_to_num[icat][idx]
 
@@ -1180,12 +1178,12 @@ class CounterFactualProto(Explainer, FitMixin):
                     print('Target proba: {:.2f}, max non target proba: {:.2f}'.format(target_proba,
                                                                                       nontarget_proba_max))
                     print('Gradient graph min/max: {:.3f}/{:.3f}'.format(grads_graph.min(), grads_graph.max()))
-                    print('Gradient graph mean/abs mean: {:.3f}/{:.3f}' \
+                    print('Gradient graph mean/abs mean: {:.3f}/{:.3f}'
                           .format(np.mean(grads_graph), np.mean(np.abs(grads_graph))))  # type: ignore
                     if not self.model:
-                        print('Gradient numerical attack min/max: {:.3f}/{:.3f}' \
+                        print('Gradient numerical attack min/max: {:.3f}/{:.3f}'
                               .format(grads_num.min(), grads_num.max()))  # type: ignore
-                        print('Gradient numerical mean/abs mean: {:.3f}/{:.3f}' \
+                        print('Gradient numerical mean/abs mean: {:.3f}/{:.3f}'
                               .format(np.mean(grads_num), np.mean(np.abs(grads_num))))  # type: ignore
                     sys.stdout.flush()
 

--- a/alibi/explainers/tests/test_anchor_image.py
+++ b/alibi/explainers/tests/test_anchor_image.py
@@ -52,7 +52,7 @@ def test_anchor_image(models, mnist_data):
     # grayscale image should be replicated across channel dim before segmentation
     assert image_preproc.shape[-1] == 3
     for channel in range(image_preproc.shape[-1]):
-        assert (image.squeeze() - image_preproc[..., channel] <= eps).all() is True
+        assert (image.squeeze() - image_preproc[..., channel] <= eps).all()
     # check superpixels mask
     assert superpixels_mask.shape[0] == num_samples
     assert superpixels_mask.shape[1] == len(list(np.unique(segments)))

--- a/alibi/explainers/tests/test_anchor_image.py
+++ b/alibi/explainers/tests/test_anchor_image.py
@@ -1,4 +1,3 @@
-# flake8: noqa E731
 import pytest
 
 import numpy as np
@@ -26,7 +25,7 @@ def test_anchor_image(models, mnist_data):
 
     # define and train model
     # model = conv_net
-    predict_fn = lambda x: models[0].predict(x)
+    predict_fn = lambda x: models[0].predict(x)  # noqa: E731
 
     explainer = AnchorImage(
         predict_fn,
@@ -36,7 +35,7 @@ def test_anchor_image(models, mnist_data):
     )
     # test explainer initialization
     assert explainer.predictor(np.zeros((1,) + image_shape)).shape == (1,)
-    assert explainer.custom_segmentation == False
+    assert explainer.custom_segmentation is False
 
     # test sampling and segmentation functions
     image = x_train[0]
@@ -53,7 +52,7 @@ def test_anchor_image(models, mnist_data):
     # grayscale image should be replicated across channel dim before segmentation
     assert image_preproc.shape[-1] == 3
     for channel in range(image_preproc.shape[-1]):
-        assert (image.squeeze() - image_preproc[..., channel] <= eps).all() == True
+        assert (image.squeeze() - image_preproc[..., channel] <= eps).all() is True
     # check superpixels mask
     assert superpixels_mask.shape[0] == num_samples
     assert superpixels_mask.shape[1] == len(list(np.unique(segments)))

--- a/alibi/explainers/tests/test_anchor_tabular.py
+++ b/alibi/explainers/tests/test_anchor_tabular.py
@@ -1,4 +1,3 @@
-# flake8: noqa E731
 from collections import OrderedDict
 
 import numpy as np
@@ -75,7 +74,7 @@ def test_explainer(n_explainer_runs, at_defaults, rf_classifier, explainer, test
     for _ in range(n_explainer_runs):
         explanation = explainer.explain(X_test[test_instance_idx], threshold=threshold, **explain_defaults)
         assert explainer.instance_label == instance_label
-        if not "Could not find" in caplog.text:
+        if "Could not find" not in caplog.text:
             assert explanation.precision >= threshold
         assert explanation.coverage >= 0.01
         assert explanation.meta.keys() == DEFAULT_META_ANCHOR.keys()

--- a/alibi/explainers/tests/test_anchor_text.py
+++ b/alibi/explainers/tests/test_anchor_text.py
@@ -1,4 +1,3 @@
-# flake8: noqa E731
 import pytest
 from pytest_lazyfixture import lazy_fixture
 import spacy

--- a/alibi/explainers/tests/test_cem.py
+++ b/alibi/explainers/tests/test_cem.py
@@ -1,5 +1,3 @@
-# flake8: noqa E731
-
 from alibi.api.defaults import DEFAULT_META_CEM, DEFAULT_DATA_CEM
 from alibi.explainers import CEM
 import numpy as np
@@ -25,7 +23,7 @@ def test_cem(disable_tf2):
     clf.fit(X, Y)
 
     # define prediction function
-    predict_fn = lambda x: clf.predict_proba(x)
+    predict_fn = lambda x: clf.predict_proba(x)  # noqa: E731
 
     # instance to be explained
     idx = 0

--- a/alibi/explainers/tests/test_cfproto.py
+++ b/alibi/explainers/tests/test_cfproto.py
@@ -1,4 +1,3 @@
-# flake8: noqa E731
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -115,7 +114,6 @@ def test_tf_keras_adult_explainer(disable_tf2, adult_data, tf_keras_adult_explai
     # instance to be explained
     x = X_train[0].reshape(1, -1)
     pred_class = np.argmax(model.predict(x))
-    not_pred_class = np.argmin(model.predict(x))
 
     # test fit
     cf.fit(X_train, d_type=d_type)

--- a/alibi/explainers/tests/test_counterfactual.py
+++ b/alibi/explainers/tests/test_counterfactual.py
@@ -1,4 +1,3 @@
-# flake8: noqa E731
 import pytest
 import numpy as np
 from sklearn.datasets import load_iris

--- a/alibi/explainers/tests/utils.py
+++ b/alibi/explainers/tests/utils.py
@@ -1,4 +1,3 @@
-# flake8: noqa: E731
 # A file containing functions that can be used by multiple tests
 import numpy as np
 
@@ -18,14 +17,14 @@ def predict_fcn(predict_type, clf, preproc=None):
             )
     if predict_type == 'proba':
         if preproc:
-            predict_fn = lambda x: clf.predict_proba(preproc.transform(x))
+            predict_fn = lambda x: clf.predict_proba(preproc.transform(x))  # noqa: E731
         else:
-            predict_fn = lambda x: clf.predict_proba(x)
+            predict_fn = lambda x: clf.predict_proba(x)  # noqa: E731
     elif predict_type == 'class':
         if preproc:
-            predict_fn = lambda x: clf.predict(preproc.transform(x))
+            predict_fn = lambda x: clf.predict(preproc.transform(x))  # noqa: E731
         else:
-            predict_fn = lambda x: clf.predict(x)
+            predict_fn = lambda x: clf.predict(x)  # noqa: E731
 
     return predict_fn
 

--- a/alibi/utils/tests/test_utils.py
+++ b/alibi/utils/tests/test_utils.py
@@ -6,11 +6,11 @@ import tensorflow as tf
 from alibi.utils.tf import _check_keras_or_tf
 from unittest import mock
 
-blackbox_model = lambda x: x
+blackbox_model = lambda x: x  # noqa: E731
 keras_model = keras.Model()
 tf_model = tf.keras.Model()
-blackbox_keras = lambda x: keras_model.predict(x)
-blackbox_tf = lambda x: tf_model.predict(x)
+blackbox_keras = lambda x: keras_model.predict(x)  # noqa: E731
+blackbox_tf = lambda x: tf_model.predict(x)  # noqa: E731
 
 
 def test_blackbox_check_keras_or_tf():


### PR DESCRIPTION
`flake8` doesn't allow file-level ignoring of certain error codes so some of our files were actually not linted at all.