### PR TITLE
Fix bugs with passing images_background to AnchorImage

### DIFF
--- a/alibi/explainers/anchor_image.py
+++ b/alibi/explainers/anchor_image.py
@@ -248,11 +248,9 @@ class AnchorImageSampler:
                 mask[segments == superpixel] = True
             if background_idx is not None:
                 # replace values with those of background image
-                # TODO: Could images_background be None herre?
                 temp[mask] = self.images_background[background_idx][mask]
             else:
                 # ... or with the averaged superpixel value
-                # TODO: Where is fudged_image defined?
                 temp[mask] = fudged_image[mask]
             pert_imgs.append(temp)
 

--- a/alibi/explainers/anchor_image.py
+++ b/alibi/explainers/anchor_image.py
@@ -221,13 +221,12 @@ class AnchorImageSampler:
         segments_mask[:, anchor] = 1
 
         # for each sample, need to sample one of the background images if provided
-        if self.images_background:
+        if self.images_background is not None:
             backgrounds = np.random.choice(
                 range(len(self.images_background)),
                 segments_mask.shape[0],
                 replace=True,
             )
-            segments_mask = np.hstack((segments_mask, backgrounds.reshape(-1, 1)))
         else:
             backgrounds = [None] * segments_mask.shape[0]
             # create fudged image where the pixel value in each superpixel is set to the
@@ -247,7 +246,7 @@ class AnchorImageSampler:
             mask = np.zeros(segments.shape).astype(bool)
             for superpixel in to_perturb:
                 mask[segments == superpixel] = True
-            if background_idx:
+            if background_idx is not None:
                 # replace values with those of background image
                 # TODO: Could images_background be None herre?
                 temp[mask] = self.images_background[background_idx][mask]

--- a/alibi/explainers/tests/test_anchor_image.py
+++ b/alibi/explainers/tests/test_anchor_image.py
@@ -102,19 +102,22 @@ def test_sampler(predict_fn, models, mnist_data):
                          indirect=True,
                          ids='models={}'.format
                          )
-def test_anchor_image(predict_fn, models, mnist_data):
+@pytest.mark.parametrize('images_background', [True, False], ids='images_background={}'.format)
+def test_anchor_image(predict_fn, models, mnist_data, images_background):
     x_train = mnist_data["X_train"]
     image = x_train[0]
 
     segmentation_fn = "slic"
     segmentation_kwargs = {"n_segments": 10, "compactness": 10, "sigma": 0.5}
     image_shape = (28, 28, 1)
+    images_background = x_train[:10] if images_background else None
 
     explainer = AnchorImage(
         predict_fn,
         image_shape,
         segmentation_fn=segmentation_fn,
         segmentation_kwargs=segmentation_kwargs,
+        images_background=images_background
     )
 
     p_sample = 0.5  # probability of perturbing a superpixel


### PR DESCRIPTION
Resolves #540.

I have manually checked that the code now works passing an array of `images_background` and that the proposed anchor is actually superimposed on these background images. I will see if an automated test can also be written relatively easily.