### PR TITLE
Update minimum version of sphinx-autodoc-typehints to current

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,7 @@
 # dependencies for building docs, separate from dev.txt as this is also used for builds on readthedocs.org
 # core dependencies
 sphinx>=4.2.0, <5.0.0 # Enforce 4.x sphinx version so that mathjax works correctly
-sphinx-autodoc-typehints>=1.6.0, <=2.0.0 
+sphinx-autodoc-typehints>=1.12.0, <=2.0.0 
 sphinx-rtd-theme>=1.0.0, <2.0.0
 myst-parser>=0.14, <0.16
 sphinxcontrib-apidoc>=0.3.0, <0.4.0


### PR DESCRIPTION
version.

Docs cannot be built using version 1.6.0 anymore so updating the
minimum version.