### PR TITLE
Update .gitignore for rst files and doc folder name change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,7 @@ instance/
 
 # Sphinx documentation
 doc/_build/
-doc/source/api/*.rst
+doc/source/api/
 
 # PyBuilder
 target/


### PR DESCRIPTION
### Overview:
Auto generated doc files where being checked into version control in two places. Firstly the `doc/_build` folder and secondly the `doc/source/api/` was populated by `rst` files. Updated the `.gitignore` file to remove these.