### PR TITLE
Fix numpy related type issues

### DIFF
--- a/alibi/explainers/anchor_image.py
+++ b/alibi/explainers/anchor_image.py
@@ -215,6 +215,7 @@ class AnchorImageSampler:
 
         image = self.image
         segments = self.segments
+        backgrounds: Union[np.ndarray, List[None]]
 
         # choose superpixels to be perturbed
         segments_mask = self._choose_superpixels(num_samples, p_sample=self.p_sample)

--- a/alibi/explainers/anchor_tabular.py
+++ b/alibi/explainers/anchor_tabular.py
@@ -286,8 +286,8 @@ class TabularSampler:
         num_samples_pos = np.searchsorted(nb_partial_anchors, num_samples)
         if num_samples_pos == 0:
             samples_idxs = np.random.choice(partial_anchor_rows[-1], num_samples)
-            samples[:, uniq_feat_ids] = self.train_data[np.ix_(samples_idxs, uniq_feat_ids)]
-            d_samples[:, uniq_feat_ids] = self.d_train_data[np.ix_(samples_idxs, uniq_feat_ids)]
+            samples[:, uniq_feat_ids] = self.train_data[np.ix_(samples_idxs, uniq_feat_ids)]  # type: ignore
+            d_samples[:, uniq_feat_ids] = self.d_train_data[np.ix_(samples_idxs, uniq_feat_ids)]  # type: ignore
 
             return samples, d_samples, coverage
 
@@ -389,7 +389,8 @@ class TabularSampler:
                         replace=True,
                     )
                 n_samp = num_samples
-            samples[start:start + n_samp, uniq_feat_ids[idx:]] = self.train_data[np.ix_(samp_idxs, uniq_feat_ids[idx:])]
+            samples[start:start + n_samp, uniq_feat_ids[idx:]] = self.train_data[
+                np.ix_(samp_idxs, uniq_feat_ids[idx:])]  # type: ignore
 
             # deal with partial anchors; idx = 0 means that we actually sample the entire anchor
             if idx > 0:

--- a/alibi/explainers/tests/test_anchor_image.py
+++ b/alibi/explainers/tests/test_anchor_image.py
@@ -34,7 +34,7 @@ def predict_fn(request):
             # NB: torch models need dtype=torch.float32, we are not setting it here
             # to test that `dtype` argument to AnchorImage does the right thing when
             # a dummy call is made
-            image = torch.as_tensor(np.moveaxis(image, -1, 1))
+            image = torch.as_tensor(np.moveaxis(image, -1, 1))  # type: ignore
             return request.param[0].forward(image).detach().numpy()
     else:
         raise ValueError(f'Unknown model {request.param[0]} of type {type(request.param[0])}')


### PR DESCRIPTION
This PR is a prerequisite for #521 as the newest `tensorflow` pulls in the newest `numpy` which has support for type hints. This has revealed some typing issues in our codebase.

This PR uses `type: ignore` fairly liberally as in some places it is not fully clear why the upstream types are failing (e.g. `List[int]` not being valid input to `np.ix_`), and in others we're missing some validation/type narrowing on our side (e.g. `baselines`). I've also used `cast` in a few places to help the typechecker narrow down types based on the boolean flags we use.