### PR TITLE
Integrated Gradients `target_fn`

### DIFF
--- a/alibi/explainers/integrated_gradients.py
+++ b/alibi/explainers/integrated_gradients.py
@@ -583,8 +583,8 @@ def _get_target_from_target_fn(target_fn: Callable,
     # raise a warning if the predictions are scalar valued already
     # TODO: in the future we want to support outputs that are >2D at which point this check should change
     if preds.shape[-1] == 1:
-        msg = f"Predictions from the model are scalar valued but `target_fn` was passed. `target_fn` is not necessary" \
-              f"when predictions are scalar valued already. Using `target_fn` here may result in unexpected behaviour."
+        msg = "Predictions from the model are scalar valued but `target_fn` was passed. `target_fn` is not necessary" \
+              "when predictions are scalar valued already. Using `target_fn` here may result in unexpected behaviour."
         warnings.warn(msg)
 
     target = target_fn(preds)
@@ -815,7 +815,7 @@ class IntegratedGradients(Explainer):
         """
         # target handling logic
         if self.target_fn and target is not None:
-            msg = f'Both `target_fn` and `target` were provided. Only one of these should be provided.'
+            msg = 'Both `target_fn` and `target` were provided. Only one of these should be provided.'
             raise ValueError(msg)
         if self.target_fn:
             target = _get_target_from_target_fn(self.target_fn, self.model, X, forward_kwargs)

--- a/alibi/explainers/integrated_gradients.py
+++ b/alibi/explainers/integrated_gradients.py
@@ -553,14 +553,37 @@ def _format_target(target: Union[None, int, list, np.ndarray],
 def _get_target_from_target_fn(target_fn: Callable,
                                model: tf.keras.Model,
                                X: Union[np.ndarray, List[np.ndarray]],
-                               forward_kwargs: Optional[dict] = None) -> List[int]:
+                               forward_kwargs: Optional[dict] = None) -> np.ndarray:
+    """
+    Generate a target vector by using the `target_fn` to pick out a
+    scalar dimension from the predictions.
+
+    Parameters
+    ----------
+    target_fn
+        Target function.
+    model
+        Model
+    X
+        Data to be explained.
+    forward_kwargs
+        Any additional kwargs needed for the model forward pass.
+
+    Returns
+    -------
+    Integer array of dimension (N, ).
+    """
     if forward_kwargs is None:
         preds = model(X)
     else:
         preds = model(X, **forward_kwargs)
 
     target = target_fn(preds)
-    # TODO: validate target here before returning
+    expected_shape = (target.shape[0],)
+    if target.shape != expected_shape:
+        # TODO: in the future we want to support outputs that are >2D at which point this check should change
+        msg = f"`target_fn` returned an array of shape {target.shape} but expected an array of shape {expected_shape}."
+        raise ValueError(msg)  # TODO: raise a more specific error type?
     return target
 
 

--- a/alibi/explainers/integrated_gradients.py
+++ b/alibi/explainers/integrated_gradients.py
@@ -805,7 +805,7 @@ class IntegratedGradients(Explainer):
 
         """
         # target handling logic
-        if self.target_fn and target:
+        if self.target_fn and target is not None:
             msg = f'Both `target_fn` and `target` were provided. Only one of these should be provided.'
             raise ValueError(msg)
         if self.target_fn:

--- a/alibi/explainers/tests/test_integrated_gradients.py
+++ b/alibi/explainers/tests/test_integrated_gradients.py
@@ -729,5 +729,5 @@ def test__get_target_from_target_fn__with_2d_output_argmax():
 
 def test__get_target_from_target_fn__with_3d_output_argmax():
     with pytest.raises(ValueError):
-        target = _get_target_from_target_fn(np_argmax_fn, bad_model,
-                                            X_train)  # noqa: F841  # TODO: fix up types, though mypy doesn't complain
+        target = _get_target_from_target_fn(np_argmax_fn, bad_model,  # noqa: F841
+                                            X_train)  # TODO: fix up types, though mypy doesn't complain

--- a/doc/source/methods/IntegratedGradients.ipynb
+++ b/doc/source/methods/IntegratedGradients.ipynb
@@ -75,6 +75,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "\n",
     "```python \n",
     "import tensorflow as tf\n",
     "from alibi.explainers import IntegratedGradients\n",
@@ -83,6 +84,7 @@
     "\n",
     "ig  = IntegratedGradients(model,\n",
     "                          layer=None,\n",
+    "                          taget_fn=None,\n",
     "                          method=\"gausslegendre\",\n",
     "                          n_steps=50,\n",
     "                          internal_batch_size=100)\n",
@@ -92,11 +94,12 @@
     "* `model`: Tensorflow or Keras model.\n",
     "* `layer`: Layer with respect to which the gradients are calculated.\n",
     "           If not provided, the gradients are calculated with respect to the input.\n",
+    "* `target_fn`: A scalar function that is applied to the predictions of the model. This can be used to specify which scalar output the attributions should be calculated for (see the example below).\n",
     "* `method`: Method for the integral approximation. Methods available: `riemann_left`, `riemann_right`, `riemann_middle`, `riemann_trapezoid`, `gausslegendre`.\n",
     "* `n_steps`: Number of step in the path integral approximation from the baseline to the input instance.\n",
     "* `internal_batch_size`: Batch size for the internal batching.\n",
     "\n",
-    "```python \n",
+    "```python\n",
     "explanation = ig.explain(X,\n",
     "                         baselines=None,\n",
     "                         target=None)\n",
@@ -106,7 +109,36 @@
     "\n",
     "* `X`: Instances for which integrated gradients attributions are computed.\n",
     "* `baselines`: Baselines (starting point of the path integral) for each instance. If the passed value is an `np.ndarray` must have the same shape as X. If not provided, all features values for the baselines are set to 0.\n",
-    "* `target`: Defines which element of the model output is considered to compute the gradients. It can be a list of integers or a numeric value. If a numeric value is passed, the gradients are calculated for the same element of the output for all data points. It must be provided if the model output dimension is higher than 1. For regression models whose output is a scalar, target should not be provided. For classification models `target` can be either the true classes or the classes predicted by the model."
+    "* `target`: Defines which element of the model output is considered to compute the gradients. It can be a list of integers or a numeric value. If a numeric value is passed, the gradients are calculated for the same element of the output for all data points. It must be provided if the model output dimension is higher than 1 and no `target_fn` is provided. For regression models whose output is a scalar, target should not be provided. For classification models `target` can be either the true classes or the classes predicted by the model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "Example\n",
+    "    \n",
+    "If your model is a classifier outputting class probabilities (i.e. the predictions are $N\\times C$ arrays where $N$ is batch size and $C$ is the number of classes), then you can provide a `target_fn` to the constructor that, for each data point, would select the class of highest probability to calculate the attributions for:\n",
+    "    \n",
+    "```python\n",
+    "from functools import partial\n",
+    "import numpy as np\n",
+    "target_fn = partial(np.argmax, axis=1)\n",
+    "ig = IntegratedGradients(model=model, target_fn=target_fn)\n",
+    "explanation = ig.explain(X)\n",
+    "```\n",
+    "\n",
+    "    \n",
+    "Alternatively, you can leave out `target_fn` and instead provide the predicted class labels directly to the `explain` method:\n",
+    "    \n",
+    "```python\n",
+    "predictions = model.predict(X).argmax(axis=1)\n",
+    "ig = IntegratedGradients(model=model)\n",
+    "explanation = ig.explain(X, target=predictions)\n",
+    "```\n",
+    "    \n",
+    "</div>"
    ]
   },
   {
@@ -199,9 +231,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This is a PR partially addressing #492. In particular, it introduces the ability to pass a callback via the `target_fn` argument to calculate the scalar target dimension from the model output within the method. This is to bypass the requirement of passing `target` directly to `explain` when the `target` of interest may depend on the prediction output as in the case of the highest probability class.

Now both of these are possible to define an explainer:
```python
# current
ig = IntegratedGradients(model)
preds = np.argmax(model(X), axis=1)  # need to define upfront
exp = ig.explain(X, target=preds)

# proposed
from functools import partial
target_fn = partial(np.argmax, axis=1)  # user defined
ig = IntegratedGradients(model, target_fn=target_fn)
exp = ig.explain(X) # no preds needed
```

**TODO:**
- [x] Validate the output of `target_fn`
- [x] Tests
- [x] Docs updates
- [x] Example updates
- [ ] (Out of scope?) Desired output shape of `target_fn`. If the output shape of the model is `(N,M)` as in probabilistic classification, then naturally the output of `target_fn` is expected to be an `(N,)` array of integers which specify, for each instance in the batch, which dimension of the output (e.g. maximum probabilitie) to take. However, if the output shape of the model is `>2` this would not apply, e.g. if the output shape of the model is `(N,M,K)`, the `target_fn` would have to specify the indices for both `M` and `K` dimensions which would be reflected in the shape of `target_fn`. That being said, I'm not certain our current implementation of `IntegratedGradients` supports `>2D` model outputs so the point may be moot (for now).

**To discuss:**

1. I put `target_fn` as an argument to `__init__` as it seemed more natural, however, a case could be made that his belongs in `explain` as `target` is part of explain ~(and so is `forward_kwargs`—although I would personally like to see this shift to `__init__`)~ EDIT: Actually `forward_kwargs` is data dependent so belongs in `explain`.
2. This PR does not resolve the issue of fully specifying the `target_fn` from outside Python—in particular, the user application must define it. We could approach this (outside of the scope of this PR) by introducing function registries within `alibi` itself for pre-defined functions using [catalogue](https://github.com/explosion/catalogue). It would then look something like this:

```python
# alibi.utils.registries
import catalogue
scalar_reducers = catalogue.create("alibi", "scalar_reducers)

@scalar_reducers.register("argmax")
def argmax(X):
    return np.argmax(X, axis=...)  # TODO: numpy doesn't support multi-axis reduction for argmax
```

```python
# user code option 1
# this does not fully solve the issue in #492 as the user still has to fetch the function
from alibi.utils.registries import scalar_reducers
target_fn = scalar_reducers['argmax']
explainer = IntegratedGradients(model, target_fn=target_fn)
```
```python
# user code option 2
# this fully solves the issue in #492 by extending the explainer constructor signature
# to accept strings which are looked up internally in the register
target_fn = "argmax"  # or provided from some config file
explainer = IntegratedGradients(model, target_fn=target_fn)

# inside IntegratedGradients:
    ...
    target_fn = scalar_reducers[target_fn]
```

We can separate the registry discussion in a separate issue in the future.

It would be nice imo to provide both callback functionality for maximum flexibility as well as strings mapping to `alibi` built-in functions for ease of use (in this example avoiding the use of `partial` and defining `target_fn` manually). Although, we may want to think about separating interfaces that act on pure callbacks (e.g. the public `IntegratedGradients` interface) and interfaces that act on string names to construct an explainer for greater clarity and separation of concerns.