### PR TITLE
Revert bugs related to selecting dictionary keys with highest values

### DIFF
--- a/alibi/explainers/cfproto.py
+++ b/alibi/explainers/cfproto.py
@@ -192,7 +192,7 @@ class CounterfactualProto(Explainer, FitMixin):
             self.map_cat_to_num = tf.ragged.constant([np.zeros(v) for _, v in cat_vars.items()])
 
             # define placeholder for mapping which can be fed after the fit step
-            max_key = max(cat_vars)
+            max_key = max(cat_vars, key=cat_vars.get)  # type: ignore[type-var] # feature with the most categories
             self.max_cat = cat_vars[max_key]
             cat_keys = list(cat_vars.keys())
             n_cat = len(cat_keys)
@@ -1059,8 +1059,7 @@ class CounterfactualProto(Explainer, FitMixin):
                 self.class_proto[c] = self.X_by_class[c][idx_c[0][-1]].reshape(1, -1)
 
         if self.enc_or_kdtree:
-            self.id_proto = min(dist_proto)
-            self.id_proto = min(dist_proto)
+            self.id_proto = min(dist_proto, key=dist_proto.get)  # type: ignore[type-var]
             proto_val = self.class_proto[self.id_proto]
             if verbose:
                 print('Prototype class: {}'.format(self.id_proto))


### PR DESCRIPTION
Fixes #610.

The `mypy` type-ignore's are due to the `get` method potentially returning `None` (even though it's not possible in this case), see https://stackoverflow.com/questions/66317557/type-hints-for-dict-when-finding-min-value.