### PR TITLE
Reorder spacy model installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
         run: |
           pip install --upgrade pip setuptools
           pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt
-          python -m spacy download en_core_web_md
           pip install --upgrade --upgrade-strategy eager -e .
           pip install --upgrade --upgrade-strategy eager -e .[shap]
+          python -m spacy download en_core_web_md
           pip freeze
       - name: Lint with flake8
         run: |


### PR DESCRIPTION
I updated the `alibi-testing` package to `0.0.2` so that it does not depend on `alibi` itself which was causing dependency resolution issues. This meant that the spacy model installation step in the CI script needs to come after `alibi` is installed.