### PR TITLE
Dev/reinstate strict optional mypy

### DIFF
--- a/alibi/api/defaults.py
+++ b/alibi/api/defaults.py
@@ -8,7 +8,7 @@ DEFAULT_META_ANCHOR = {"name": None,
                        "type": ["blackbox"],
                        "explanations": ["local"],
                        "params": {},
-                       "version": None}
+                       "version": None}  # type: dict
 """
 Default anchor metadata.
 """
@@ -35,7 +35,7 @@ DEFAULT_META_CEM = {"name": None,
                     "type": ["blackbox", "tensorflow", "keras"],
                     "explanations": ["local"],
                     "params": {},
-                    "version": None}
+                    "version": None}  # type: dict
 """
 Default CEM metadata.
 """
@@ -57,7 +57,7 @@ DEFAULT_META_CF = {"name": None,
                    "type": ["blackbox", "tensorflow", "keras"],
                    "explanations": ["local"],
                    "params": {},
-                   "version": None}
+                   "version": None}  # type: dict
 """
 Default counterfactual metadata.
 """
@@ -76,7 +76,7 @@ DEFAULT_META_CFP = {"name": None,
                     "type": ["blackbox", "tensorflow", "keras"],
                     "explanations": ["local"],
                     "params": {},
-                    "version": None}
+                    "version": None}  # type: dict
 """
 Default counterfactual prototype metadata.
 """

--- a/alibi/confidence/model_linearity.py
+++ b/alibi/confidence/model_linearity.py
@@ -1,10 +1,11 @@
 import logging
-from time import time
-from typing import Tuple, Callable, Union, List
-from numpy.linalg import norm
-import numpy as np
-from sklearn.neighbors import NearestNeighbors
 import string
+from time import time
+from typing import Callable, List, Optional, Tuple, Union
+
+import numpy as np
+from numpy.linalg import norm
+from sklearn.neighbors import NearestNeighbors
 
 logger = logging.getLogger(__name__)
 
@@ -218,7 +219,7 @@ def _sample_knn(x: np.ndarray, X_train: np.ndarray, nb_samples: int = 10) -> np.
     return np.asarray(X_sampled)  # shape=(nb_instances, nb_samples, nb_features)
 
 
