### PR TITLE
Bump shap minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ pip install alibi[ray]
 
 For SHAP support, install `alibi` as follows:
 ```bash
-pip install alibi && pip install alibi[shap]
+pip install alibi[shap]
 ```
 
 The alibi explanation API takes inspiration from `scikit-learn`, consisting of distinct initialize,

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -11,6 +11,6 @@ ipykernel>=5.1.0, <6.0.0 # required for executing notebooks via nbsphinx
 ipython>=7.2.0, <8.0.0 # required for executing notebooks nbsphinx
 # dependencies required for imports to work and docs to render properly (as mocking doesn't work well)
 # these should be identical to the ones in `setup.py` or `dev.txt`
-shap>=0.36.0, !=0.38.1, <0.41 # https://github.com/SeldonIO/alibi/issues/333
+shap>=0.40.0, <0.41.0 # https://github.com/SeldonIO/alibi/issues/333
 # pandoc
 # pandoc==1.19.2 # NB: as this is not a Python library, it should be installed manually on the system or via a package manager such as `conda`

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,7 @@ extras_require = {
     'ray': ['ray>=0.8.7, <2.0.0'],  # from requirements/dev.txt
     # shap is separated due to build issues, see https://github.com/slundberg/shap/pull/1802
     'shap': [
-        'shap>=0.36.0, !=0.38.1, <0.41.0', # versioning: https://github.com/SeldonIO/alibi/issues/333
-        'numba!=0.54.0' # To fix: https://github.com/SeldonIO/alibi/issues/466
+        'shap>=0.40.0, <0.41.0', # versioning: https://github.com/SeldonIO/alibi/issues/333
     ],  
 }
 


### PR DESCRIPTION
Addressing #509.

I've also removed the pin on `numba` as it shouldn't be an issue with `shap>=0.40.0`.