### PR TITLE
Add bounds to click to prevent CI error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ setup(name='alibi',
           'typing-extensions>=3.7.4.3',
           'dill>=0.3.0, <0.4.0',
           'transformers>=4.7.0, <5.0.0',
-          'tqdm>=4.28.1, <5.0.0'
+          'tqdm>=4.28.1, <5.0.0',
+          'click<8.1.0' # remove once https://github.com/explosion/spaCy/pull/10573 is released
       ],
       extras_require=extras_require,
       test_suite='tests',


### PR DESCRIPTION
Should be removed once https://github.com/explosion/spaCy/pull/10573 is released