### PR TITLE
Avoid numba==0.54.0 (#466)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,10 @@ extras_require = {
     'examples': ['seaborn>=0.9.0', 'xgboost>=0.90'],
     'ray': ['ray>=0.8.7, <2.0.0'],  # from requirements/dev.txt
     # shap is separated due to build issues, see https://github.com/slundberg/shap/pull/1802
-    'shap': ['shap>=0.36.0, !=0.38.1, <0.40.0'],  # versioning: https://github.com/SeldonIO/alibi/issues/333
+    'shap': [
+        'shap>=0.36.0, !=0.38.1, <0.40.0', # versioning: https://github.com/SeldonIO/alibi/issues/333
+        'numba!=0.54.0' # To fix: https://github.com/SeldonIO/alibi/issues/466
+    ],  
 }
 
 setup(name='alibi',


### PR DESCRIPTION
Avoiding numba==0.54.0 when built with shap, to fix #466.