-def _sample_grid(x: np.ndarray, feature_range: np.ndarray = None, epsilon: float = 0.04,
+def _sample_grid(x: np.ndarray, feature_range: np.ndarray, epsilon: float = 0.04,
                  nb_samples: int = 10, res: int = 100) -> np.ndarray:
     """Samples data points uniformly from an interval centered at x and with size epsilon * Delta,
     with delta = f_max - f_min the features ranges.
@@ -259,10 +260,17 @@ def _sample_grid(x: np.ndarray, feature_range: np.ndarray = None, epsilon: float
     return X_sampled
 
 
-def _linearity_measure(predict_fn: Callable, x: np.ndarray, X_train: np.ndarray = None,
-                       feature_range: Union[List, np.ndarray] = None, method: str = None,
-                       epsilon: float = 0.04, nb_samples: int = 10, res: int = 100,
-                       alphas: np.ndarray = None, model_type: str = 'classifier', agg: str = 'global') -> np.ndarray:
+def _linearity_measure(predict_fn: Callable,
+                       x: np.ndarray,
+                       X_train: Optional[np.ndarray] = None,
+                       feature_range: Optional[Union[List, np.ndarray]] = None,
+                       method: Optional[str] = None,
+                       epsilon: float = 0.04,
+                       nb_samples: int = 10,
+                       res: int = 100,
+                       alphas: Optional[np.ndarray] = None,
+                       model_type: str = 'classifier',
+                       agg: str = 'global') -> np.ndarray:
     """Calculate the linearity measure of the model around an instance of interest x.
 
     Parameters
@@ -341,10 +349,16 @@ def _infer_feature_range(X_train: np.ndarray) -> np.ndarray:
     return np.vstack((X_train.min(axis=0), X_train.max(axis=0))).T
 
 
-class LinearityMeasure(object):
+class LinearityMeasure:
 
-    def __init__(self, method: str = 'grid', epsilon: float = 0.04, nb_samples: int = 10, res: int = 100,
-                 alphas: np.ndarray = None, model_type: str = 'classifier', agg: str = 'pairwise',
+    def __init__(self,
+                 method: str = 'grid',
+                 epsilon: float = 0.04,
+                 nb_samples: int = 10,
+                 res: int = 100,
+                 alphas: Optional[np.ndarray] = None,
+                 model_type: str = 'classifier',
+                 agg: str = 'pairwise',
                  verbose: bool = False) -> None:
         """
 
@@ -430,9 +444,16 @@ class LinearityMeasure(object):
         return lin
 
 
-def linearity_measure(predict_fn: Callable, x: np.ndarray, feature_range: Union[List, np.ndarray] = None,
-                      method: str = 'grid', X_train: np.ndarray = None, epsilon: float = 0.04,
-                      nb_samples: int = 10, res: int = 100, alphas: np.ndarray = None, agg: str = 'global',
+def linearity_measure(predict_fn: Callable,
+                      x: np.ndarray,
+                      feature_range: Optional[Union[List, np.ndarray]] = None,
+                      method: str = 'grid',
+                      X_train: Optional[np.ndarray] = None,
+                      epsilon: float = 0.04,
+                      nb_samples: int = 10,
+                      res: int = 100,
+                      alphas: Optional[np.ndarray] = None,
+                      agg: str = 'global',
                       model_type: str = 'classifier') -> np.ndarray:
     """Calculate the linearity measure of the model around an instance of interest x.
 

--- a/alibi/confidence/trustscore.py
+++ b/alibi/confidence/trustscore.py
@@ -1,16 +1,21 @@
 import logging
+from typing import Any, Optional, Tuple
+
 import numpy as np
-from sklearn.neighbors import KDTree
-from sklearn.neighbors import KNeighborsClassifier
-from typing import Tuple, Any
+from sklearn.neighbors import KDTree, KNeighborsClassifier
 
 logger = logging.getLogger(__name__)
 
 
-class TrustScore(object):
+class TrustScore:
 
-    def __init__(self, k_filter: int = 10, alpha: float = 0., filter_type: str = None,
-                 leaf_size: int = 40, metric: str = 'euclidean', dist_filter_type: str = 'point') -> None:
+    def __init__(self,
+                 k_filter: int = 10,
+                 alpha: float = 0.,
+                 filter_type: Optional[str] = None,
+                 leaf_size: int = 40,
+                 metric: str = 'euclidean',
+                 dist_filter_type: str = 'point') -> None:
         """
         Initialize trust scores.
 
@@ -93,7 +98,7 @@ class TrustScore(object):
         X_keep, Y_keep = X[keep_id, :], Y[keep_id]
         return X_keep, Y_keep
 
-    def fit(self, X: np.ndarray, Y: np.ndarray, classes: int = None) -> None:
+    def fit(self, X: np.ndarray, Y: np.ndarray, classes: Optional[int] = None) -> None:
         """
         Build KDTrees for each prediction class.
 

--- a/alibi/datasets.py
+++ b/alibi/datasets.py
@@ -51,15 +51,16 @@ def load_cats(target_size: tuple = (299, 299), return_X_y: bool = False) -> Unio
     (data, target)
         Tuple if ``return_X_y`` is true
     """
-    tar = tarfile.open(fileobj=BytesIO(pkgutil.get_data(__name__, "data/cats.tar.gz")), mode='r:gz')  # type: ignore
+    tar = tarfile.open(fileobj=BytesIO(pkgutil.get_data(__name__, "data/cats.tar.gz")),  # type: ignore[arg-type]
+                       mode='r:gz')
     images = []
     target = []
     target_names = []
     for member in tar.getmembers():
         # data
-        img = tar.extractfile(member).read()  # type: ignore
+        img = tar.extractfile(member).read()  # type: ignore[union-attr]
         img = PIL.Image.open(BytesIO(img))
-        img = np.expand_dims(img.resize(target_size), axis=0)  # type: ignore
+        img = np.expand_dims(img.resize(target_size), axis=0)
         images.append(img)
 
         # labels
@@ -71,7 +72,7 @@ def load_cats(target_size: tuple = (299, 299), return_X_y: bool = False) -> Unio
     images = np.concatenate(images, axis=0)
     targets = np.asarray(target)
     if return_X_y:
-        return images, targets  # type: ignore
+        return images, targets  # type: ignore[return-value] # TODO: allow redefiniton
     else:
         return Bunch(data=images, target=targets, target_names=target_names)
 
@@ -115,7 +116,7 @@ def fetch_movie_sentiment(return_X_y: bool = False, url_id: int = 0) -> Union[Bu
     labels = []
     for i, member in enumerate(tar.getnames()[1:]):
         f = tar.extractfile(member)
-        for line in f.readlines():  # type: ignore
+        for line in f.readlines():  # type: ignore[union-attr]
             try:
                 line.decode('utf8')
             except UnicodeDecodeError:

--- a/alibi/datasets.py
+++ b/alibi/datasets.py
@@ -1,17 +1,18 @@
-import PIL
+import logging
+import pkgutil
+import tarfile
 from io import BytesIO, StringIO
+from typing import Optional, Tuple, Union
+
 import numpy as np
 import pandas as pd
-import pkgutil
+import PIL
 import requests
+import tensorflow.keras as keras
 from requests import RequestException
 from sklearn.preprocessing import LabelEncoder
-import tarfile
-from typing import Tuple, Union
-import logging
-from alibi.utils.data import Bunch
 
-import tensorflow.keras as keras
+from alibi.utils.data import Bunch
 
 logger = logging.getLogger(__name__)
 
@@ -50,13 +51,13 @@ def load_cats(target_size: tuple = (299, 299), return_X_y: bool = False) -> Unio
     (data, target)
         Tuple if ``return_X_y`` is true
     """
-    tar = tarfile.open(fileobj=BytesIO(pkgutil.get_data(__name__, "data/cats.tar.gz")), mode='r:gz')
+    tar = tarfile.open(fileobj=BytesIO(pkgutil.get_data(__name__, "data/cats.tar.gz")), mode='r:gz')  # type: ignore
     images = []
     target = []
     target_names = []
     for member in tar.getmembers():
         # data
-        img = tar.extractfile(member).read()
+        img = tar.extractfile(member).read()  # type: ignore
         img = PIL.Image.open(BytesIO(img))
         img = np.expand_dims(img.resize(target_size), axis=0)  # type: ignore
         images.append(img)
@@ -114,7 +115,7 @@ def fetch_movie_sentiment(return_X_y: bool = False, url_id: int = 0) -> Union[Bu
     labels = []
     for i, member in enumerate(tar.getnames()[1:]):
         f = tar.extractfile(member)
-        for line in f.readlines():
+        for line in f.readlines():  # type: ignore
             try:
                 line.decode('utf8')
             except UnicodeDecodeError:
@@ -129,7 +130,7 @@ def fetch_movie_sentiment(return_X_y: bool = False, url_id: int = 0) -> Union[Bu
     return Bunch(data=data, target=labels, target_names=target_names)
 
 
-def fetch_adult(features_drop: list = None, return_X_y: bool = False, url_id: int = 0) -> \
+def fetch_adult(features_drop: Optional[list] = None, return_X_y: bool = False, url_id: int = 0) -> \
         Union[Bunch, Tuple[np.ndarray, np.ndarray]]:
     """
     Downloads and pre-processes 'adult' dataset.

--- a/alibi/explainers/ale.py
+++ b/alibi/explainers/ale.py
@@ -89,7 +89,7 @@ class ALE(Explainer):
                                    extrapolate_constant_perc=extrapolate_constant_perc,
                                    extrapolate_constant_min=extrapolate_constant_min)
 
-    def explain(self, X: np.ndarray, features: List[int] = None, min_bin_points: int = 4) -> Explanation:
+    def explain(self, X: np.ndarray, features: Optional[List[int]] = None, min_bin_points: int = 4) -> Explanation:
         """
         Calculate the ALE curves for each feature with respect to the dataset `X`.
 
@@ -130,7 +130,7 @@ class ALE(Explainer):
             feature_names = self.feature_names[features]  # type: ignore
         else:
             feature_names = self.feature_names
-            features = range(n_features)  # type: ignore
+            features = list(range(n_features))
 
         feature_values = []
         ale_values = []

--- a/alibi/explainers/anchor_base.py
+++ b/alibi/explainers/anchor_base.py
@@ -199,7 +199,7 @@ class AnchorBaseBeam:
         return coverage_data
 
     def select_critical_arms(self, means: np.ndarray, ub: np.ndarray, lb: np.ndarray, n_samples: np.ndarray,
-                             delta: float, top_n: int, t: int):  # type: ignore
+                             delta: float, top_n: int, t: int):
         """
         Determines a set of two anchors by updating the upper bound for low emprical precision anchors and
         the lower bound for anchors with high empirical precision.
@@ -475,7 +475,7 @@ class AnchorBaseBeam:
                 (self.state['labels'], np.zeros(prealloc_size, labels.dtype))
             )
 
-        return labels.sum(), data.shape[0]  # type: ignore
+        return labels.sum(), data.shape[0]
 
     def get_init_stats(self, anchors: list, coverages=False) -> dict:
         """
@@ -836,7 +836,8 @@ class DistributedAnchorBaseBeam(AnchorBaseBeam):
         self.pool = ActorPool(samplers)
         self.samplers = samplers
 
-    def _get_coverage_samples(self, coverage_samples: int, samplers: List[Callable]) -> np.ndarray:  # type: ignore
+    def _get_coverage_samples(self, coverage_samples: int,  # type: ignore[override]
+                              samplers: List[Callable]) -> np.ndarray:
         """
         Sends a request for a coverage set to process running sampling tasks.
 
@@ -855,7 +856,7 @@ class DistributedAnchorBaseBeam(AnchorBaseBeam):
 
         return coverage_data
 
-    def draw_samples(self, anchors: list, batch_size: int) -> Tuple[np.ndarray, np.ndarray]:  # type: ignore
+    def draw_samples(self, anchors: list, batch_size: int) -> Tuple[np.ndarray, np.ndarray]:  # type: ignore[override]
         """
         Distributes sampling requests among processes running sampling tasks.
 

--- a/alibi/explainers/anchor_base.py
+++ b/alibi/explainers/anchor_base.py
@@ -836,7 +836,7 @@ class DistributedAnchorBaseBeam(AnchorBaseBeam):
         self.pool = ActorPool(samplers)
         self.samplers = samplers
 
-    def _get_coverage_samples(self, coverage_samples: int, samplers: List[Callable]) -> np.ndarray: # type: ignore
+    def _get_coverage_samples(self, coverage_samples: int, samplers: List[Callable]) -> np.ndarray:  # type: ignore
         """
         Sends a request for a coverage set to process running sampling tasks.
 

--- a/alibi/explainers/anchor_explanation.py
+++ b/alibi/explainers/anchor_explanation.py
@@ -1,5 +1,6 @@
+from typing import Optional, Union
+
 import numpy as np
-from typing import Union
 
 
 class AnchorExplanation:
@@ -18,7 +19,7 @@ class AnchorExplanation:
         self.type = exp_type
         self.exp_map = exp_map
 
-    def names(self, partial_index: int = None) -> list:
+    def names(self, partial_index: Optional[int] = None) -> list:
         """
         Parameters
         ----------
@@ -36,7 +37,7 @@ class AnchorExplanation:
             names = names[:partial_index + 1]
         return names
 
-    def features(self, partial_index: int = None) -> list:
+    def features(self, partial_index: Optional[int] = None) -> list:
         """
         Parameters
         ----------
@@ -54,7 +55,7 @@ class AnchorExplanation:
             features = features[:partial_index + 1]
         return features
 
-    def precision(self, partial_index: int = None) -> float:
+    def precision(self, partial_index: Optional[int] = None) -> float:
         """
         Parameters
         ----------
@@ -75,7 +76,7 @@ class AnchorExplanation:
         else:
             return precision[-1]
 
-    def coverage(self, partial_index: int = None) -> float:
+    def coverage(self, partial_index: Optional[int] = None) -> float:
         """
         Parameters
         ----------
@@ -97,7 +98,7 @@ class AnchorExplanation:
             return coverage[-1]
 
     def examples(self, only_different_prediction: bool = False,
-                 only_same_prediction: bool = False, partial_index: int = None) -> Union[list, np.ndarray]:
+                 only_same_prediction: bool = False, partial_index: Optional[int] = None) -> Union[list, np.ndarray]:
         """
         Parameters
         ----------

--- a/alibi/explainers/anchor_image.py
+++ b/alibi/explainers/anchor_image.py
@@ -1,18 +1,19 @@
 import copy
 import logging
+from functools import partial
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import numpy as np
+from skimage.segmentation import felzenszwalb, quickshift, slic
 
-from functools import partial
-from typing import Any, Callable, List, Union, Tuple, Type
-
-from alibi.utils.wrappers import ArgmaxTransformer
+from alibi.api.defaults import DEFAULT_DATA_ANCHOR_IMG, DEFAULT_META_ANCHOR
 from alibi.api.interfaces import Explainer, Explanation
-from alibi.api.defaults import DEFAULT_META_ANCHOR, DEFAULT_DATA_ANCHOR_IMG
-from alibi.exceptions import AlibiPredictorCallException, AlibiPredictorReturnTypeError
+from alibi.exceptions import (AlibiPredictorCallException,
+                              AlibiPredictorReturnTypeError)
+from alibi.utils.wrappers import ArgmaxTransformer
+
 from .anchor_base import AnchorBaseBeam
 from .anchor_explanation import AnchorExplanation
-from skimage.segmentation import felzenszwalb, slic, quickshift
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +21,7 @@ DEFAULT_SEGMENTATION_KWARGS = {
     'felzenszwalb': {},
     'quickshift': {},
     'slic': {'n_segments': 10, 'compactness': 10, 'sigma': .5}
-}
+}  # type: Dict[str, Dict]
 
 
 def scale_image(image: np.ndarray, scale: tuple = (0, 255)) -> np.ndarray:
@@ -54,7 +55,7 @@ class AnchorImageSampler:
             segmentation_fn: Callable,
             custom_segmentation: bool,
             image: np.ndarray,
-            images_background: np.ndarray = None,
+            images_background: Optional[np.ndarray] = None,
             p_sample: float = 0.5,
             n_covered_ex: int = 10,
     ):
@@ -304,9 +305,9 @@ class AnchorImage(Explainer):
                  image_shape: tuple,
                  dtype: Type[np.generic] = np.float32,
                  segmentation_fn: Any = 'slic',
-                 segmentation_kwargs: dict = None,
-                 images_background: np.ndarray = None,
-                 seed: int = None) -> None:
+                 segmentation_kwargs: Optional[dict] = None,
+                 images_background: Optional[np.ndarray] = None,
+                 seed: Optional[int] = None) -> None:
         """
         Initialize anchor image explainer.
 
@@ -342,9 +343,11 @@ class AnchorImage(Explainer):
         super().__init__(meta=copy.deepcopy(DEFAULT_META_ANCHOR))
         np.random.seed(seed)
 
-        if isinstance(segmentation_fn, str) and not segmentation_kwargs:
+        # TODO: this logic needs improvement. We should check against a fixed set of strings
+        # for built-ins instead of any `str`.
+        if isinstance(segmentation_fn, str) and segmentation_kwargs is None:
             try:
-                segmentation_kwargs = DEFAULT_SEGMENTATION_KWARGS[segmentation_fn]  # type: ignore
+                segmentation_kwargs = DEFAULT_SEGMENTATION_KWARGS[segmentation_fn]
             except KeyError:
                 logger.warning(
                     'DEFAULT_SEGMENTATION_KWARGS did not contain any entry'
@@ -355,9 +358,11 @@ class AnchorImage(Explainer):
         elif callable(segmentation_fn) and segmentation_kwargs:
             logger.warning(
                 'Specified both a segmentation function to create superpixels and '
-                'keyword arguments for built segmentation functions. By default '
+                'keyword arguments for built-in segmentation functions. By default '
                 'the specified segmentation function will be used.'
             )
+        else:
+            segmentation_kwargs = {}
 
         # set the predictor
         self.image_shape = tuple(image_shape)  # coerce lists
@@ -441,7 +446,7 @@ class AnchorImage(Explainer):
                 coverage_samples: int = 10000,
                 beam_size: int = 1,
                 stop_on_first: bool = False,
-                max_anchor_size: int = None,
+                max_anchor_size: Optional[int] = None,
                 min_samples_start: int = 100,
                 n_covered_ex: int = 10,
                 binary_cache_size: int = 10000,

--- a/alibi/explainers/anchor_image.py
+++ b/alibi/explainers/anchor_image.py
@@ -250,7 +250,7 @@ class AnchorImageSampler:
                 mask[segments == superpixel] = True
             if background_idx is not None:
                 # replace values with those of background image
-                temp[mask] = self.images_background[background_idx][mask]
+                temp[mask] = self.images_background[background_idx][mask]  # type: ignore[index]
             else:
                 # ... or with the averaged superpixel value
                 temp[mask] = fudged_image[mask]
@@ -436,7 +436,7 @@ class AnchorImage(Explainer):
 
         return image_preproc
 
-    def explain(self,  # type: ignore
+    def explain(self,  # type: ignore[override]
                 image: np.ndarray,
                 p_sample: float = 0.5,
                 threshold: float = 0.95,

--- a/alibi/explainers/anchor_tabular.py
+++ b/alibi/explainers/anchor_tabular.py
@@ -292,7 +292,8 @@ class TabularSampler:
         if num_samples_pos == 0:
             samples_idxs = np.random.choice(partial_anchor_rows[-1], num_samples)
             samples[:, uniq_feat_ids] = self.train_data[np.ix_(samples_idxs, uniq_feat_ids)]  # type: ignore[arg-type]
-            d_samples[:, uniq_feat_ids] = self.d_train_data[np.ix_(samples_idxs, uniq_feat_ids)]  # type: ignore[arg-type]
+            d_samples[:, uniq_feat_ids] = self.d_train_data[
+                np.ix_(samples_idxs, uniq_feat_ids)]  # type: ignore[arg-type]
 
             return samples, d_samples, coverage
 
@@ -394,7 +395,8 @@ class TabularSampler:
                         replace=True,
                     )
                 n_samp = num_samples
-            samples[start:start + n_samp, uniq_feat_ids[idx:]] = self.train_data[np.ix_(samp_idxs, uniq_feat_ids[idx:])]  # type: ignore[arg-type]
+            samples[start:start + n_samp, uniq_feat_ids[idx:]] = self.train_data[
+                np.ix_(samp_idxs, uniq_feat_ids[idx:])]  # type: ignore[arg-type]
 
             # deal with partial anchors; idx = 0 means that we actually sample the entire anchor
             if idx > 0:

--- a/alibi/explainers/anchor_tabular.py
+++ b/alibi/explainers/anchor_tabular.py
@@ -291,8 +291,8 @@ class TabularSampler:
         num_samples_pos = np.searchsorted(nb_partial_anchors, num_samples)
         if num_samples_pos == 0:
             samples_idxs = np.random.choice(partial_anchor_rows[-1], num_samples)
-            samples[:, uniq_feat_ids] = self.train_data[np.ix_(samples_idxs, uniq_feat_ids)]  # type: ignore
-            d_samples[:, uniq_feat_ids] = self.d_train_data[np.ix_(samples_idxs, uniq_feat_ids)]  # type: ignore
+            samples[:, uniq_feat_ids] = self.train_data[np.ix_(samples_idxs, uniq_feat_ids)]  # type: ignore[arg-type]
+            d_samples[:, uniq_feat_ids] = self.d_train_data[np.ix_(samples_idxs, uniq_feat_ids)]  # type: ignore[arg-type]
 
             return samples, d_samples, coverage
 
@@ -380,7 +380,7 @@ class TabularSampler:
 
         # replace partial anchors with partial anchors drawn from the training dataset
         # samp_idxs are arrays of training set row indices from where partial anchors are extracted for replacement
-        for idx, n_samp in enumerate(nb_partial_anchors[start_idx:end_idx + 1], start=start_idx):  # type: ignore
+        for idx, n_samp in enumerate(nb_partial_anchors[start_idx:end_idx + 1], start=start_idx):  # type: ignore[misc]
             if num_samples >= n_samp:
                 samp_idxs = partial_anchor_rows[n_anchor_feats - idx - 1]
                 num_samples -= n_samp
@@ -394,8 +394,7 @@ class TabularSampler:
                         replace=True,
                     )
                 n_samp = num_samples
-            samples[start:start + n_samp, uniq_feat_ids[idx:]] = self.train_data[
-                np.ix_(samp_idxs, uniq_feat_ids[idx:])]  # type: ignore
+            samples[start:start + n_samp, uniq_feat_ids[idx:]] = self.train_data[np.ix_(samp_idxs, uniq_feat_ids[idx:])]  # type: ignore[arg-type]
 
             # deal with partial anchors; idx = 0 means that we actually sample the entire anchor
             if idx > 0:
@@ -518,7 +517,7 @@ class TabularSampler:
 
         if not self.numerical_features:  # data contains only categorical variables
             self.cat_lookup = dict(zip(self.categorical_features, X))
-            self.enc2feat_idx = dict(zip(*[self.categorical_features] * 2))  # type: ignore
+            self.enc2feat_idx = dict(zip(*[self.categorical_features] * 2))  # type: ignore[arg-type]
             return [self.cat_lookup, self.ord_lookup, self.enc2feat_idx]
 
         first_numerical_idx = np.searchsorted(self.categorical_features, self.numerical_features[0]).item()
@@ -733,7 +732,9 @@ class AnchorTabular(Explainer, FitMixin):
         # update metadata
         self.meta['params'].update(seed=seed)
 
-    def fit(self, train_data: np.ndarray, disc_perc: Tuple[Union[int, float], ...] = (25, 50, 75),  # type:ignore
+    def fit(self,  # type: ignore[override]
+            train_data: np.ndarray,
+            disc_perc: Tuple[Union[int, float], ...] = (25, 50, 75),
             **kwargs) -> "AnchorTabular":
         """
         Fit discretizer to train data to bin numerical features into ordered bins and compute statistics for
