### PR TITLE
Add custom exceptions for calling and validating user models

### DIFF
--- a/alibi/exceptions.py
+++ b/alibi/exceptions.py
@@ -1,0 +1,29 @@
+"""
+This module defines the Alibi exception hierarchy and common exceptions
+used across the library.
+"""
+from abc import ABC
+
+
+class AlibiException(Exception, ABC):
+    """
+    Abstract base class of all alibi exceptions.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
+class AlibiPredictorCallException(AlibiException):
+    """
+    This exception is raised whenever a call to a user supplied predictor fails at runtime.
+    """
+    pass
+
+
+class AlibiPredictorReturnTypeError(AlibiException):
+    """
+    This exception is raised whenever the return type of a user supplied predictor is of
+    an unexpected or unsupported type.
+    """
+    pass

--- a/alibi/explainers/anchor_image.py
+++ b/alibi/explainers/anchor_image.py
@@ -338,6 +338,8 @@ class AnchorImage(Explainer):
         ------
         alibi.exceptions.AlibiPredictorCallException
             If calling `predictor` fails at runtime.
+        alibi.exceptions.AlibiPredictorReturnTypeError
+            If the return type of `predictor` is not `np.ndarray`.
         """
         super().__init__(meta=copy.deepcopy(DEFAULT_META_ANCHOR))
         np.random.seed(seed)

--- a/alibi/explainers/anchor_tabular.py
+++ b/alibi/explainers/anchor_tabular.py
@@ -690,6 +690,8 @@ class AnchorTabular(Explainer, FitMixin):
         ------
         alibi.exceptions.AlibiPredictorCallException
             If calling `predictor` fails at runtime.
+        alibi.exceptions.AlibiPredictorReturnTypeError
+            If the return type of `predictor` is not `np.ndarray`.
         """
         super().__init__(meta=copy.deepcopy(DEFAULT_META_ANCHOR))
 

--- a/alibi/explainers/tests/test_anchor_image.py
+++ b/alibi/explainers/tests/test_anchor_image.py
@@ -4,6 +4,7 @@ import numpy as np
 import tensorflow as tf
 import torch
 from alibi.api.defaults import DEFAULT_META_ANCHOR, DEFAULT_DATA_ANCHOR_IMG
+from alibi.exceptions import AlibiPredictorCallException, AlibiPredictorReturnTypeError
 from alibi.explainers.anchor_image import AnchorImage, AnchorImageSampler, scale_image
 
 
@@ -162,5 +163,33 @@ def test_anchor_image(predict_fn, models, mnist_data):
 @pytest.mark.parametrize('predict_fn', [lazy_fixture('models'), ], indirect=True)
 @pytest.mark.parametrize('models', [("mnist-cnn-pt1.9.1.pt",)], indirect=True)
 def test_anchor_image_fails_init_torch_float64(predict_fn, models):
-    with pytest.raises(RuntimeError):
+    with pytest.raises(AlibiPredictorCallException):
         explainer = AnchorImage(predict_fn, image_shape=(28, 28, 1), dtype=np.float64)  # noqa: F841
+
+
+def bad_predictor(x: np.ndarray) -> list:
+    """
+    A dummy predictor emulating the following:
+     - Expecting an array of certain dimension (4 dimensions - 1 batch, 2 spatial, 1 channel)
+     - Returning an incorrect type
+     This is used below to test custom exception functionality.
+    """
+    if x.ndim != 4:
+        raise ValueError
+    return list(x)
+
+
+def test_anchor_image_fails_init_bad_image_shape_predictor_call():
+    """
+    In this test `image_shape` is misspecified leading to an exception calling the `predictor`.
+    """
+    with pytest.raises(AlibiPredictorCallException):
+        explainer = AnchorImage(bad_predictor, image_shape=(28, 28))  # noqa: F841
+
+
+def test_anchor_image_fails_bad_predictor_return_type():
+    """
+    In this test `image_shape` is specified correctly, but the predictor returns the wrong type.
+    """
+    with pytest.raises(AlibiPredictorReturnTypeError):
+        explainer = AnchorImage(bad_predictor, image_shape=(28, 28, 1))  # noqa: F841


### PR DESCRIPTION
This PR introduces a new public `alibi.exceptions` module defining a (small) hierarchy of general exceptions to be used across `alibi`. The motivation is to provide nicer messages when things go wrong and also well-defined exceptions which can be handled by the caller. This could be considered an adjacent building block towards #516.

The initial application of this is 2 fold:
 - Catching and raising errors when calling user provided models with dummy data (currently `AnchorTabular`, `AnchorText`, `AnchorImage`)
 - Validating that the output type of the call (if successful) is of the expected type

The first use case now clearly defines to the caller what error to expect and when it is raised. I've raised this when the call to a user provided model fails during `__init__`, but not in other methods as it could be argued that in `fit` and `explain` we are calling the model with user provided data (and perturbations thereof) so it should work fine (if there is a compelling reason to introduce `try/except` on calling the user model elsewhere in the code then that can be done later).

The second use case is, if a call succeeds, we can check whether the return is of the expected type so an error can be raised early if it is not. I opted for an explicit `isinstance` check rather than something of the EAFP style `try: prediction.shape`. This has the side-effect that we tighten the return type expected to be exactly `np.ndarray` as opposed to anything that implements `.shape` attribute (for example `tensorflow` tensors). I don't think this is a big deal as other tensor/array types that may implement `.shape` should not work with `alibi` currently anyway, so it's good to tighten up the requirements at runtime.

The PR should be ready to review as is with a few minor points outstanding:
 - [ ] There are a few other explainers which call the `predictor` at `__init__` with dummy data (e.g. `Countefactual`) which should be treated the same way
 - [ ] In docstrings we should use the `sphinx` directives to link to the custom exception definitions in the code.