### PR TITLE
Mock torch and matplotlib in sphinx build

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -71,8 +71,8 @@ apidoc_extra_args = ['-d 6']
 
 # mock imports
 autodoc_mock_imports = ['sklearn', 'skimage', 'requests',
-                        'cv2', 'keras', 'seaborn', 'PIL', 'tensorflow', 'spacy', 
-                        'catboost', 'dill', 'transformers', 'torch', 'matplotlib']
+                        'cv2', 'keras', 'seaborn', 'PIL', 'tensorflow', 'spacy',
+                        'catboost', 'dill', 'transformers', 'torch', 'matplotlib', 'mpl_toolkits']
 
 # Napoleon settings
 napoleon_google_docstring = True

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -72,7 +72,7 @@ apidoc_extra_args = ['-d 6']
 # mock imports
 autodoc_mock_imports = ['sklearn', 'skimage', 'requests',
                         'cv2', 'keras', 'seaborn', 'PIL', 'tensorflow', 'spacy', 
-                        'catboost', 'dill', 'transformers']
+                        'catboost', 'dill', 'transformers', 'torch', 'matplotlib']
 
 # Napoleon settings
 napoleon_google_docstring = True


### PR DESCRIPTION
Noticed that `autodoc` was failing to import some module because `torch` and `matplotlib` are not dependencies of docs but also were not being mocked.