### PR TITLE
Extended AnchorTabular to one-hot encoding input.

### DIFF
--- a/doc/source/methods/Anchors.ipynb
+++ b/doc/source/methods/Anchors.ipynb
@@ -292,6 +292,11 @@
     "```python\n",
     "predict_fn = lambda x: clf.predict(preprocessor.transform(x))\n",
     "explainer = AnchorTabular(predict_fn, feature_names, categorical_names=category_map)\n",
+    "```\n",
+    "\n",
+    "The implementation supports one-hot encoding representation of the cateforical features by setting `ohe=True`. The `feature_names` and `categorical_names(category_map)` remain unchanged. The prediction function `predict_fn` should expect as input datapoints with one-hot encoded categorical features. To initialize the explainer with the one-hot encoding support:  \n",
+    "```python\n",
+    "explainer = AnchorTabular(predict_fn, feature_names, categorical_names=category_map, ohe=True)\n",
     "```"
    ]
   },
@@ -303,7 +308,9 @@
     "\n",
     "```python\n",
     "explainer.fit(X_train, disc_perc=[25, 50, 75])\n",
-    "```"
+    "```\n",
+    "\n",
+    "Note that if one-hot encoding support is enabled (`ohe=True`), the `fit` calls expect the data to be one-hot encoded."
    ]
   },
   {
@@ -332,7 +339,9 @@
     "Anchor: Marital Status = Never-Married AND Relationship = Own-child\n",
     "Precision: 1.00\n",
     "Coverage: 0.13\n",
-    "```"
+    "```\n",
+    "\n",
+    "Note that if one-hot encoding support is enabled (`ohe=True`), the `explain` calls expect the data to be one-hot encode."
    ]
   },
   {


### PR DESCRIPTION
Extends AnchorTabular to one-hot encoding input. This solves the issue https://github.com/SeldonIO/alibi/issues/336

### Description
The categorical variable can be passed as one-hot encoded by setting the introduced flag `ohe=True`. The rest of the arguments (`feature_names: List[str], categorical_names: Dict[int, List[str]]` -- typing was add which solves the issue https://github.com/SeldonIO/alibi/issues/420) remain consistent with the previous version. For example, if the data contains the following `feature_names=['age', 'gender', 'race']` then the `categorical_names={1: ['female', 'male'], 2: ['asian', 'black', 'hispanic', 'white']}`. Note that the keys in the categorical_names are not offseted by the numbers of categories required for the one-hot encoding.

### Code changes

1.  `ohe` flag added to the constructor: `def __init__(self, predictor: Callable, feature_names: List[str], categorical_names: Dict[int, List[str]] = None, ohe: bool = False, seed: int = None) -> None:`
2. if the `ohe=True`, the predictor is expecting the categorical input features to be one-hot encoded, but the AnchorTabular works with label encoding. Thus we define a proxy for the predictor `ord_predictor = lambda x: predictor(ord_to_ohe(x, self.cat_vars_ord)[0])` which takes as input labels and transforms them to one-hot encodings before passing them to the original prediction function passed as argument in the constructor. Thus the new predictor used in AnchorTabular is defined by `self._predictor = self._transform_predictor(ord_predictor)`. Note that there has been a renaming from `self.predictor` to `self._predictor` as will be further explained. See the predictor.setter
3.  `train_data` passed as an argument to the `fit` method is transformed from one-hot encoding to labels to be compatible with AnchorTabular: ` train_data = ohe_to_ord(X_ohe=train_data, cat_vars_ohe=self.cat_vars_ohe)[0]` if `self.ohe == True`. Similar in the `expain` method, `X = ohe_to_ord(X_ohe=X.reshape(1, -1), cat_vars_ohe=self.cat_vars_ohe)[0].reshape(-1)`.
4. As the `predictor` was exposed to the user (see example [here](https://docs.seldon.io/projects/alibi/en/stable/examples/anchor_tabular_adult.html)), the newly defined self._predictor can not be used since it expects categorical data labeled encoded. Thus, we define another internal predictor `self._ohe_predictor = self._transform_ohe_predictor(predictor)`, which expects one-hot encoded features. Finally, the `predictor` is exposed to the user through the `@property predictor` which returns the appropriate `self._ohe_predictor` if `self.ohe == True` and `self._predictor` otherwise.
5. Similar changes to the constructor were introduced in reset_predictor.
6. All changes were added to DistributedAnchorTabular.