@@ -757,7 +758,7 @@ class AnchorTabular(Explainer, FitMixin):
         self.feature_values.update(disc.feature_intervals)
 
         sampler = TabularSampler(
-            self._predictor,  # type: ignore # TODO: fix me, ignored as can be None due to saving.py
+            self._predictor,  # type: ignore[arg-type] # TODO: fix me, ignored as can be None due to saving.py
             disc_perc,
             self.numerical_features,
             self.categorical_features,
@@ -1081,7 +1082,10 @@ class DistributedAnchorTabular(AnchorTabular):
         if not DistributedAnchorTabular.ray.is_initialized():
             DistributedAnchorTabular.ray.init()
 
-    def fit(self, train_data: np.ndarray, disc_perc: tuple = (25, 50, 75), **kwargs) -> "AnchorTabular":  # type: ignore
+    def fit(self,  # type: ignore[override]
+            train_data: np.ndarray,
+            disc_perc: tuple = (25, 50, 75),
+            **kwargs) -> "AnchorTabular":
         """
         Creates a list of handles to parallel processes handles that are used for submitting sampling
         tasks.
@@ -1116,7 +1120,7 @@ class DistributedAnchorTabular(AnchorTabular):
         )
         train_data_id = DistributedAnchorTabular.ray.put(train_data)
         d_train_data_id = DistributedAnchorTabular.ray.put(d_train_data)
-        samplers = [TabularSampler(*sampler_args, seed=self.seed) for _ in range(ncpu)]  # type: ignore
+        samplers = [TabularSampler(*sampler_args, seed=self.seed) for _ in range(ncpu)]  # type: ignore[arg-type]
         d_samplers = []
         for sampler in samplers:
             d_samplers.append(

--- a/alibi/explainers/anchor_tabular.py
+++ b/alibi/explainers/anchor_tabular.py
@@ -1010,19 +1010,19 @@ class AnchorTabular(Explainer, FitMixin):
         return self._ohe_predictor if self.ohe else self._predictor
 
     @predictor.setter
-    def predictor(self, predictor: Callable) -> None:
+    def predictor(self, predictor: Optional[Callable]) -> None:  # Optional here because in saving.py we set it to None
         # if input is one-hot encoded
         if self.ohe:
             # this predictor expects ordinal/labels encoded categorical variables
             ord_predictor = lambda x: predictor(ord_to_ohe(x, self.cat_vars_ord)[0])  # noqa: E731
-            self._predictor = self._transform_predictor(ord_predictor)
+            self._predictor = self._transform_predictor(ord_predictor) if predictor else None
 
             # this predictor expects one-hot encoded categorical variable
-            self._ohe_predictor = self._transform_ohe_predictor(predictor)
+            self._ohe_predictor = self._transform_ohe_predictor(predictor) if predictor else None
 
         else:
             # set the predictor
-            self._predictor = self._transform_predictor(predictor)
+            self._predictor = self._transform_predictor(predictor) if predictor else None
 
     def _transform_predictor(self, predictor: Callable) -> Callable:
         # define data instance full of zeros

--- a/alibi/explainers/anchor_text.py
+++ b/alibi/explainers/anchor_text.py
@@ -1,21 +1,23 @@
 import copy
-import spacy
-import string
 import logging
-import numpy as np
-import tensorflow as tf
-
+import string
+from abc import abstractmethod
 from copy import deepcopy
 from functools import partial
-from abc import abstractmethod
-from typing import Any, Callable, Dict, List, Tuple, TYPE_CHECKING, Union, Optional
+from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple,
+                    Union)
 
-from alibi.utils.wrappers import ArgmaxTransformer
-from alibi.utils.lang_model import LanguageModel
+import numpy as np
+import spacy
+import tensorflow as tf
 
+from alibi.api.defaults import DEFAULT_DATA_ANCHOR, DEFAULT_META_ANCHOR
 from alibi.api.interfaces import Explainer, Explanation
-from alibi.api.defaults import DEFAULT_META_ANCHOR, DEFAULT_DATA_ANCHOR
-from alibi.exceptions import AlibiPredictorCallException, AlibiPredictorReturnTypeError
+from alibi.exceptions import (AlibiPredictorCallException,
+                              AlibiPredictorReturnTypeError)
+from alibi.utils.lang_model import LanguageModel
+from alibi.utils.wrappers import ArgmaxTransformer
+
 from .anchor_base import AnchorBaseBeam
 from .anchor_explanation import AnchorExplanation
 
@@ -24,7 +26,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _load_spacy_lexeme_prob(nlp: 'spacy.language.Language'):
+def _load_spacy_lexeme_prob(nlp: 'spacy.language.Language') -> 'spacy.language.Language':
     """
     This utility function loads the `lexeme_prob` table for a spacy model if it is not present.
     This is required to enable support for different spacy versions.
@@ -1367,7 +1369,7 @@ class AnchorText(Explainer):
                 coverage_samples: int = 10000,
                 beam_size: int = 1,
                 stop_on_first: bool = True,
-                max_anchor_size: int = None,
+                max_anchor_size: Optional[int] = None,
                 min_samples_start: int = 100,
                 n_covered_ex: int = 10,
                 binary_cache_size: int = 10000,

--- a/alibi/explainers/anchor_text.py
+++ b/alibi/explainers/anchor_text.py
@@ -4,7 +4,7 @@ import string
 from abc import abstractmethod
 from copy import deepcopy
 from functools import partial
-from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple,
+from typing import (TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Tuple,
                     Union)
 
 import numpy as np
@@ -56,7 +56,7 @@ def _load_spacy_lexeme_prob(nlp: 'spacy.language.Language') -> 'spacy.language.L
         # https://github.com/explosion/spaCy/discussions/6388#discussioncomment-331096
         if 'lexeme_prob' not in nlp.vocab.lookups.tables:
             from spacy.lookups import load_lookups
-            lookups = load_lookups(nlp.lang, ['lexeme_prob'])
+            lookups = load_lookups(nlp.lang, ['lexeme_prob'])  # type: ignore
             nlp.vocab.lookups.add_table('lexeme_prob', lookups.get_table('lexeme_prob'))  # type: ignore
 
     return nlp
@@ -262,6 +262,7 @@ class UnknownSampler(AnchorTextSampler):
 
 
 class SimilaritySampler(AnchorTextSampler):
+
     def __init__(self, nlp: 'spacy.language.Language', perturb_opts: Dict):
         """
         Initialize similarity sampler. This sampler replaces words with similar words.
@@ -285,7 +286,10 @@ class SimilaritySampler(AnchorTextSampler):
 
         # dict containing an np.array of similar words with same part of speech and an np.array of similarities
         self.synonyms = {}  # type: Dict[str, Dict[str, np.ndarray]]
-        self.tokens, self.words, self.positions, self.punctuation = [], [], [], []  # type: List, List, List, List
+        self.tokens: 'spacy.tokens.Doc'
+        self.words: List[str] = []
+        self.positions: List[int] = []
+        self.punctuation: List['spacy.tokens.Token'] = []
 
     def set_text(self, text: str) -> None:
         """

--- a/alibi/explainers/anchor_text.py
+++ b/alibi/explainers/anchor_text.py
@@ -4,7 +4,7 @@ import string
 from abc import abstractmethod
 from copy import deepcopy
 from functools import partial
-from typing import (TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Tuple,
+from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple,
                     Union)
 
 import numpy as np

--- a/alibi/explainers/anchor_text.py
+++ b/alibi/explainers/anchor_text.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 from copy import deepcopy
 from functools import partial
 from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple,
-                    Union)
+                    Type, Union)
 
 import numpy as np
 import spacy
@@ -56,8 +56,8 @@ def _load_spacy_lexeme_prob(nlp: 'spacy.language.Language') -> 'spacy.language.L
         # https://github.com/explosion/spaCy/discussions/6388#discussioncomment-331096
         if 'lexeme_prob' not in nlp.vocab.lookups.tables:
             from spacy.lookups import load_lookups
-            lookups = load_lookups(nlp.lang, ['lexeme_prob'])  # type: ignore
-            nlp.vocab.lookups.add_table('lexeme_prob', lookups.get_table('lexeme_prob'))  # type: ignore
+            lookups = load_lookups(nlp.lang, ['lexeme_prob'])  # type: ignore[arg-type]
+            nlp.vocab.lookups.add_table('lexeme_prob', lookups.get_table('lexeme_prob'))
 
     return nlp
 
@@ -142,7 +142,7 @@ class AnchorTextSampler:
     def __call__(self, anchor: tuple, num_samples: int) -> Tuple[np.ndarray, np.ndarray]:
         pass
 
-    def _joiner(self, arr: np.ndarray, dtype: np.dtype = None) -> np.ndarray:
+    def _joiner(self, arr: np.ndarray, dtype: Optional[Type[np.generic]] = None) -> np.ndarray:
         """
         Function to concatenate an np.array of strings along a specified axis.
 
@@ -756,7 +756,7 @@ class LanguageModelSampler(AnchorTextSampler):
         # convert to array and return
         return np.array(full_raw, dtype=self.dtype_sent)
 
-    def _joiner(self, arr: np.ndarray, dtype: np.dtype = None) -> np.ndarray:
+    def _joiner(self, arr: np.ndarray, dtype: Optional[Type[np.generic]] = None) -> np.ndarray:
         """
         Function to concatenate an np.array of strings along a specified axis.
 
@@ -1364,7 +1364,7 @@ class AnchorText(Explainer):
         """
         return self.predictor(samples.tolist()) == self.instance_label
 
-    def explain(self,  # type: ignore
+    def explain(self,  # type: ignore[override]
                 text: str,
                 threshold: float = 0.95,
                 delta: float = 0.1,

--- a/alibi/explainers/backends/cfrl_tabular.py
+++ b/alibi/explainers/backends/cfrl_tabular.py
@@ -3,17 +3,17 @@ This module contains utility functions for the Counterfactual with Reinforcement
 :py:class:`alibi.explainers.cfrl_tabular`, that are common for both Tensorflow and Pytorch backends.
 """
 
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union
+
 import numpy as np
 import pandas as pd  # type: ignore
-from typing import List, Dict, Union, Tuple, Callable, Optional, TYPE_CHECKING
-
-from sklearn.preprocessing import StandardScaler, OneHotEncoder  # type: ignore
-from sklearn.compose import ColumnTransformer  # type: ignore
 from scipy.special import softmax  # type: ignore
+from sklearn.compose import ColumnTransformer  # type: ignore
+from sklearn.preprocessing import OneHotEncoder, StandardScaler  # type: ignore
 
 if TYPE_CHECKING:
-    import torch
     import tensorflow as tf
+    import torch
 
 
 def get_conditional_dim(feature_names: List[str], category_map: Dict[int, List[str]]) -> int:
