### PR TITLE
Update CI to trigger on PRs for feature branches but not draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,14 @@ defaults:
 
 on:
   # Trigger the workflow on push or pull request,
-  # but only for the master branch
+  # push only for the master branch.
   push:
     branches:
       - master
   pull_request:
-    branches:
-      - master
-  # Trigger workflow once per week
+    # don't trigger for draft PRs
+    types: [opened, synchronize, reopened, ready_for_review]
+  # Trigger workflow once per day at midnight
   schedule:
     - cron: '0 0 * * *'
   # Trigger the workflow on manual dispatch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,12 @@ defaults:
 
 on:
   # Trigger the workflow on push or pull request,
-  # push only for the master branch.
+  # push only for the master branch,
+  # pull request for master and feature branches.
   push:
     branches:
       - master
+      - 'feature/*'
   pull_request:
     # don't trigger for draft PRs
     types: [opened, synchronize, reopened, ready_for_review]
@@ -29,9 +31,9 @@ jobs:
         os: [ubuntu-latest]
         python-version: [ '3.7', '3.8', '3.9' ]
         include: # Run macos and windows tests on python 3.9 only
-          - os: windows-latest 
+          - os: windows-latest
             python-version:  '3.9'
-          - os: macos-latest 
+          - os: macos-latest
             python-version:  '3.9'
 
     steps:


### PR DESCRIPTION
Resolves #633.

This largely brings the CI workflow closer to the one in `alibi-detect`: https://github.com/SeldonIO/alibi-detect/blob/master/.github/workflows/ci.yml

1. Trigger CI on PRs to any branch since we're starting to use feature branches more. I allow now all branches instead of just `features/*` as we already have one that is named `feature/*`...
2. Don't trigger CI on draft PRs
3. Updated comment on daily crontab (previously said weekly - same comment should be changed on `alibi-detect` workflow)