### PR TITLE
internal batch size bug fix

### DIFF
--- a/alibi/explainers/integrated_gradients.py
+++ b/alibi/explainers/integrated_gradients.py
@@ -732,7 +732,7 @@ class IntegratedGradients(Explainer):
             Instance for which integrated gradients attribution are computed.
         forward_kwargs
             Input keyword args. If it's not None, it must be a dict with numpy arrays as values.
-            The first dimension of the array must correspond to the number of examples.
+            The first dimension of the arrays must correspond to the number of examples.
             It will be repeated for each of n_steps along the integrated path.
             The attributions are not computed with respect to these arguments.
         baselines

--- a/alibi/explainers/integrated_gradients.py
+++ b/alibi/explainers/integrated_gradients.py
@@ -451,8 +451,9 @@ def _gradients_layer(model: Union[tf.keras.models.Model],
 
     #  Repeating the dummy input needed to initiate the model's forward call in order to ensure that
     #  the number of dummy instances is the same as the number of real instances.
-    #  This is necessary in case `forward_kwargs` is not None. The number of instances in `forward_kwargs`
-    #  are the same as the number of instances in `x` by construction.
+    #  This is necessary in case `forward_kwargs` is not None. In that case, the model forward call  would crash
+    #  if the number of instances in `orig_dummy_input` is different from the number of instances in `forward_kwargs`.
+    #  The number of instances in `forward_kwargs` is the same as the number of instances in `x` by construction.
     if isinstance(orig_dummy_input, list):
         if isinstance(x, list):
             orig_dummy_input = [np.repeat(inp, x[0].shape[0], axis=0) for inp in orig_dummy_input]

--- a/alibi/explainers/integrated_gradients.py
+++ b/alibi/explainers/integrated_gradients.py
@@ -449,6 +449,10 @@ def _gradients_layer(model: Union[tf.keras.models.Model],
 
         layer.call = decorator(layer.call)
 
+    #  Repeating the dummy input needed to initiate the model's forward call in order to ensure that
+    #  the number of dummy instances is the same as the number or real instance x in a batch.
+    #  This is necessary because having a different number of instances in `orig_dummy_input` and 'x'
+    #  might results in incorrect outcome for certain models.
     if isinstance(orig_dummy_input, list):
         if isinstance(x, list):
             orig_dummy_input = [np.repeat(inp, x[0].shape[0], axis=0) for inp in orig_dummy_input]
@@ -460,6 +464,7 @@ def _gradients_layer(model: Union[tf.keras.models.Model],
         else:
             orig_dummy_input = np.repeat(orig_dummy_input, x.shape[0], axis=0)
 
+    #  Calculating the gradients with respect to the layer.
     with tf.GradientTape() as tape:
         watch_layer(layer, tape)
         preds = _run_forward(model, orig_dummy_input, target, forward_kwargs=forward_kwargs)

--- a/alibi/explainers/integrated_gradients.py
+++ b/alibi/explainers/integrated_gradients.py
@@ -450,9 +450,9 @@ def _gradients_layer(model: Union[tf.keras.models.Model],
         layer.call = decorator(layer.call)
 
     #  Repeating the dummy input needed to initiate the model's forward call in order to ensure that
-    #  the number of dummy instances is the same as the number or real instance x in a batch.
-    #  This is necessary because having a different number of instances in `orig_dummy_input` and 'x'
-    #  might results in incorrect outcome for certain models.
+    #  the number of dummy instances is the same as the number of real instances.
+    #  This is necessary in case `forward_kwargs` is not None. The number of instances in `forward_kwargs`
+    #  are the same as the number of instances in `x` by construction.
     if isinstance(orig_dummy_input, list):
         if isinstance(x, list):
             orig_dummy_input = [np.repeat(inp, x[0].shape[0], axis=0) for inp in orig_dummy_input]

--- a/alibi/explainers/integrated_gradients.py
+++ b/alibi/explainers/integrated_gradients.py
@@ -161,6 +161,7 @@ def _run_forward_from_layer(model: tf.keras.models.Model,
                             run_from_layer_inputs: bool = False,
                             select_target: bool = True) -> tf.Tensor:
     """
+    Function currently unused.
     Executes a forward call from an internal layer of the model to the model output.
 
     Parameters
@@ -172,14 +173,16 @@ def _run_forward_from_layer(model: tf.keras.models.Model,
     orig_call
         Original `call` method of the layer.
     orig_dummy_input
-        Dummy input needed to initiate the model forward call.
-        The  layer's status is overwritten during the forward call.
+        Dummy input needed to initiate the model forward call. The number of instances in the dummy input must
+        be the same as the number of instances in x. The dummy input values play no role in the evaluation
+        as the  layer's status is overwritten during the forward call.
     x
         Layer's inputs. The layer's status is overwritten with `x` during the forward call.
     target
         Target for the output position to be returned.
     forward_kwargs
-        Input keyword args.
+        Input keyword args. It must be a dict with numpy arrays as values. If it's not None,
+        the first dimension of the arrays must correspond to the number of instances in x and orig_dummy_input.
     run_from_layer_inputs
         If True, the forward pass starts from the layer's inputs, if False it starts from the layer's outputs.
     select_target
@@ -728,7 +731,10 @@ class IntegratedGradients(Explainer):
         X
             Instance for which integrated gradients attribution are computed.
         forward_kwargs
-            Input keyword args.
+            Input keyword args. If it's not None, it must be a dict with numpy arrays as values.
+            The first dimension of the array must correspond to the number of examples.
+            It will be repeated for each of n_steps along the integrated path.
+            The attributions are not computed with respect to these arguments.
         baselines
             Baselines (starting point of the path integral) for each instance.
             If the passed value is an `np.ndarray` must have the same shape as X.


### PR DESCRIPTION
This pull request fixes a bug that might have caused incorrect results in cases in which the total number of instance in the integrated gradients path is smaller than the internal batch size and layer's attributions are computed. 

Main changes: 
The code is changed in order to make sure that the number of dummy instances and the number of real instance are always the same for a given batch when the gradients are computed with respect to a layer. 