### PR TITLE
Warn/matplotlib shap issue

### DIFF
--- a/doc/source/examples/interventional_tree_shap_adult_xgb.ipynb
+++ b/doc/source/examples/interventional_tree_shap_adult_xgb.ipynb
@@ -737,6 +737,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-warning\">\n",
+    "Warning\n",
+    "    \n",
+    "For the following plots to run the `matplotlib` version needs to be `<3.5.0`. This is because of an upstream issue of how the `shap.dependence_plot` function is handled in the `shap` library. An issue tracking it can be found [here](https://github.com/slundberg/shap/issues/2273).\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 32,
    "metadata": {},
@@ -1383,7 +1395,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/doc/source/examples/path_dependent_tree_shap_adult_xgb.ipynb
+++ b/doc/source/examples/path_dependent_tree_shap_adult_xgb.ipynb
@@ -906,9 +906,21 @@
     "\n",
     "As far as `Age` is concerned, the odds of earning more increase as a person ages, and, in general, this variable is used by the model to assign individuals to a lower income class. People in their 30s-60s are thought to be more likely to make an income over \\$50, 000 if their capital gains are high. Interestingly, for people over 60, high capital gains have a large negative contribution to the odds of making large incomes, a pattern that is perhaps not intuitive. \n",
     "\n",
-    "As far as the `Hours per week` is concerned, one sees that older people working no to few hours a week are predicted better odds for making a larger income, and that, up to a certain threshold (of approximately 60 hours), working more than 20 hours increases the odds of a  > \\\\$50, 000 prediction for all ages.\n",
+    "As far as the `Hours per week` is concerned, one sees that older people working no to few hours a week are predicted better odds for making a larger income, and that, up to a certain threshold (of approximately 60 hours), working more than 20 hours increases the odds of a  > \\$50, 000 prediction for all ages.\n",
     "\n",
     "Finally, note that not knowing the occupation hurts the odds of predicting a high income. No significant interactions between the sex of the individual (males in red), their occupation and their predicted odds are observed with the exception of, perhaps, `Admin` and `Blue Collar` groups. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-warning\">\n",
+    "Warning\n",
+    "    \n",
+    "For the following plots to run the `matplotlib` version needs to be `<3.5.0`. This is because of an upstream issue of how the `shap.dependence_plot` function is handled in the `shap` library. An issue tracking it can be found [here](https://github.com/slundberg/shap/issues/2273).\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -1468,7 +1480,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds a warning to 2 notebooks regarding `shap.dependence_plot` bug as discussed here https://github.com/slundberg/shap/issues/2273. The affected notebooks are the ones for `TreeShap` and although a few more `KernelShap` notebooks do use `shap.dependence_plot`, the plots work fine which may be something to do with the difference in how numerical and categorical data types are treated (alluded to in the above `shap` issue).