@@ -193,7 +193,7 @@ def generate_categorical_condition(X_ohe: np.ndarray,
         Conditional vector for categorical feature.
     """
 
-    C_cat = []   # define list of conditional vector for each feature
+    C_cat = []  # define list of conditional vector for each feature
     cat_idx = 0  # categorical feature index
 
     # Split the one-hot representation into a list where each element corresponds to an feature.
@@ -285,7 +285,7 @@ def generate_condition(X_ohe: np.ndarray,
 
 def sample_numerical(X_hat_num_split: List[np.ndarray],
                      X_ohe_num_split: List[np.ndarray],
-                     C_num_split: List[np.ndarray],
+                     C_num_split: Optional[List[np.ndarray]],
                      stats: Dict[int, Dict[str, float]]) -> List[np.ndarray]:
     """
     Samples numerical features according to the conditional vector. This method clips the values between the
@@ -335,7 +335,7 @@ def sample_numerical(X_hat_num_split: List[np.ndarray],
 
 
 def sample_categorical(X_hat_cat_split: List[np.ndarray],
-                       C_cat_split: List[np.ndarray]) -> List[np.ndarray]:
+                       C_cat_split: Optional[List[np.ndarray]]) -> List[np.ndarray]:
     """
     Samples categorical features according to the conditional vector. This method sample conditional according to
     the masking vector the most probable outcome.
@@ -425,7 +425,7 @@ def sample(X_hat_split: List[np.ndarray],
 def get_he_preprocessor(X: np.ndarray,
                         feature_names: List[str],
                         category_map: Dict[int, List[str]],
-                        feature_types: Dict[str, type] = None
+                        feature_types: Optional[Dict[str, type]] = None
                         ) -> Tuple[Callable[[np.ndarray], np.ndarray], Callable[[np.ndarray], np.ndarray]]:
     """
     Heterogeneous dataset preprocessor. The numerical features are standardized and the categorical features
@@ -506,7 +506,7 @@ def get_he_preprocessor(X: np.ndarray,
 
         np_X_inv = np_X_inv[:, inv_perm].astype(object)
         for i, fn in enumerate(feature_names):
-            type = feature_types[fn] if fn in feature_types else float
+            type = feature_types[fn] if fn in feature_types else float  # type: ignore # TODO: closure resets type info?
             np_X_inv[:, i] = np_X_inv[:, i].astype(type)
 
         return np_X_inv
@@ -557,8 +557,8 @@ def get_numerical_conditional_vector(X: np.ndarray,
                                      feature_names: List[str],
                                      category_map: Dict[int, List[str]],
                                      stats: Dict[int, Dict[str, float]],
-                                     ranges: Dict[str, List[float]] = None,
-                                     immutable_features: List[str] = None,
+                                     ranges: Optional[Dict[str, List[float]]] = None,
+                                     immutable_features: Optional[List[str]] = None,
                                      diverse=False) -> List[np.ndarray]:
     """
     Generates a conditional vector. The condition is expressed a a delta change of the feature.
@@ -674,7 +674,7 @@ def get_categorical_conditional_vector(X: np.ndarray,
                                        preprocessor: Callable[[np.ndarray], np.ndarray],
                                        feature_names: List[str],
                                        category_map: Dict[int, List[str]],
-                                       immutable_features: List[str] = None,
+                                       immutable_features: Optional[List[str]] = None,
                                        diverse=False) -> List[np.ndarray]:
     """
     Generates a conditional vector. The condition is expressed a a delta change of the feature.
@@ -753,8 +753,8 @@ def get_conditional_vector(X: np.ndarray,
                            feature_names: List[str],
                            category_map: Dict[int, List[str]],
                            stats: Dict[int, Dict[str, float]],
-                           ranges: Dict[str, List[float]] = None,
-                           immutable_features: List[str] = None,
+                           ranges: Optional[Dict[str, List[float]]] = None,
+                           immutable_features: Optional[List[str]] = None,
                            diverse=False) -> np.ndarray:
     """
     Generates a conditional vector. The condition is expressed a a delta change of the feature.

--- a/alibi/explainers/backends/cfrl_tabular.py
+++ b/alibi/explainers/backends/cfrl_tabular.py
@@ -6,10 +6,10 @@ This module contains utility functions for the Counterfactual with Reinforcement
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
-import pandas as pd  # type: ignore
-from scipy.special import softmax  # type: ignore
-from sklearn.compose import ColumnTransformer  # type: ignore
-from sklearn.preprocessing import OneHotEncoder, StandardScaler  # type: ignore
+import pandas as pd
+from scipy.special import softmax
+from sklearn.compose import ColumnTransformer
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
 
 if TYPE_CHECKING:
     import tensorflow as tf
@@ -506,7 +506,7 @@ def get_he_preprocessor(X: np.ndarray,
 
         np_X_inv = np_X_inv[:, inv_perm].astype(object)
         for i, fn in enumerate(feature_names):
-            type = feature_types[fn] if fn in feature_types else float  # type: ignore # TODO: closure resets type info?
+            type = feature_types[fn] if fn in feature_types else float  # type: ignore[index,operator]
             np_X_inv[:, i] = np_X_inv[:, i].astype(type)
 
         return np_X_inv

--- a/alibi/explainers/backends/pytorch/cfrl_base.py
+++ b/alibi/explainers/backends/pytorch/cfrl_base.py
@@ -63,10 +63,6 @@ class PtCounterfactualRLDataset(CounterfactualRLDataset, Dataset):
                                         batch_size=self.batch_size)
 
         # Define number of classes for classification & minimum and maximum labels for regression
-        self.num_classes: int
-        self.min_m: float
-        self.max_m: float
-
         if self.Y_m.shape[1] > 1:
             self.num_classes = self.Y_m.shape[1]
         else:
@@ -462,24 +458,24 @@ def update_actor_critic(encoder: nn.Module,
     losses: Dict[str, float] = dict()
 
     # Transform data to tensors and it device
-    X = torch.tensor(X).float().to(device)                                  # type: ignore
-    X_cf = torch.tensor(X_cf).float().to(device)                            # type: ignore
-    Z = torch.tensor(Z).float().to(device)                                  # type: ignore
-    Z_cf_tilde = torch.tensor(Z_cf_tilde).float().to(device)                # type: ignore
-    Y_m = torch.tensor(Y_m).float().to(device)                              # type: ignore
-    Y_t = torch.tensor(Y_t).float().to(device)                              # type: ignore
-    C = torch.tensor(C).float().to(device) if (C is not None) else None     # type: ignore
-    R_tilde = torch.tensor(R_tilde).float().to(device)                      # type: ignore
+    X = torch.tensor(X).float().to(device)  # type: ignore
+    X_cf = torch.tensor(X_cf).float().to(device)  # type: ignore
+    Z = torch.tensor(Z).float().to(device)  # type: ignore
+    Z_cf_tilde = torch.tensor(Z_cf_tilde).float().to(device)  # type: ignore
+    Y_m = torch.tensor(Y_m).float().to(device)  # type: ignore
+    Y_t = torch.tensor(Y_t).float().to(device)  # type: ignore
+    C = torch.tensor(C).float().to(device) if (C is not None) else None  # type: ignore
+    R_tilde = torch.tensor(R_tilde).float().to(device)  # type: ignore
 
     # Define state by concatenating the input embedding, the classification label, the target label, and optionally
     # the conditional vector if exists.
     state = [Z, Y_m, Y_t] + ([C] if (C is not None) else [])  # type: ignore
-    state = torch.cat(state, dim=1).to(device)                # type: ignore
+    state = torch.cat(state, dim=1).to(device)  # type: ignore
 
     # Define input for critic, compute q-values and append critic's loss.
     input_critic = torch.cat([state, Z_cf_tilde], dim=1).float()  # type: ignore
-    output_critic = critic(input_critic).squeeze(1)               # type: ignore
-    loss_critic = F.mse_loss(output_critic, R_tilde)              # type: ignore
+    output_critic = critic(input_critic).squeeze(1)  # type: ignore
+    loss_critic = F.mse_loss(output_critic, R_tilde)  # type: ignore
     losses.update({"critic_loss": loss_critic.item()})
 
     # Update critic by gradient step.

--- a/alibi/explainers/backends/pytorch/cfrl_base.py
+++ b/alibi/explainers/backends/pytorch/cfrl_base.py
@@ -63,9 +63,9 @@ class PtCounterfactualRLDataset(CounterfactualRLDataset, Dataset):
                                         batch_size=self.batch_size)
 
         # Define number of classes for classification & minimum and maximum labels for regression
-        self.num_classes: Optional[int] = None
-        self.min_m: Optional[float] = None
-        self.max_m: Optional[float] = None
+        self.num_classes: int
+        self.min_m: float
+        self.max_m: float
 
         if self.Y_m.shape[1] > 1:
             self.num_classes = self.Y_m.shape[1]
@@ -80,7 +80,7 @@ class PtCounterfactualRLDataset(CounterfactualRLDataset, Dataset):
         return self.X.shape[0]
 
     def __getitem__(self, idx) -> Dict[str, np.ndarray]:
-        if self.num_classes is not None:
+        if hasattr(self, 'num_classes'):
             # Generate random target for classification task
             tgt = np.random.randint(low=0, high=self.num_classes, size=1)
             Y_t = np.zeros(self.num_classes)

--- a/alibi/explainers/backends/tensorflow/cfrl_base.py
+++ b/alibi/explainers/backends/tensorflow/cfrl_base.py
@@ -65,10 +65,6 @@ class TfCounterfactualRLDataset(CounterfactualRLDataset, keras.utils.Sequence):
                                         batch_size=self.batch_size)
 
         # Define number of classes for classification & minimum and maximum labels for regression
-        self.num_classes: int
-        self.max_m: float
-        self.min_m: float
-
         if self.Y_m.shape[1] > 1:
             self.num_classes = self.Y_m.shape[1]
         else:

--- a/alibi/explainers/backends/tensorflow/cfrl_base.py
+++ b/alibi/explainers/backends/tensorflow/cfrl_base.py
@@ -65,9 +65,9 @@ class TfCounterfactualRLDataset(CounterfactualRLDataset, keras.utils.Sequence):
                                         batch_size=self.batch_size)
 
         # Define number of classes for classification & minimum and maximum labels for regression
-        self.num_classes: Optional[int] = None
-        self.max_m: Optional[float] = None
-        self.min_m: Optional[float] = None
+        self.num_classes: int
+        self.max_m: float
+        self.min_m: float
 
         if self.Y_m.shape[1] > 1:
             self.num_classes = self.Y_m.shape[1]
@@ -92,7 +92,7 @@ class TfCounterfactualRLDataset(CounterfactualRLDataset, keras.utils.Sequence):
         return self.X.shape[0] // self.batch_size
 
     def __getitem__(self, idx) -> Dict[str, np.ndarray]:
-        if self.num_classes is not None:
+        if hasattr(self, 'num_classes'):
             # Generate random targets for classification task.
             tgts = np.random.randint(low=0, high=self.num_classes, size=self.batch_size)
             Y_t = np.zeros((self.batch_size, self.num_classes))

--- a/alibi/explainers/cem.py
+++ b/alibi/explainers/cem.py
@@ -1,11 +1,13 @@
-from alibi.api.interfaces import Explainer, Explanation, FitMixin
-from alibi.api.defaults import DEFAULT_META_CEM, DEFAULT_DATA_CEM
 import copy
 import logging
-import numpy as np
 import sys
+from typing import Any, Callable, Optional, Tuple, Union
+
+import numpy as np
 import tensorflow.compat.v1 as tf
-from typing import Any, Callable, Tuple, Union
+
+from alibi.api.defaults import DEFAULT_DATA_CEM, DEFAULT_META_CEM
+from alibi.api.interfaces import Explainer, Explanation, FitMixin
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +22,7 @@ class CEM(Explainer, FitMixin):
                  beta: float = .1,
                  feature_range: tuple = (-1e10, 1e10),
                  gamma: float = 0.,
-                 ae_model: Union[tf.keras.Model] = None,
+                 ae_model: Optional[tf.keras.Model] = None,
                  learning_rate_init: float = 1e-2,
                  max_iterations: int = 1000,
                  c_init: float = 10.,
@@ -28,9 +30,9 @@ class CEM(Explainer, FitMixin):
                  eps: tuple = (1e-3, 1e-3),
                  clip: tuple = (-100., 100.),
                  update_num_grad: int = 1,
-                 no_info_val: Union[float, np.ndarray] = None,
-                 write_dir: str = None,
-                 sess: tf.Session = None) -> None:
+                 no_info_val: Optional[Union[float, np.ndarray]] = None,
+                 write_dir: Optional[str] = None,
+                 sess: Optional[tf.Session] = None) -> None:
         """
         Initialize contrastive explanation method.
         Paper: https://arxiv.org/abs/1802.07623
@@ -652,7 +654,7 @@ class CEM(Explainer, FitMixin):
             best_attack = X - best_attack
         return best_attack, overall_best_grad
 
-    def explain(self, X: np.ndarray, Y: np.ndarray = None, verbose: bool = False) -> Explanation:
+    def explain(self, X: np.ndarray, Y: Optional[np.ndarray] = None, verbose: bool = False) -> Explanation:
         """
         Explain instance and return PP or PN with metadata.
 

--- a/alibi/explainers/cfproto.py
+++ b/alibi/explainers/cfproto.py
@@ -1272,7 +1272,7 @@ class CounterfactualProto(Explainer, FitMixin):
 
     def explain(self,
                 X: np.ndarray,
-                Y: np.ndarray = Optional[np.ndarray] = None,
+                Y: Optional[np.ndarray] = None,
                 target_class: Optional[list] = None,
                 k: Optional[int] = None,
                 k_type: str = 'mean',

--- a/alibi/explainers/cfproto.py
+++ b/alibi/explainers/cfproto.py
@@ -1,17 +1,19 @@
 import copy
 import logging
-import numpy as np
 import sys
-import tensorflow.compat.v1 as tf
-from typing import Any, Callable, Dict, Tuple, Union, Sequence
+from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union
 
+import numpy as np
+import tensorflow.compat.v1 as tf
+
+from alibi.api.defaults import DEFAULT_DATA_CFP, DEFAULT_META_CFP
 from alibi.api.interfaces import Explainer, Explanation, FitMixin
-from alibi.api.defaults import DEFAULT_META_CFP, DEFAULT_DATA_CFP
 from alibi.confidence import TrustScore
 from alibi.utils.discretizer import Discretizer
-from alibi.utils.distance import abdm, mvdm, multidim_scaling
+from alibi.utils.distance import abdm, multidim_scaling, mvdm
 from alibi.utils.gradients import perturb
-from alibi.utils.mapping import ohe_to_ord_shape, ord_to_num, num_to_ord, ohe_to_ord, ord_to_ohe
+from alibi.utils.mapping import (num_to_ord, ohe_to_ord, ohe_to_ord_shape,
+                                 ord_to_num, ord_to_ohe)
 from alibi.utils.tf import argmax_grad, argmin_grad, one_hot_grad, round_grad
 
 logger = logging.getLogger(__name__)
@@ -41,7 +43,7 @@ class CounterfactualProto(Explainer, FitMixin):
                  ae_model: Union[tf.keras.Model] = None,
                  enc_model: Union[tf.keras.Model] = None,
                  theta: float = 0.,
-                 cat_vars: dict = None,
+                 cat_vars: Optional[Dict[int, int]] = None,
                  ohe: bool = False,
                  use_kdtree: bool = False,
                  learning_rate_init: float = 1e-2,
@@ -51,8 +53,8 @@ class CounterfactualProto(Explainer, FitMixin):
                  eps: tuple = (1e-3, 1e-3),
                  clip: tuple = (-1000., 1000.),
                  update_num_grad: int = 1,
-                 write_dir: str = None,
-                 sess: tf.Session = None) -> None:
+                 write_dir: Optional[str] = None,
+                 sess: Optional[tf.Session] = None) -> None:
         """
         Initialize prototypical counterfactual method.
 
@@ -160,6 +162,7 @@ class CounterfactualProto(Explainer, FitMixin):
             self.is_cat = True
         else:
             self.is_cat = False
+            cat_vars = dict()  # to avoid further None checks
         self.meta['params'].update(is_cat=self.is_cat)
 
         self.shape = shape
@@ -182,16 +185,15 @@ class CounterfactualProto(Explainer, FitMixin):
         self.clip = clip
         self.write_dir = write_dir
 
-        # compute dimensionality after conversion from OHE to ordinal encoding
-        shape = ohe_to_ord_shape(shape, cat_vars=cat_vars, is_ohe=self.ohe)
-
         if self.is_cat:
+            # compute dimensionality after conversion from OHE to ordinal encoding
+            shape = ohe_to_ord_shape(shape, cat_vars=cat_vars, is_ohe=self.ohe)
 
             # define ragged tensor for mapping from categorical to numerical values
-            self.map_cat_to_num = tf.ragged.constant([np.zeros(v) for _, v in self.cat_vars.items()])
+            self.map_cat_to_num = tf.ragged.constant([np.zeros(v) for _, v in cat_vars.items()])
 
             # define placeholder for mapping which can be fed after the fit step
-            max_key = max(cat_vars, key=cat_vars.get)
+            max_key = max(cat_vars)
             self.max_cat = cat_vars[max_key]
             cat_keys = list(cat_vars.keys())
             n_cat = len(cat_keys)
@@ -654,9 +656,16 @@ class CounterfactualProto(Explainer, FitMixin):
         else:
             self.writer = None
 
-    def fit(self, train_data: np.ndarray, trustscore_kwargs: dict = None, d_type: str = 'abdm',
-            w: float = None, disc_perc: Sequence[Union[int, float]] = (25, 50, 75), standardize_cat_vars: bool = False,
-            smooth: float = 1., center: bool = True, update_feature_range: bool = True) -> "CounterfactualProto":
+    def fit(self,
+            train_data: np.ndarray,
+            trustscore_kwargs: Optional[dict] = None,
+            d_type: str = 'abdm',
+            w: Optional[float] = None,
+            disc_perc: Sequence[Union[int, float]] = (25, 50, 75),
+            standardize_cat_vars: bool = False,
+            smooth: float = 1.,
+            center: bool = True,
+            update_feature_range: bool = True) -> "CounterfactualProto":
         """
         Get prototypes for each class using the encoder or k-d trees.
         The prototypes are used for the encoder loss term or to calculate the optional trust scores.
@@ -701,7 +710,7 @@ class CounterfactualProto(Explainer, FitMixin):
         else:
             preds = np.argmax(self.predict(train_data), axis=1)
 
-        self.cat_vars_ord = None
+        self.cat_vars_ord = dict()  # type: dict
         if self.is_cat:  # compute distance metrics for categorical variables
 
             if self.ohe:  # convert OHE to ordinal encoding
@@ -734,6 +743,10 @@ class CounterfactualProto(Explainer, FitMixin):
 
             # combined distance measure
             if d_type == 'abdm-mvdm':
+                if w is None:
+                    msg = f"Must specify a value for `w` if using d_type='abdm-mvdm'"
+                    raise ValueError(msg)
+
                 # pairwise distances
                 d_abdm = abdm(train_data_bin, self.cat_vars_ord, cat_vars_bin)
                 d_mvdm = mvdm(train_data_ord, preds, self.cat_vars_ord, alpha=1)  # type: ignore
@@ -826,7 +839,7 @@ class CounterfactualProto(Explainer, FitMixin):
         return loss_attack
 
     def get_gradients(self, X: np.ndarray, Y: np.ndarray, grads_shape: tuple,
-                      cat_vars_ord: dict = None) -> np.ndarray:
+                      cat_vars_ord: dict) -> np.ndarray:
         """
         Compute numerical gradients of the attack loss term:
         dL/dx = (dL/dP)*(dP/dx) with L = loss_attack_s; P = predict; x = adv_s
@@ -854,7 +867,6 @@ class CounterfactualProto(Explainer, FitMixin):
                 X_pred = ord_to_ohe(X_pred, cat_vars_ord)[0]
         else:
             X_pred = X
-
         # N = gradient batch size; F = nb of features; P = nb of prediction classes; B = instance batch size
         # dL/dP -> BxP
         preds = self.predict(X_pred)  # NxP
@@ -933,9 +945,9 @@ class CounterfactualProto(Explainer, FitMixin):
             logger.warning('Need either an encoder or the k-d trees enabled to compute distance scores.')
         return dist_orig / (dist_adv + eps)
 
-    def attack(self, X: np.ndarray, Y: np.ndarray, target_class: list = None, k: int = None, k_type: str = 'mean',
-               threshold: float = 0., verbose: bool = False, print_every: int = 100, log_every: int = 100) \
-            -> Tuple[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+    def attack(self, X: np.ndarray, Y: np.ndarray, target_class: Optional[list] = None, k: Optional[int] = None,
+               k_type: str = 'mean', threshold: float = 0., verbose: bool = False, print_every: int = 100,
+               log_every: int = 100) -> Tuple[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
         """
         Find a counterfactual (CF) for instance X using a fast iterative shrinkage-thresholding algorithm (FISTA).
 
@@ -1005,6 +1017,7 @@ class CounterfactualProto(Explainer, FitMixin):
                 print('Target classes: {}'.format(target_class))
 
         if self.is_cat and self.ohe:  # map categorical to numerical data
+
             X_ord = ohe_to_ord(X, self.cat_vars)[0]
             X_num = ord_to_num(X_ord, self.d_abs)
         elif self.is_cat:
@@ -1045,15 +1058,16 @@ class CounterfactualProto(Explainer, FitMixin):
                 self.class_proto[c] = self.X_by_class[c][idx_c[0][-1]].reshape(1, -1)
 
         if self.enc_or_kdtree:
-            self.id_proto = min(dist_proto, key=dist_proto.get)
+            self.id_proto = min(dist_proto)
             proto_val = self.class_proto[self.id_proto]
             if verbose:
                 print('Prototype class: {}'.format(self.id_proto))
         else:  # no prototype loss term used
             proto_val = np.zeros(self.shape_enc)
 
-        # set shape for perturbed instance and gradients
-        pert_shape = ohe_to_ord_shape(self.shape, cat_vars=self.cat_vars, is_ohe=self.ohe)
+        if self.is_cat:
+            # set shape for perturbed instance and gradients
+            pert_shape = ohe_to_ord_shape(self.shape, cat_vars=self.cat_vars, is_ohe=self.ohe)
 
         # set the lower and upper bounds for the constant 'c' to scale the attack loss term
         # these bounds are updated for each c_step iteration
@@ -1256,9 +1270,16 @@ class CounterfactualProto(Explainer, FitMixin):
 
         return best_attack, overall_best_grad
 
-    def explain(self, X: np.ndarray, Y: np.ndarray = None, target_class: list = None, k: int = None,
-                k_type: str = 'mean', threshold: float = 0., verbose: bool = False,
-                print_every: int = 100, log_every: int = 100) -> Explanation:
+    def explain(self,
+                X: np.ndarray,
+                Y: np.ndarray = Optional[None],
+                target_class: Optional[list] = None,
+                k: Optional[int] = None,
+                k_type: str = 'mean',
+                threshold: float = 0.,
+                verbose: bool = False,
+                print_every: int = 100,
+                log_every: int = 100) -> Explanation:
         """
         Explain instance and return counterfactual with metadata.
 

--- a/alibi/explainers/cfproto.py
+++ b/alibi/explainers/cfproto.py
@@ -1065,9 +1065,8 @@ class CounterfactualProto(Explainer, FitMixin):
         else:  # no prototype loss term used
             proto_val = np.zeros(self.shape_enc)
 
-        if self.is_cat:
-            # set shape for perturbed instance and gradients
-            pert_shape = ohe_to_ord_shape(self.shape, cat_vars=self.cat_vars, is_ohe=self.ohe)
+        # set shape for perturbed instance and gradients
+        pert_shape = ohe_to_ord_shape(self.shape, cat_vars=self.cat_vars, is_ohe=self.ohe)
 
         # set the lower and upper bounds for the constant 'c' to scale the attack loss term
         # these bounds are updated for each c_step iteration

--- a/alibi/explainers/cfproto.py
+++ b/alibi/explainers/cfproto.py
@@ -1272,7 +1272,7 @@ class CounterfactualProto(Explainer, FitMixin):
 
     def explain(self,
                 X: np.ndarray,
-                Y: np.ndarray = Optional[None],
+                Y: np.ndarray = Optional[np.ndarray] = None,
                 target_class: Optional[list] = None,
                 k: Optional[int] = None,
                 k_type: str = 'mean',

--- a/alibi/explainers/cfproto.py
+++ b/alibi/explainers/cfproto.py
@@ -744,7 +744,7 @@ class CounterfactualProto(Explainer, FitMixin):
             # combined distance measure
             if d_type == 'abdm-mvdm':
                 if w is None:
-                    msg = f"Must specify a value for `w` if using d_type='abdm-mvdm'"
+                    msg = "Must specify a value for `w` if using d_type='abdm-mvdm'"
                     raise ValueError(msg)
 
                 # pairwise distances

--- a/alibi/explainers/cfrl_base.py
+++ b/alibi/explainers/cfrl_base.py
@@ -2,7 +2,7 @@ import logging
 import os
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Union, cast
 
 import numpy as np
 from tqdm import tqdm  # type: ignore
@@ -79,7 +79,6 @@ class ReplayBuffer:
     Y_t: np.ndarray  # buffer for the counterfactual targets
     Z: np.ndarray  # buffer for the input embedding
     Z_cf_tilde: np.ndarray  # buffer for the noised counterfactual embedding
-    C: np.ndarray  # buffer for the conditional tensor
     R_tilde: np.ndarray  # buffer for the noised counterfactual reward tensor
 
     def __init__(self, size: int = 1000) -> None:
@@ -97,6 +96,7 @@ class ReplayBuffer:
         self.len = 0  # current length of the buffer
         self.size = size  # buffer's maximum capacity
         self.batch_size = 0  # batch size (inferred during `append`)
+        self.C: Optional[np.ndarray] = None  # buffer for the conditional tensor
 
     def append(self,
                X: np.ndarray,
@@ -160,6 +160,7 @@ class ReplayBuffer:
         self.R_tilde[start:start + self.batch_size] = R_tilde
 
         if C is not None:
+            self.C = cast(np.ndarray, self.C)  # helping mypy out as self.C cannot be None at this point
             self.C[start:start + self.batch_size] = C
 
         # Compute the next index. Not that if the buffer reached its maximum capacity, for the next iteration

--- a/alibi/explainers/cfrl_tabular.py
+++ b/alibi/explainers/cfrl_tabular.py
@@ -1,17 +1,20 @@
-from alibi.api.interfaces import Explainer, Explanation
-from alibi.utils.frameworks import has_pytorch, has_tensorflow
-from alibi.explainers.cfrl_base import CounterfactualRL, Postprocessing, _PARAM_TYPES
-from alibi.explainers.backends.cfrl_tabular import sample, get_conditional_vector, get_statistics
+from functools import partial
+from itertools import count
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 from tqdm import tqdm
-from itertools import count
-from functools import partial
-from typing import Tuple, List, Dict, Callable, Union, Optional, TYPE_CHECKING
+
+from alibi.api.interfaces import Explainer, Explanation
+from alibi.explainers.backends.cfrl_tabular import (get_conditional_vector,
+                                                    get_statistics, sample)
+from alibi.explainers.cfrl_base import (_PARAM_TYPES, CounterfactualRL,
+                                        Postprocessing)
+from alibi.utils.frameworks import has_pytorch, has_tensorflow
 
 if TYPE_CHECKING:
-    import torch
     import tensorflow
+    import torch
 
 if has_pytorch:
     # import pytorch backend
@@ -29,7 +32,7 @@ class SampleTabularPostprocessing(Postprocessing):
     is required to perform the conditional sampling.
     """
 
-    def __init__(self,  category_map: Dict[int, List[str]], stats: Dict[int, Dict[str, float]]):
+    def __init__(self, category_map: Dict[int, List[str]], stats: Dict[int, Dict[str, float]]):
         """
         Constructor.
 
@@ -462,7 +465,7 @@ class CounterfactualRLTabular(CounterfactualRL):
             X_cf, Y_m_cf, Y_t = results["X_cf"], results["Y_m_cf"], results["Y_t"]
 
             # Select only counterfactuals where prediction matches the target.
-            X_cf = X_cf[Y_t == Y_m_cf]
+            X_cf = X_cf[Y_t == Y_m_cf]  # type: ignore # TODO: fix me
             if X_cf.shape[0] == 0:
                 continue
 

--- a/alibi/explainers/cfrl_tabular.py
+++ b/alibi/explainers/cfrl_tabular.py
@@ -1,6 +1,6 @@
 from functools import partial
 from itertools import count
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union, cast
 
 import numpy as np
 from tqdm import tqdm
@@ -276,9 +276,9 @@ class CounterfactualRLTabular(CounterfactualRL):
         # call base class fit
         return super().fit(X)
 
-    def explain(self,
+    def explain(self,  # type: ignore[override]
                 X: np.ndarray,
-                Y_t: np.ndarray = None,  # TODO remove default value (mypy error)
+                Y_t: np.ndarray,
                 C: Optional[List[Dict[str, List[Union[str, float]]]]] = None,
                 batch_size: int = 100,
                 diversity: bool = False,
@@ -462,10 +462,13 @@ class CounterfactualRLTabular(CounterfactualRL):
 
             # Generate counterfactuals.
             results = self._compute_counterfactual(X=X_repeated, Y_t=Y_t, C=C_vec)
-            X_cf, Y_m_cf, Y_t = results["X_cf"], results["Y_m_cf"], results["Y_t"]
+            X_cf, Y_m_cf, Y_t = results["X_cf"], results["Y_m_cf"], results["Y_t"]  # type: ignore[assignment]
+            X_cf = cast(np.ndarray, X_cf)  # help mypy out
 
             # Select only counterfactuals where prediction matches the target.
-            X_cf = X_cf[Y_t == Y_m_cf]  # type: ignore # TODO: fix me
+            X_cf = X_cf[Y_t == Y_m_cf]
+            X_cf = cast(np.ndarray, X_cf)  # help mypy out
+
             if X_cf.shape[0] == 0:
                 continue
 
@@ -497,4 +500,4 @@ class CounterfactualRLTabular(CounterfactualRL):
         if self._is_classification(Y_t):
             Y_t = np.argmax(Y_t, axis=1)
 
-        return self._build_explanation(X=X, Y_m=Y_m, X_cf=X_cf, Y_m_cf=Y_m_cf, Y_t=Y_t, C=C)
+        return self._build_explanation(X=X, Y_m=Y_m, X_cf=X_cf, Y_m_cf=Y_m_cf, Y_t=Y_t, C=C)  # type: ignore[arg-type]

--- a/alibi/explainers/counterfactual.py
+++ b/alibi/explainers/counterfactual.py
@@ -1,11 +1,12 @@
 import copy
-import numpy as np
-from typing import Callable, Optional, Tuple, Union
-import tensorflow.compat.v1 as tf
 import logging
+from typing import Callable, Optional, Tuple, Union
 
+import numpy as np
+import tensorflow.compat.v1 as tf
+
+from alibi.api.defaults import DEFAULT_DATA_CF, DEFAULT_META_CF
 from alibi.api.interfaces import Explainer, Explanation
-from alibi.api.defaults import DEFAULT_META_CF, DEFAULT_DATA_CF
 from alibi.utils.gradients import num_grad_batch
 
 logger = logging.getLogger(__name__)
@@ -90,9 +91,9 @@ class Counterfactual(Explainer):
                  eps: Union[float, np.ndarray] = 0.01,  # feature-wise epsilons
                  init: str = 'identity',
                  decay: bool = True,
-                 write_dir: str = None,
+                 write_dir: Optional[str] = None,
                  debug: bool = False,
-                 sess: tf.Session = None) -> None:
+                 sess: Optional[tf.Session] = None) -> None:
         """
         Initialize counterfactual explanation method based on Wachter et al. (2017)
 

--- a/alibi/explainers/integrated_gradients.py
+++ b/alibi/explainers/integrated_gradients.py
@@ -777,8 +777,8 @@ class IntegratedGradients(Explainer):
     def explain(self,
                 X: Union[np.ndarray, List[np.ndarray]],
                 forward_kwargs: Optional[dict] = None,
-                baselines: Union[int, float, np.ndarray, List[int], List[float], List[np.ndarray]] = None,
-                target: Union[int, list, np.ndarray] = None,
+                baselines: Optional[Union[int, float, np.ndarray, List[int], List[float], List[np.ndarray]]] = None,
+                target: Optional[Union[int, list, np.ndarray]] = None,
                 attribute_to_layer_inputs: bool = False) -> Explanation:
         """Calculates the attributions for each input feature or element of layer and
         returns an Explanation object.
@@ -865,7 +865,7 @@ class IntegratedGradients(Explainer):
         # defining integral method
         step_sizes_func, alphas_func = approximation_parameters(self.method)
         step_sizes, alphas = step_sizes_func(self.n_steps), alphas_func(self.n_steps)
-        target = _format_target(target, nb_samples)
+        target = _format_target(target, nb_samples)  # type: ignore[assignment]
 
         if self._is_list:
             X = cast(List[np.ndarray], X)  # help mypy out
@@ -876,12 +876,12 @@ class IntegratedGradients(Explainer):
                 inputs = [tf.keras.Input(shape=xx.shape[1:], dtype=xx.dtype) for xx in X]
                 self.model(inputs, **forward_kwargs)
 
-            _validate_output(self.model, target)
+            _validate_output(self.model, target)  # type: ignore[arg-type]
 
             if self.layer is None:
                 # No layer passed, attributions computed with respect to the inputs
                 attributions = self._compute_attributions_list_input(X,
-                                                                     baselines,  # type: ignore # TODO: validate/narrow
+                                                                     baselines,  # type: ignore[arg-type]
                                                                      target,
                                                                      step_sizes,
                                                                      alphas,
@@ -892,10 +892,10 @@ class IntegratedGradients(Explainer):
             else:
                 # forwad inputs and  baselines
                 X_layer, baselines_layer = _forward_input_baseline(X,
-                                                                   baselines,  # type: ignore # TODO: validate/narrow
+                                                                   baselines,  # type: ignore[arg-type]
                                                                    self.model,
                                                                    self.layer,
-                                                                   self.orig_call,  # type: ignore # TODO: fix me
+                                                                   self.orig_call,  # type: ignore[arg-type]
                                                                    forward_kwargs=forward_kwargs,
                                                                    forward_to_inputs=attribute_to_layer_inputs)
 
@@ -939,10 +939,10 @@ class IntegratedGradients(Explainer):
             else:
                 # forwad inputs and  baselines
                 X_layer, baselines_layer = _forward_input_baseline(X,
-                                                                   baselines,  # type: ignore # TODO: validate/narrow
+                                                                   baselines,  # type: ignore[arg-type]
                                                                    self.model,
                                                                    self.layer,
-                                                                   self.orig_call,  # type: ignore # TODO: fix me
+                                                                   self.orig_call,  # type: ignore[arg-type]
                                                                    forward_kwargs=forward_kwargs,
                                                                    forward_to_inputs=attribute_to_layer_inputs)
 
@@ -968,7 +968,7 @@ class IntegratedGradients(Explainer):
         deltas = _compute_convergence_delta(self.model,
                                             input_dtypes,
                                             attributions,
-                                            baselines,  # type: ignore # TODO: validate/narrow
+                                            baselines,  # type: ignore[arg-type]
                                             X,
                                             forward_kwargs,
                                             target,
@@ -977,7 +977,7 @@ class IntegratedGradients(Explainer):
         return self.build_explanation(
             X=X,
             forward_kwargs=forward_kwargs,
-            baselines=baselines,  # type: ignore # TODO: validate/narrow
+            baselines=baselines,  # type: ignore[arg-type]
             target=target,
             attributions=attributions,
             deltas=deltas
@@ -995,7 +995,7 @@ class IntegratedGradients(Explainer):
         data = copy.deepcopy(DEFAULT_DATA_INTGRAD)
         predictions = self.model(X, **forward_kwargs).numpy()
         if isinstance(attributions[0], tf.Tensor):
-            attributions = [attr.numpy() for attr in attributions]  # type: ignore # TODO: cast didn't work here
+            attributions = [attr.numpy() for attr in attributions]  # type: ignore[union-attr]
         data.update(X=X,
                     forward_kwargs=forward_kwargs,
                     baselines=baselines,
@@ -1110,8 +1110,8 @@ class IntegratedGradients(Explainer):
             else:
                 grads_b = _gradients_layer(self.model,
                                            self.layer,
-                                           self.orig_call,  # type: ignore # TODO: fix me
-                                           self.orig_dummy_input,
+                                           self.orig_call,  # type: ignore[arg-type]
+                                           self.orig_dummy_input,  # type: ignore[arg-type]
                                            paths_b,
                                            target_b,
                                            forward_kwargs=kwargs_b,
@@ -1224,8 +1224,8 @@ class IntegratedGradients(Explainer):
             else:
                 grads_b = _gradients_layer(self.model,
                                            self.layer,
-                                           self.orig_call,  # type: ignore # TODO: fix me
-                                           self.orig_dummy_input,
+                                           self.orig_call,  # type: ignore[arg-type]
+                                           self.orig_dummy_input,  # type: ignore[arg-type]
                                            paths_b,
                                            target_b,
                                            forward_kwargs=kwargs_b,

--- a/alibi/explainers/integrated_gradients.py
+++ b/alibi/explainers/integrated_gradients.py
@@ -751,8 +751,8 @@ class IntegratedGradients(Explainer):
             self._has_inputs = True
 
         if layer is None:
-            self.orig_call = None
-            layer_num = 0
+            self.orig_call: Optional[Callable] = None
+            layer_num: Optional[int] = 0
         else:
             self.orig_call = layer.call
             try:
@@ -895,7 +895,7 @@ class IntegratedGradients(Explainer):
                                                                    baselines,  # type: ignore # TODO: validate/narrow
                                                                    self.model,
                                                                    self.layer,
-                                                                   self.orig_call,
+                                                                   self.orig_call,  # type: ignore # TODO: fix me
                                                                    forward_kwargs=forward_kwargs,
                                                                    forward_to_inputs=attribute_to_layer_inputs)
 
@@ -942,7 +942,7 @@ class IntegratedGradients(Explainer):
                                                                    baselines,  # type: ignore # TODO: validate/narrow
                                                                    self.model,
                                                                    self.layer,
-                                                                   self.orig_call,
+                                                                   self.orig_call,  # type: ignore # TODO: fix me
                                                                    forward_kwargs=forward_kwargs,
                                                                    forward_to_inputs=attribute_to_layer_inputs)
 
@@ -1061,7 +1061,7 @@ class IntegratedGradients(Explainer):
 
         if forward_kwargs:
             paths_kwargs = {k: np.concatenate([forward_kwargs[k] for _ in range(self.n_steps)], axis=0)
-                            for k in forward_kwargs.keys()}
+                            for k in forward_kwargs.keys()}  # type: Optional[dict]
         else:
             paths_kwargs = None
 
@@ -1110,7 +1110,7 @@ class IntegratedGradients(Explainer):
             else:
                 grads_b = _gradients_layer(self.model,
                                            self.layer,
-                                           self.orig_call,
+                                           self.orig_call,  # type: ignore # TODO: fix me
                                            self.orig_dummy_input,
                                            paths_b,
                                            target_b,
@@ -1177,7 +1177,7 @@ class IntegratedGradients(Explainer):
 
         if forward_kwargs:
             paths_kwargs = {k: np.concatenate([forward_kwargs[k] for _ in range(self.n_steps)], axis=0)
-                            for k in forward_kwargs.keys()}
+                            for k in forward_kwargs.keys()}  # type: Optional[dict]
         else:
             paths_kwargs = None
 
@@ -1224,7 +1224,7 @@ class IntegratedGradients(Explainer):
             else:
                 grads_b = _gradients_layer(self.model,
                                            self.layer,
-                                           self.orig_call,
+                                           self.orig_call,  # type: ignore # TODO: fix me
                                            self.orig_dummy_input,
                                            paths_b,
                                            target_b,

--- a/alibi/explainers/shap_wrappers.py
+++ b/alibi/explainers/shap_wrappers.py
@@ -740,7 +740,7 @@ class KernelShap(Explainer, FitMixin):
         if not self.use_groups:
             group_names, groups = None, None
         else:
-            self.feature_names = group_names  # type:ignore # TODO: fix me
+            self.feature_names = group_names  # type: ignore[assignment]
 
         # perform grouping if requested by the user
         self.background_data = self._get_data(background_data, group_names, groups, weights, **kwargs)
@@ -1095,7 +1095,7 @@ class TreeShap(Explainer, FitMixin):
         self._update_metadata({"task": self.task})
         self._update_metadata({"model_output": self.model_output}, params=True)
 
-    def fit(self,  # type: ignore
+    def fit(self,  # type: ignore[override]
             background_data: Union[np.ndarray, pd.DataFrame, None] = None,
             summarise_background: Union[bool, str] = False,
             n_background_samples: int = TREE_SHAP_BACKGROUND_WARNING_THRESHOLD,

--- a/alibi/explainers/shap_wrappers.py
+++ b/alibi/explainers/shap_wrappers.py
@@ -1,22 +1,24 @@
 import copy
 import logging
-import shap
+from functools import partial
+from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional,
+                    Sequence, Tuple, Union)
 
 import numpy as np
 import pandas as pd
-
-from alibi.api.defaults import DEFAULT_META_KERNEL_SHAP, DEFAULT_DATA_KERNEL_SHAP, DEFAULT_META_TREE_SHAP, \
-    DEFAULT_DATA_TREE_SHAP
-from alibi.api.interfaces import Explanation, Explainer, FitMixin
-from alibi.utils.wrappers import methdispatch
-from alibi.utils.distributed import DistributedExplainer
-from functools import partial
+import shap
+import shap.utils._legacy as shap_utils
 from scipy import sparse
 from scipy.special import expit
 from shap import KernelExplainer
-from typing import Any, Callable, Dict, List, Optional, Sequence, Union, Tuple, TYPE_CHECKING
 
-import shap.utils._legacy as shap_utils
+from alibi.api.defaults import (DEFAULT_DATA_KERNEL_SHAP,
+                                DEFAULT_DATA_TREE_SHAP,
+                                DEFAULT_META_KERNEL_SHAP,
+                                DEFAULT_META_TREE_SHAP)
+from alibi.api.interfaces import Explainer, Explanation, FitMixin
+from alibi.utils.distributed import DistributedExplainer
+from alibi.utils.wrappers import methdispatch
 
 if TYPE_CHECKING:
     import catboost  # noqa F401
@@ -275,14 +277,16 @@ class KernelExplainerWrapper(KernelExplainer):
 
 
 class KernelShap(Explainer, FitMixin):
+    # object that implements the explanation algorithm (set in fit)
+    _explainer: Union[KernelExplainerWrapper, DistributedExplainer]
 
     def __init__(self,
                  predictor: Callable[[np.ndarray], np.ndarray],
                  link: str = 'identity',
-                 feature_names: Union[List[str], Tuple[str], None] = None,
+                 feature_names: Optional[Union[List[str], Tuple[str]]] = None,
                  categorical_names: Optional[Dict[int, List[str]]] = None,
                  task: str = 'classification',
-                 seed: int = None,
+                 seed: Optional[int] = None,
                  distributed_opts: Optional[Dict] = None
                  ):
         """
@@ -359,8 +363,6 @@ class KernelShap(Explainer, FitMixin):
             self.distributed_opts.update(distributed_opts)
         self.distributed_opts['algorithm'] = 'kernel_shap'
         self.distribute = True if self.distributed_opts['n_cpus'] else False
-        # object that implements the explanation algorithm (set in fit)
-        self._explainer = None  # type: Union[KernelExplainerWrapper, DistributedExplainer]
 
     def _check_inputs(self,
                       background_data: Union[shap_utils.Data, pd.DataFrame, np.ndarray, sparse.spmatrix],
@@ -730,7 +732,7 @@ class KernelShap(Explainer, FitMixin):
 
         # check user inputs to provide warnings if input is incorrect
         self._check_inputs(background_data, group_names, groups, weights)
-        if self.create_group_names:
+        if self.create_group_names and groups:
             group_names = ['group_{}'.format(i) for i in range(len(groups))]
         # disable grouping or data weights if inputs are not correct
         if self.ignore_weights:
@@ -738,12 +740,12 @@ class KernelShap(Explainer, FitMixin):
         if not self.use_groups:
             group_names, groups = None, None
         else:
-            self.feature_names = group_names
+            self.feature_names = group_names  # type:ignore # TODO: fix me
 
         # perform grouping if requested by the user
         self.background_data = self._get_data(background_data, group_names, groups, weights, **kwargs)
         explainer_args = (self.predictor, self.background_data)
-        explainer_kwargs = {'link': self.link}  # type: Dict[str, Union[str, int]]
+        explainer_kwargs = {'link': self.link}  # type: Dict[str, Union[str, int, None]]
         # distribute computation
         if self.distribute:
             # set seed for each process
@@ -780,8 +782,8 @@ class KernelShap(Explainer, FitMixin):
     def explain(self,
                 X: Union[np.ndarray, pd.DataFrame, sparse.spmatrix],
                 summarise_result: bool = False,
-                cat_vars_start_idx: Sequence[int] = None,
-                cat_vars_enc_dim: Sequence[int] = None,
+                cat_vars_start_idx: Optional[Sequence[int]] = None,
+                cat_vars_enc_dim: Optional[Sequence[int]] = None,
                 **kwargs) -> Explanation:
         """
         Explains the instances in the array `X`.
@@ -998,10 +1000,10 @@ class TreeShap(Explainer, FitMixin):
     def __init__(self,
                  predictor: Any,
                  model_output: str = 'raw',
-                 feature_names: Union[List[str], Tuple[str], None] = None,
+                 feature_names: Optional[Union[List[str], Tuple[str]]] = None,
                  categorical_names: Optional[Dict[int, List[str]]] = None,
                  task: str = 'classification',
-                 seed: int = None):
+                 seed: Optional[int] = None):
         """
         A wrapper around the `shap.TreeExplainer` class. It adds the following functionality:
 

--- a/alibi/explainers/tests/test_anchor_tabular.py
+++ b/alibi/explainers/tests/test_anchor_tabular.py
@@ -218,6 +218,13 @@ def test_sampler(test_instance_idx, anchors, nb_samples, dataset, rf_classifier,
     test_dataset = dataset
     test_dataset_name = test_dataset['metadata']['name']
 
+    # the `explain` call does some more sampler setup before using it so we need to repeat it here
+    sampler = explainer.samplers[0]
+    sampler.set_instance_label(X_test[test_instance_idx])
+    # TODO: the test passes now, but we're not setting other things passed to `explain` like `n_covered_ex`
+    #  or calling explainer._build_sampling_lookups. This suggests either the coupling between `sampler` and
+    #  `explainer` is too strong or this test should be re-written in a different way.
+
     # test sampler setup is correct
     assert len(explainer.samplers) == 1
     sampler = explainer.samplers[0]

--- a/alibi/explainers/tests/test_cfproto.py
+++ b/alibi/explainers/tests/test_cfproto.py
@@ -78,7 +78,7 @@ def test_tf_keras_iris_explainer(disable_tf2, iris_data, tf_keras_iris_explainer
     y = np.zeros((1, cf.classes))
     np.put(y, pred_class, 1)
     cf.predict = cf.predict.predict  # make model black box
-    grads = cf.get_gradients(x, y, x.shape[1:])
+    grads = cf.get_gradients(x, y, x.shape[1:], cf.cat_vars_ord)
     assert grads.shape == x.shape
 
 

--- a/alibi/models/pytorch/model.py
+++ b/alibi/models/pytorch/model.py
@@ -49,7 +49,7 @@ class Model(nn.Module):
 
         if isinstance(loss, list):
             # check if the number of weights is the same as the number of partial losses
-            if len(loss_weights) != len(loss):
+            if len(self.loss_weights) != len(loss):
                 raise ValueError("The number of loss weights differs from the number of losses")
 
             self.loss = []

--- a/alibi/saving.py
+++ b/alibi/saving.py
@@ -165,7 +165,7 @@ def _save_AnchorImage(explainer: 'AnchorImage', path: Union[str, os.PathLike]) -
         dill.dump(segmentation_fn, f, recurse=True)
 
     predictor = explainer.predictor
-    explainer.predictor = None
+    explainer.predictor = None  # type: ignore
     with open(Path(path, 'explainer.dill'), 'wb') as f:
         dill.dump(explainer, f, recurse=True)
     explainer.segmentation_fn = segmentation_fn
@@ -216,8 +216,8 @@ def _save_AnchorText(explainer: 'AnchorText', path: Union[str, os.PathLike]) -> 
     dir_name = 'nlp' if sampling_strategy in nlp_sampling else 'language_model'
     model.to_disk(Path(path, dir_name))
 
-    explainer.model = None
-    explainer.predictor = None
+    explainer.model = None  # type: ignore
+    explainer.predictor = None  # type: ignore
     explainer.perturbation = None
 
     with open(Path(path, 'explainer.dill'), 'wb') as f:
@@ -257,7 +257,7 @@ def _save_CounterfactualRL(explainer: 'CounterfactualRL', path: Union[str, os.Pa
 
     # save actor
     actor = explainer.params["actor"]
-    optimizer_actor = explainer.params["optimizer_actor"]    # TODO: save the actor optimizer?
+    optimizer_actor = explainer.params["optimizer_actor"]  # TODO: save the actor optimizer?
     backend.save_model(path=Path(path, "actor" + ext), model=explainer.params["actor"])
 
     # save critic

--- a/alibi/saving.py
+++ b/alibi/saving.py
@@ -103,11 +103,11 @@ def save_explainer(explainer: 'Explainer', path: Union[str, os.PathLike]) -> Non
 
 
 def _simple_save(explainer: 'Explainer', path: Union[str, os.PathLike]) -> None:
-    predictor = explainer.predictor  # type: ignore
-    explainer.predictor = None  # type: ignore
+    predictor = explainer.predictor  # type: ignore[attr-defined] # TODO: declare this in the Explainer interface
+    explainer.predictor = None  # type: ignore[attr-defined]
     with open(Path(path, 'explainer.dill'), 'wb') as f:
         dill.dump(explainer, f, recurse=True)
-    explainer.predictor = predictor  # type: ignore
+    explainer.predictor = predictor  # type: ignore[attr-defined]
 
 
 def _simple_load(path: Union[str, os.PathLike], predictor, meta) -> 'Explainer':
@@ -165,7 +165,7 @@ def _save_AnchorImage(explainer: 'AnchorImage', path: Union[str, os.PathLike]) -
         dill.dump(segmentation_fn, f, recurse=True)
 
     predictor = explainer.predictor
-    explainer.predictor = None  # type: ignore
+    explainer.predictor = None  # type: ignore[assignment]
     with open(Path(path, 'explainer.dill'), 'wb') as f:
         dill.dump(explainer, f, recurse=True)
     explainer.segmentation_fn = segmentation_fn
@@ -216,8 +216,8 @@ def _save_AnchorText(explainer: 'AnchorText', path: Union[str, os.PathLike]) -> 
     dir_name = 'nlp' if sampling_strategy in nlp_sampling else 'language_model'
     model.to_disk(Path(path, dir_name))
 
-    explainer.model = None  # type: ignore
-    explainer.predictor = None  # type: ignore
+    explainer.model = None  # type: ignore[assignment]
+    explainer.predictor = None  # type: ignore[assignment]
     explainer.perturbation = None
 
     with open(Path(path, 'explainer.dill'), 'wb') as f:

--- a/alibi/tests/utils.py
+++ b/alibi/tests/utils.py
@@ -16,17 +16,18 @@ class MockPredictor:
     def __init__(self,
                  out_dim: int,
                  out_type: str = 'proba',
-                 model_type: Optional[str] = None,
                  seed: Optional[int] = None,
                  ) -> None:
         """
         Parameters
         ----------
-            out_dim
-                The number of output classes.
-            out_type
-                Indicates if probabilities, class predictions or continuous outputs
-                are generated.
+        out_dim
+            The number of output classes.
+        out_type
+            Indicates if probabilities, class predictions or continuous outputs
+            are generated.
+        seed
+            Random seed.
 
         """
 
@@ -35,7 +36,6 @@ class MockPredictor:
         self.out_dim = out_dim
         self.num_outputs = out_dim
         self.out_type = out_type
-        self.model_type = model_type
         if out_type not in OUT_TYPES:
             raise ValueError("Unknown output type. Accepted values are {}".format(OUT_TYPES))
 

--- a/alibi/tests/utils.py
+++ b/alibi/tests/utils.py
@@ -16,18 +16,17 @@ class MockPredictor:
     def __init__(self,
                  out_dim: int,
                  out_type: str = 'proba',
+                 model_type: Optional[str] = None,
                  seed: Optional[int] = None,
                  ) -> None:
         """
         Parameters
         ----------
-        out_dim
-            The number of output classes.
-        out_type
-            Indicates if probabilities, class predictions or continuous outputs
-            are generated.
-        seed
-            Random seed.
+            out_dim
+                The number of output classes.
+            out_type
+                Indicates if probabilities, class predictions or continuous outputs
+                are generated.
 
         """
 
@@ -36,6 +35,7 @@ class MockPredictor:
         self.out_dim = out_dim
         self.num_outputs = out_dim
         self.out_type = out_type
+        self.model_type = model_type
         if out_type not in OUT_TYPES:
             raise ValueError("Unknown output type. Accepted values are {}".format(OUT_TYPES))
 

--- a/alibi/tests/utils.py
+++ b/alibi/tests/utils.py
@@ -1,6 +1,7 @@
-import numpy as np
-
 from contextlib import contextmanager
+from typing import Optional
+
+import numpy as np
 
 OUT_TYPES = ['proba', 'class', 'raw', 'probability', 'probability_doubled', 'log_loss', 'continuous']
 
@@ -15,8 +16,8 @@ class MockPredictor:
     def __init__(self,
                  out_dim: int,
                  out_type: str = 'proba',
-                 model_type: str = None,
-                 seed: int = None,
+                 model_type: Optional[str] = None,
+                 seed: Optional[int] = None,
                  ) -> None:
         """
         Parameters
@@ -55,7 +56,7 @@ class MockPredictor:
         elif self.out_type == 'raw' or self.out_type == 'log_loss' or self.out_type == 'continuous':
             return self._generate_logits(sz, *args, **kwargs)
 
-    def _generate_probas(self, sz: tuple = None, *args, **kwargs) -> np.ndarray:
+    def _generate_probas(self, sz: Optional[tuple] = None, *args, **kwargs) -> np.ndarray:
         """
         Generates probability vectors by sampling from a Dirichlet distribution.
         User can specify the Dirichlet distribution parameters via the 'alpha'
@@ -88,7 +89,7 @@ class MockPredictor:
 
         return np.random.dirichlet(alpha, size=sz)
 
-    def _generate_labels(self, sz: tuple = None, *args, **kwargs) -> np.ndarray:
+    def _generate_labels(self, sz: Optional[tuple] = None, *args, **kwargs) -> np.ndarray:
         """
         Generates labels by sampling random integers in range(0, n_classes+1).
         """
@@ -96,7 +97,7 @@ class MockPredictor:
             sz += (self.out_dim,)
         return np.random.randint(0, self.out_dim + 1, size=sz)
 
-    def _generate_logits(self, sz: tuple = None, *args, **kwargs) -> np.ndarray:
+    def _generate_logits(self, sz: Optional[tuple] = None, *args, **kwargs) -> np.ndarray:
         """
         Generates fake logit values by sampling from the standard normal
         """

--- a/alibi/tests/utils.py
+++ b/alibi/tests/utils.py
@@ -35,7 +35,7 @@ class MockPredictor:
         self.out_dim = out_dim
         self.num_outputs = out_dim
         self.out_type = out_type
-        self.model_type = model_type
+        self.model_type = model_type  # Required to emulate `shap` model wrapper arguments, see test_shap_wrappers.py
         if out_type not in OUT_TYPES:
             raise ValueError("Unknown output type. Accepted values are {}".format(OUT_TYPES))
 

--- a/alibi/utils/distance.py
+++ b/alibi/utils/distance.py
@@ -1,6 +1,7 @@
+from typing import Dict, Tuple
+
 import numpy as np
 from sklearn.manifold import MDS
-from typing import Dict, Tuple
 
 
 def cityblock_batch(X: np.ndarray,
@@ -161,10 +162,10 @@ def abdm(X: np.ndarray,
 
 
 def multidim_scaling(d_pair: dict,
+                     feature_range: tuple,
                      n_components: int = 2,
                      use_metric: bool = True,
                      standardize_cat_vars: bool = True,
-                     feature_range: tuple = None,
                      smooth: float = 1.,
                      center: bool = True,
                      update_feature_range: bool = True) -> Tuple[dict, tuple]:
@@ -176,15 +177,16 @@ def multidim_scaling(d_pair: dict,
     d_pair
         Dict with as keys the column index of the categorical variables and as values
         a pairwise distance matrix for the categories of the variable.
+    feature_range
+        Tuple with min and max ranges to allow for perturbed instances. Min and max ranges can be floats or
+        numpy arrays with dimension (1 x nb of features) for feature-wise ranges.
     n_components
         Number of dimensions in which to immerse the dissimilarities.
     use_metric
         If True, perform metric MDS; otherwise, perform nonmetric MDS.
     standardize_cat_vars
         Standardize numerical values of categorical variables if True.
-    feature_range
-        Tuple with min and max ranges to allow for perturbed instances. Min and max ranges can be floats or
-        numpy arrays with dimension (1 x nb of features) for feature-wise ranges.
+
     smooth
         Smoothing exponent between 0 and 1 for the distances. Lower values of l will smooth the difference in
         distance metric between different features.

--- a/alibi/utils/distributed.py
+++ b/alibi/utils/distributed.py
@@ -492,7 +492,7 @@ class DistributedExplainer:
         self.target_fcn = default_target_fcn
         # check global scope for any specific target function
         if concatenate_results:
-            self.concatenate = concatenate_minibatches  # type: ignore
+            self.concatenate = concatenate_minibatches  # type: ignore[assignment]
         if f"{algorithm}_target_fcn" in globals():
             self.target_fcn = globals()[f"{algorithm}_target_fcn"]
 

--- a/alibi/utils/distributed.py
+++ b/alibi/utils/distributed.py
@@ -1,11 +1,10 @@
 import copy
 import logging
+from functools import partial
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 
 import numpy as np
-
-from functools import partial
 from scipy import sparse
-from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 
 logger = logging.getLogger(__name__)
 
@@ -422,6 +421,8 @@ class DistributedExplainer:
         import ray
         ray = ray
 
+    concatenate: Callable
+
     def __init__(self,
                  distributed_opts: Dict[str, Any],
                  explainer_type: Any,
@@ -489,10 +490,9 @@ class DistributedExplainer:
                 "No algorithm specified in distributed option, default target function will be selected."
             )
         self.target_fcn = default_target_fcn
-        self.concatenate = None
         # check global scope for any specific target function
         if concatenate_results:
-            self.concatenate = concatenate_minibatches
+            self.concatenate = concatenate_minibatches  # type: ignore
         if f"{algorithm}_target_fcn" in globals():
             self.target_fcn = globals()[f"{algorithm}_target_fcn"]
 

--- a/alibi/utils/lang_model.py
+++ b/alibi/utils/lang_model.py
@@ -390,7 +390,3 @@ class RobertaBase(LanguageModel):
 
     def is_subword_prefix(self, token: str) -> bool:
         return not token.startswith(RobertaBase.SUBWORD_PREFIX)
-
-
-if __name__ == '__main__':
-    model = DistilbertBaseUncased()

--- a/alibi/utils/lang_model.py
+++ b/alibi/utils/lang_model.py
@@ -60,7 +60,7 @@ class LanguageModel(abc.ABC):
             self.model = TFAutoModelForMaskedLM.from_pretrained(model_path)
 
             # To understand the type: ignore see https://github.com/python/mypy/issues/2427
-            self.caller = tf.function(self.model.call, experimental_relax_shapes=True)  # type: ignore
+            self.caller = tf.function(self.model.call, experimental_relax_shapes=True)  # type: ignore[assignment]
 
             # set tokenizer
             self.tokenizer = AutoTokenizer.from_pretrained(model_path)
@@ -78,7 +78,7 @@ class LanguageModel(abc.ABC):
         self.model = TFAutoModelForMaskedLM.from_pretrained(path, local_files_only=True)
 
         # To understand the type: ignore see https://github.com/python/mypy/issues/2427
-        self.caller = tf.function(self.model.call, experimental_relax_shapes=True)  # type: ignore
+        self.caller = tf.function(self.model.call, experimental_relax_shapes=True)  # type: ignore[assignment]
 
         # set tokenizer
         self.tokenizer = AutoTokenizer.from_pretrained(path, local_files_only=True)

--- a/alibi/utils/mapping.py
+++ b/alibi/utils/mapping.py
@@ -1,8 +1,9 @@
+from typing import List, Tuple
+
 import numpy as np
-from typing import Tuple, List
 
 
-def ohe_to_ord_shape(shape: tuple, cat_vars: dict = None, is_ohe: bool = False) -> tuple:
+def ohe_to_ord_shape(shape: tuple, cat_vars: dict, is_ohe: bool = False) -> tuple:
     """
     Infer shape of instance if the categorical variables have ordinal instead of on-hot encoding.
 

--- a/alibi/utils/mapping.py
+++ b/alibi/utils/mapping.py
@@ -1,9 +1,9 @@
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
 import numpy as np
 
 
-def ohe_to_ord_shape(shape: tuple, cat_vars: dict, is_ohe: bool = False) -> tuple:
+def ohe_to_ord_shape(shape: tuple, cat_vars: Dict[int, int], is_ohe: bool = False) -> tuple:
     """
     Infer shape of instance if the categorical variables have ordinal instead of on-hot encoding.
 

--- a/alibi/utils/tests/test_distributed.py
+++ b/alibi/utils/tests/test_distributed.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 class MockExplainer:
     """ Mock explainer that allows testing most of the functionality in alibi.utils.distributed. """
+
     def __init__(self, sleep_time: int, multiplier: int = 3):
         self.sleep_time = sleep_time
         self.multiplier = multiplier
@@ -26,9 +27,9 @@ class MockExplainer:
         time.sleep(self.sleep_time)
         if isinstance(X, tuple):
             batch_idx, X = X
-            return batch_idx, self.multiplier*X
+            return batch_idx, self.multiplier * X
         else:
-            return self.multiplier*X
+            return self.multiplier * X
 
     def return_attribute(self, name: str):
         """
@@ -126,7 +127,6 @@ explainer_init_kwargs = [{'multiplier': 2}, ]
 @pytest.mark.parametrize('expln_kwargs', explainer_init_kwargs, ids='expln_init_kwargs={}'.format)
 @pytest.mark.parametrize('distributed_opts', distributed_opts, ids=distributed_opts_id)
 def test_distributed_explainer_init(expln_args, expln_kwargs, distributed_opts):
-
     import ray
 
     atol = 1e-5  # abs tolerance for floating point comparisons
@@ -146,13 +146,12 @@ def test_distributed_explainer_init(expln_args, expln_kwargs, distributed_opts):
     ray.shutdown()
 
 
-batch_size = [None, 1, 2]
+batch_size = [None, 1, 2]  # type: ignore
 ncpus = [2]
 actor_cpu_fraction = [0.5]
 keys = ['batch_size', 'n_cpus', 'actor_cpu_fraction']
 values = [batch_size, ncpus, actor_cpu_fraction]
 distributed_opts = kwargs_factory(keys, values)  # type: ignore
-
 
 # MockExplainer args and kwargs
 explainer_init_args = [(0.01,), ]
@@ -176,7 +175,6 @@ def test_distributed_explainer_get_explanation(
         distributed_opts,
         return_generator,
         concatenate_results):
-
     import ray
     atol = 1e-5  # tolerance for numerical comparisons
 
@@ -252,12 +250,13 @@ def test_invert_permutation(permutation_generator):
 
 
 # MockExplainer args and kwargs
-explainer_init_args = [[(0.01,), (0.05, )], ]   # type: ignore
+explainer_init_args = [[(0.01,), (0.05,)], ]  # type: ignore
 explainer_init_kwargs = [[{'multiplier': 2}, {'multiplier': 3}], [{'multiplier': 2}, ]]  # type: ignore
 
 batch_size = [2]
 ncpus = [1, len(explainer_init_kwargs[0])]  # set so that both the error raising inputs and correct inputs are tested
-actor_cpu_fraction = [1.0, 0.5, None]
+# TODO: check that redefining these (type: ignore) actually makes the tests run with the right parameters
+actor_cpu_fraction = [1.0, 0.5, None]  # type: ignore
 keys = ['batch_size', 'n_cpus', 'actor_cpu_fraction']
 values = [batch_size, ncpus, actor_cpu_fraction]
 distributed_opts = kwargs_factory(keys, values)  # type: ignore
@@ -269,7 +268,6 @@ concatenate_results = [False, True]
 @pytest.mark.parametrize('distributed_opts', distributed_opts, ids=distributed_opts_id)
 @pytest.mark.parametrize('concatenate_results', concatenate_results, ids='concat_results={}'.format)
 def test_pool_collection_init(expln_args, expln_kwargs, distributed_opts, concatenate_results):
-
     import ray
 
     ncpus = distributed_opts['n_cpus']
@@ -317,7 +315,7 @@ def test_pool_collection_init(expln_args, expln_kwargs, distributed_opts, concat
 
 
 # MockExplainer positional args and kwargs
-explainer_init_args = [[(0.01,), (0.05, )], ]  # type: ignore
+explainer_init_args = [[(0.01,), (0.05,)], ]  # type: ignore
 explainer_init_kwargs = [[{'multiplier': 2}, {'multiplier': 3}], ]  # type: ignore
 
 batch_size = [2]
@@ -334,7 +332,6 @@ n_instances, n_features = 5, 6
 @pytest.mark.parametrize('expln_kwargs', explainer_init_kwargs, ids='expln_init_kwargs={}'.format)
 @pytest.mark.parametrize('distributed_opts', distributed_opts, ids=distributed_opts_id)
 def test_pool_collection_get_explanation(data_generator, expln_args, expln_kwargs, distributed_opts):
-
     import ray
     atol = 1e-5  # absolute tolerance for floating point comparisons
 
@@ -368,7 +365,7 @@ def test_pool_collection_get_explanation(data_generator, expln_args, expln_kwarg
 
 # repetitions: how many lists with n_minibatches of size minibatch_size are fed to the function in one go
 n_minibatches, minibatch_size, repetitions, n_features = 3, 3, 3, 6
-n_instances = n_minibatches*minibatch_size*repetitions
+n_instances = n_minibatches * minibatch_size * repetitions
 
 
 @pytest.mark.parametrize('data_generator', [(n_instances, n_features), ], ids=data_generator_id, indirect=True)
@@ -389,7 +386,7 @@ def test_concatenate_minibatches(data_generator, n_minibatches, repetitions, n_f
     np.testing.assert_allclose(X, concat_result)
 
     # List[List[np.ndarray]] input
-    split_arr = np.split(X, n_minibatches*repetitions)
+    split_arr = np.split(X, n_minibatches * repetitions)
     minibatch_seq = [split_arr[i:i + n_minibatches] for i in range(0, len(split_arr), n_minibatches)]
     concat_result = concatenate_minibatches(minibatch_seq)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ exclude =
 
 [mypy]
 ignore_missing_imports = True
+no_implicit_optional = True
 
 # sphinx configuration
 [mypy-conf]

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ exclude =
 
 [mypy]
 ignore_missing_imports = True
-strict_optional = False
 
 # sphinx configuration
 [mypy-conf]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ exclude =
 [mypy]
 ignore_missing_imports = True
 no_implicit_optional = True
+show_error_codes = True
 
 # sphinx configuration
 [mypy-conf]


### PR DESCRIPTION
This PR reinstates strict `Optional` type-checking with `mypy` because it's both a prerequisite of #511 and also a good idea (there were multiple genuine bugs caught by re-enabling strict behaviour).

Specifically, `setup.cfg` now contains the following:
```
[mypy]
ignore_missing_imports = True
no_implicit_optional = True
```

Note that `strict_optional = True` is the default and disallows `None` as a valid type for functions that don't declare it explicitly as valid. Furthermore, `no_implicit_optional` now requires writing `Optional[some_type] = None` instead of `some_type = None` which is [recommended behaviour](https://www.python.org/dev/peps/pep-0484/#id29).

Most of the code is just type changes, but where genuine bugs were revealed some (minor) logic changes were needed also.

I will post some comments on the PR shortly to ease reviewing.

I have additionally taken the change to run `isort` on the affected modules for more pleasant import ordering.

One particularly pernicious pattern I have decided to refactor is to do with initializing instance attributes as `None` and later setting them to their proper values. So instead of this (which would fail type-checking now):
```python
class Foo:
    def __init__(self):
        # to be set later
        self.attr = None # type: int
```

we now declare the type of the non-initialized attribute in the class instead:
```python
class Foo:
    attr: int
```

Now you may ask, why not just stick with the first variant and annotate with `# type: Optional[int]`? The answer is that `None` is (almost always) not a valid value as in the `self.attr = None` pattern is used as a placeholder to be initialized later on. But this can lead to a variety of bugs if we don't explicitly check for `None` every time we want to use the (hopefully initialized) attribute. Type checkers like `mypy` are also unlikely to know that when accessing `self.attr` after initialization there is no risk of it being `None` because of potentially complex runtime logic that determines `self.attr` can't be `None` which the type-checker cannot follow. Finally, we may fail to consider all cases of setting `self.attr` to it's not-`None` value and have a genuine bug where we believe `self.attr` isn't `None` anymore when it still is... Thus, it is better to declare but not instantiate to a generally invalid `None` value. In this scenario we can also check that if the value needs instantiating by calling `hasattr(self, 'attr')` instead of comparing to `None` as in the previous scenario.

A final minor curiosity, because our `numpy` version is older and doesn't include `numpy.typing` advancements, anywhere `arr: np.ndarray = None` is declared doesn't actually result in a `mypy` error. However, we're good citizens and wrap it in `Optional` as well, this will future-proof when later versionf of `numpy` can be used.