### PR TITLE
Add missing batched similarity method explanations functionality

### DIFF
--- a/alibi/explainers/similarity/base.py
+++ b/alibi/explainers/similarity/base.py
@@ -149,10 +149,10 @@ class BaseSimilarityExplainer(Explainer, ABC):
         grad_X
             Gradients of the test instances.
         """
-        scores = np.zeros(self.X_train.shape[0])
+        scores = np.zeros((grad_X.shape[0], self.X_train.shape[0]))
         for i, (X, Y) in tqdm(enumerate(zip(self.X_train, self.Y_train)), disable=not self.verbose):
             grad_X_train = self._compute_grad(X[None], Y[None])
-            scores[i] = self.sim_fn(grad_X_train, grad_X)
+            scores[:, i] = self.sim_fn(grad_X_train[None], grad_X)
         return scores
 
     def _compute_grad(self,

--- a/alibi/explainers/similarity/base.py
+++ b/alibi/explainers/similarity/base.py
@@ -152,7 +152,7 @@ class BaseSimilarityExplainer(Explainer, ABC):
         scores = np.zeros((grad_X.shape[0], self.X_train.shape[0]))
         for i, (X, Y) in tqdm(enumerate(zip(self.X_train, self.Y_train)), disable=not self.verbose):
             grad_X_train = self._compute_grad(X[None], Y[None])
-            scores[:, i] = self.sim_fn(grad_X_train[None], grad_X)
+            scores[:, i] = self.sim_fn(grad_X, grad_X_train[None])[:, 0]
         return scores
 
     def _compute_grad(self,

--- a/alibi/explainers/similarity/metrics.py
+++ b/alibi/explainers/similarity/metrics.py
@@ -5,77 +5,70 @@ import numpy as np
 
 def dot(X: np.ndarray, Y: np.ndarray) -> Union[float, np.ndarray]:
     """
-    Performs a dot product between the vector(s) in X and vector Y. (:math:`X^T Y = \\sum_i X_i Y_i`).
+    Performs a dot product between the vector(s) in X and vector Y. (:math:`X^T Y = \\sum_i X_i Y_i`). Each of `X` and
+    `Y` should have a leading batch dimension of size at least 1.
 
     Parameters
     ----------
     X
         Matrix of vectors.
     Y
-        Single vector
+        Matrix of vectors.
 
     Returns
     -------
-        Dot product between the vector(s) in X and vector Y.
+        Matrix of dot products between the vector(s) in X and vectors in Y.
     """
-    if len(X.shape) == 1:
-        assert X.shape == Y.shape, "The vector `X` and `Y` need to have the same dimensions."
-    else:
-        assert X.shape[1] == Y.shape[0], "The second dimension of `X` need to be the same as the dimension of `Y`"
-    return np.dot(X, Y)
+    assert len(X.shape) > 1 and len(Y.shape) > 1, "The vectors `X` and `Y` should have a leading batch dimension."
+    assert X.shape[1] == Y.shape[1], "The second dimension of `X` needs to be the same as the dimension of `Y`."
+    return np.dot(X, Y.T)
 
 
 def cos(X: np.ndarray, Y: np.ndarray, eps: float = 1e-7) -> Union[float, np.ndarray]:
     """
-    Computes the cosine between the vector(s) in X and vector Y. (:math:`X^T Y//\\|X\\|\\|Y\\|`).
+    Computes the cosine between the vector(s) in X and vector Y. (:math:`X^T Y//\\|X\\|\\|Y\\|`). Each of `X` and `Y`
+    should have a leading batch dimension of size at least 1.
 
     Parameters
     ----------
     X
         Matrix of vectors.
     Y
-        Single vector
+        Matrix of vectors.
     eps
         Numerical stability.
 
     Returns
     -------
-        Cosine between the vector(s) in X and vector Y.
+        Matrix of cosine similarities between the vector(s) in X and vectors in Y.
     """
-
-    if len(X.shape) == 1:
-        assert X.shape == Y.shape, "The vectors `X` and `Y` need to have the same dimensions."
-        denominator = np.linalg.norm(X) * np.linalg.norm(Y)
-    else:
-        assert X.shape[1] == Y.shape[0], "The second dimension of `X` need to be the same as the dimension of `Y`"
-        denominator = np.linalg.norm(X, axis=1) * np.linalg.norm(Y)
-
-    return np.dot(X, Y) / (denominator + eps)
+    assert len(X.shape) > 1 and len(Y.shape) > 1, "The vectors `X` and `Y` should have a leading batch dimension."
+    assert X.shape[1] == Y.shape[1], "The second dimension of `X` needs to be the same as the dimension of `Y`."
+    denominator = np.linalg.norm(X, axis=1)[:, None] @ np.linalg.norm(Y, axis=1)[None, :]
+    return np.dot(X, Y.T) / (denominator + eps)
 
 
 def asym_dot(X: np.ndarray, Y: np.ndarray, eps: float = 1e-7) -> Union[float, np.ndarray]:
     """
     Computes the influence of instances `X` to instances `Y`. This is an asymmetric kernel.
-    (:math:`X^T Y//\\|X\\|^2`). See the `paper <https://arxiv.org/abs/2102.05262>`_ for more details.
+    (:math:`X^T Y//\\|X\\|^2`). See the `paper <https://arxiv.org/abs/2102.05262>`_ for more details. Each of `X` and
+    `Y` should have a leading batch dimension of size at least 1.
 
     Parameters
     ----------
     X
         Matrix of vectors.
     Y
-        Single vector.
+        Matrix of vectors.
     eps
         Numerical stability.
 
     Returns
     -------
-        Influence asymmetric kernel value.
+        Matrix of asymmetric dot product similarity values between the vector(s) in X and vectors in Y.
     """
-    if len(X.shape) == 1:
-        assert X.shape == Y.shape, "The vectors `X` and `Y` need to have the same dimensions."
-        denominator = np.linalg.norm(X) ** 2
-    else:
-        assert X.shape[1] == Y.shape[0], "The second dimension of `X` need to be the same as the dimension of `Y`."
-        denominator = np.linalg.norm(X, axis=1) ** 2
 
-    return np.dot(X, Y) / (denominator + eps)
+    assert len(X.shape) > 1 and len(Y.shape) > 1, "The vectors `X` and `Y` should have a leading batch dimension."
+    assert X.shape[1] == Y.shape[1], "The second dimension of `X` needs to be the same as the dimension of `Y`."
+    denominator = np.linalg.norm(X, axis=1) ** 2
+    return np.dot(X, Y.T) / (denominator + eps)[:, None]

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
@@ -215,7 +215,8 @@ def test_grad_cos_result_order_tf(seed):
     assert (ds[explanation['ordered_indices'][0][-1]] == ds[-1]).all()
 
 
-def test_multiple_test_instances_grad_cos():
+@pytest.mark.parametrize('precompute_grads', [True, False])
+def test_multiple_test_instances_grad_cos(precompute_grads):
     """
     Test that multiple test instances get correct explanations for `grad_cos` similarity.
     """
@@ -226,33 +227,8 @@ def test_multiple_test_instances_grad_cos():
         task='regression',
         loss_fn=loss_tf,
         sim_fn='grad_cos',
-        backend='tensorflow'
-    )
-    explainer = explainer.fit(ds, ds)
-    explanation = explainer.explain(ds[0:2], Y=ds[0:2])
-    # Test that the first two datapoints are the most similar
-    assert (ds[explanation['ordered_indices'][0][1]] == ds[1]).all()
-    assert (ds[explanation['ordered_indices'][1][1]] == ds[0]).all()
-
-    # Test that the greatest difference is between the first two and the last datapoint
-    assert (ds[explanation['ordered_indices'][0][-1]] == ds[-1]).all()
-    assert (ds[explanation['ordered_indices'][1][-1]] == ds[-1]).all()
-
-
-def test_multiple_test_instances_stored_grads_grad_cos():
-    """
-    Test that multiple test instances get correct explanations for `grad_cos` similarity and when explainer
-    `precompute_grads` is true.
-    """
-    ds = np.array([[1, 0], [0.9, 0.1], [0.5 * 100, 0.5 * 100]]).astype('float32')
-    model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
-    explainer = GradientSimilarity(
-        model,
-        task='regression',
-        loss_fn=loss_tf,
-        sim_fn='grad_cos',
         backend='tensorflow',
-        precompute_grads=True
+        precompute_grads=precompute_grads
     )
     explainer = explainer.fit(ds, ds)
     explanation = explainer.explain(ds[0:2], Y=ds[0:2])
@@ -265,7 +241,8 @@ def test_multiple_test_instances_stored_grads_grad_cos():
     assert (ds[explanation['ordered_indices'][1][-1]] == ds[-1]).all()
 
 
-def test_multiple_test_instances_grad_dot():
+@pytest.mark.parametrize('precompute_grads', [True, False])
+def test_multiple_test_instances_grad_dot(precompute_grads):
     """
     Test that multiple test instances get correct explanations for `grad_dot` similarity.
     """
@@ -276,42 +253,21 @@ def test_multiple_test_instances_grad_dot():
         task='regression',
         loss_fn=loss_tf,
         sim_fn='grad_dot',
-        backend='tensorflow'
-    )
-    explainer = explainer.fit(ds, ds)
-    explanation = explainer.explain(ds[0:2], Y=ds[0:2])
-
-    # Check that the last datapoint is the most similar to the first datapoint.
-    assert (ds[explanation['ordered_indices'][0][0]] == ds[-1]).all()
-    assert (ds[explanation['ordered_indices'][1][0]] == ds[-1]).all()
-
-
-def test_multiple_test_instances_stored_grads_grad_dot():
-    """
-    Test that multiple test instances get correct explanations for `grad_dot` similarity and when explainer
-    `precompute_grads` is true.
-    """
-    ds = np.array([[1, 0], [0.9, 0.1], [0.5 * 100, 0.5 * 100]]).astype('float32')
-    model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
-    explainer = GradientSimilarity(
-        model,
-        task='regression',
-        loss_fn=loss_tf,
-        sim_fn='grad_dot',
         backend='tensorflow',
-        precompute_grads=True
+        precompute_grads=precompute_grads
     )
     explainer = explainer.fit(ds, ds)
     explanation = explainer.explain(ds[0:2], Y=ds[0:2])
+
     # Check that the last datapoint is the most similar to the first datapoint.
     assert (ds[explanation['ordered_indices'][0][0]] == ds[-1]).all()
     assert (ds[explanation['ordered_indices'][1][0]] == ds[-1]).all()
 
 
-def test_multiple_test_instances_stored_grads_asym_dot():
+@pytest.mark.parametrize('precompute_grads', [True, False])
+def test_multiple_test_instances_stored_grads_asym_dot(precompute_grads):
     """
-    Test that multiple test instances get correct explanations for `grad_asym_dot` when explainer `precompute_grads` is
-    true.
+    Test that multiple test instances get correct explanations for `grad_asym_dot`.
     """
     ds = np.array([[1, 0], [0.9, 0.1], [0.5 * 100, 0.5 * 100]]).astype('float32')
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
@@ -321,7 +277,7 @@ def test_multiple_test_instances_stored_grads_asym_dot():
         loss_fn=loss_tf,
         sim_fn='grad_asym_dot',
         backend='tensorflow',
-        precompute_grads=True
+        precompute_grads=precompute_grads
     )
     explainer = explainer.fit(ds, ds)
     explanation = explainer.explain(ds[0:2], Y=ds[0:2])

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
@@ -105,8 +105,8 @@ def test_grad_cos_result_order_torch(seed):
     )
     explainer = explainer.fit(ds, ds)
     explanation = explainer.explain(ds[0], Y=ds[0])
-    assert (ds[explanation['ordered_indices'][0][1]] == ds[1]).all()
-    assert (ds[explanation['ordered_indices'][0][-1]] == ds[-1]).all()
+    np.testing.assert_array_equal(ds[explanation['ordered_indices'][0][1]], ds[1])
+    np.testing.assert_array_equal(ds[explanation['ordered_indices'][0][-1]], ds[-1])
 
 
 def test_grad_dot_result_order_torch(seed):
@@ -124,8 +124,8 @@ def test_grad_dot_result_order_torch(seed):
     )
     explainer = explainer.fit(ds, ds)
     explanation = explainer.explain(ds[0], Y=ds[0])
-    assert (ds[explanation['ordered_indices'][0][0]] == ds[-1]).all()
-    assert (ds[explanation['ordered_indices'][0][-1]] == ds[1]).all()
+    np.testing.assert_array_equal(ds[explanation['ordered_indices'][0][0]], ds[-1])
+    np.testing.assert_array_equal(ds[explanation['ordered_indices'][0][-1]], ds[1])
 
 
 def loss_tf(y, x):
@@ -191,8 +191,8 @@ def test_grad_dot_result_order_tf(seed):
     )
     explainer = explainer.fit(ds, ds)
     explanation = explainer.explain(ds[0], Y=ds[0])
-    assert (ds[explanation['ordered_indices'][0][0]] == ds[-1]).all()
-    assert (ds[explanation['ordered_indices'][0][-1]] == ds[1]).all()
+    np.testing.assert_array_equal(ds[explanation['ordered_indices'][0][0]], ds[-1])
+    np.testing.assert_array_equal(ds[explanation['ordered_indices'][0][-1]], ds[1])
 
 
 def test_grad_cos_result_order_tf(seed):
@@ -211,8 +211,8 @@ def test_grad_cos_result_order_tf(seed):
     )
     explainer = explainer.fit(ds, ds)
     explanation = explainer.explain(ds[0], Y=ds[0])
-    assert (ds[explanation['ordered_indices'][0][1]] == ds[1]).all()
-    assert (ds[explanation['ordered_indices'][0][-1]] == ds[-1]).all()
+    np.testing.assert_array_equal(ds[explanation['ordered_indices'][0][1]], ds[1])
+    np.testing.assert_array_equal(ds[explanation['ordered_indices'][0][-1]], ds[-1])
 
 
 @pytest.mark.parametrize('precompute_grads', [True, False])
@@ -233,12 +233,12 @@ def test_multiple_test_instances_grad_cos(precompute_grads):
     explainer = explainer.fit(ds, ds)
     explanation = explainer.explain(ds[0:2], Y=ds[0:2])
     # Test that the first two datapoints are the most similar
-    assert (ds[explanation['ordered_indices'][0][1]] == ds[1]).all()
-    assert (ds[explanation['ordered_indices'][1][1]] == ds[0]).all()
+    np.testing.assert_array_equal(ds[explanation['ordered_indices'][0][1]], ds[1])
+    np.testing.assert_array_equal(ds[explanation['ordered_indices'][1][1]], ds[0])
 
     # Test that the greatest difference is between the first two and the last datapoint
-    assert (ds[explanation['ordered_indices'][0][-1]] == ds[-1]).all()
-    assert (ds[explanation['ordered_indices'][1][-1]] == ds[-1]).all()
+    np.testing.assert_array_equal(ds[explanation['ordered_indices'][0][-1]], ds[-1])
+    np.testing.assert_array_equal(ds[explanation['ordered_indices'][1][-1]], ds[-1])
 
 
 @pytest.mark.parametrize('precompute_grads', [True, False])
@@ -260,8 +260,8 @@ def test_multiple_test_instances_grad_dot(precompute_grads):
     explanation = explainer.explain(ds[0:2], Y=ds[0:2])
 
     # Check that the last datapoint is the most similar to the first datapoint.
-    assert (ds[explanation['ordered_indices'][0][0]] == ds[-1]).all()
-    assert (ds[explanation['ordered_indices'][1][0]] == ds[-1]).all()
+    np.testing.assert_array_equal(ds[explanation['ordered_indices'][0][0]], ds[-1])
+    np.testing.assert_array_equal(ds[explanation['ordered_indices'][1][0]], ds[-1])
 
 
 @pytest.mark.parametrize('precompute_grads', [True, False])
@@ -284,16 +284,16 @@ def test_multiple_test_instances_stored_grads_asym_dot(precompute_grads):
 
     # In the case of `grad_asym_dot` we manually check the similarities as the asymmetry of the metric means ordering
     # is important.
-    sim_ds_0 = np.array([(1 * 1 + 0 * 0) / 1., (1 * 0.9 + 0 * 0.1) / 1., (1 * 50 + 0 * 50) / 1.])
+    sim_ds_0 = np.array([(1 * 1 + 0 * 0), (1 * 0.9 + 0 * 0.1), (1 * 50 + 0 * 50)]) / (1 + 1e-7)
     sim_ds_0.sort()
-    np.testing.assert_almost_equal(explanation.scores[0], sim_ds_0[::-1], decimal=3)
+    np.testing.assert_allclose(explanation.scores[0], sim_ds_0[::-1], atol=1e-6)
 
     d = (0.9**2 + 0.1**2)
-    sim_ds_1 = np.array([(0.9 * 1 + 0.1 * 0) / d, (0.9 * 0.9 + 0.1 * 0.1) / d, (0.9 * 50 + 0.1 * 50) / d])
+    sim_ds_1 = np.array([(0.9 * 1 + 0.1 * 0), (0.9 * 0.9 + 0.1 * 0.1), (0.9 * 50 + 0.1 * 50)]) / (d + 1e-7)
     sim_ds_1.sort()
-    np.testing.assert_almost_equal(explanation.scores[1], sim_ds_1[::-1], decimal=3)
+    np.testing.assert_allclose(explanation.scores[1], sim_ds_1[::-1], atol=1e-6)
 
-    assert (ds[explanation['ordered_indices'][0][0]] == ds[-1]).all()
-    assert (ds[explanation['ordered_indices'][1][0]] == ds[-1]).all()
+    np.testing.assert_array_equal(ds[explanation['ordered_indices'][0][0]], ds[-1])
+    np.testing.assert_array_equal(ds[explanation['ordered_indices'][1][0]], ds[-1])
     explanation = explainer.explain(ds[-1], Y=ds[-1])
-    assert (explanation.scores == np.array([[1., 0.01, 0.01]], dtype=np.float32)).all()
+    np.testing.assert_array_equal(explanation.scores, np.array([[1., 0.01, 0.01]], dtype=np.float32))

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
@@ -282,7 +282,17 @@ def test_multiple_test_instances_stored_grads_asym_dot(precompute_grads):
     explainer = explainer.fit(ds, ds)
     explanation = explainer.explain(ds[0:2], Y=ds[0:2])
 
-    # Check asymmetric dot product scores are correct
+    # In the case of `grad_asym_dot` we manually check the similarities as the asymmetry of the metric means ordering
+    # is important.
+    sim_ds_0 = np.array([(1 * 1 + 0 * 0) / 1., (1 * 0.9 + 0 * 0.1) / 1., (1 * 50 + 0 * 50) / 1.])
+    sim_ds_0.sort()
+    np.testing.assert_almost_equal(explanation.scores[0], sim_ds_0[::-1], decimal=3)
+
+    d = (0.9**2 + 0.1**2)
+    sim_ds_1 = np.array([(0.9 * 1 + 0.1 * 0) / d, (0.9 * 0.9 + 0.1 * 0.1) / d, (0.9 * 50 + 0.1 * 50) / d])
+    sim_ds_1.sort()
+    np.testing.assert_almost_equal(explanation.scores[1], sim_ds_1[::-1], decimal=3)
+
     assert (ds[explanation['ordered_indices'][0][0]] == ds[-1]).all()
     assert (ds[explanation['ordered_indices'][1][0]] == ds[-1]).all()
     explanation = explainer.explain(ds[-1], Y=ds[-1])

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_unit.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_unit.py
@@ -29,9 +29,13 @@ def test_method_explanations(linear_cls_model, random_cls_dataset):
     # test stored gradients
     explainer.fit(X_train=X_train, Y_train=Y_train)
     assert explainer.grad_X_train.shape == (len(X_train), *params.shape)
-    result = explainer.explain(X_train)
-    assert result.data['scores'].shape == (100, )
-    assert result.data['ordered_indices'].shape == (100,)
+    result = explainer.explain(X_train[0])
+    assert result.data['scores'].shape == (1, 100, )
+    assert result.data['ordered_indices'].shape == (1, 100,)
+
+    result = explainer.explain(X_train[0:4])
+    assert result.data['scores'].shape == (4, 100, )
+    assert result.data['ordered_indices'].shape == (4, 100,)
 
 
 @pytest.mark.parametrize('random_cls_dataset', [({'shape': 10, 'size': 100})], indirect=True)


### PR DESCRIPTION
# Adds batched similarity explanations

### What this changes:

- `explain` method returns a matrix of shape `(n_test, n_train)`. The elements of which are the similarity between each test instance to each training instance. `n_test` is the number of test instances passed to the method. If a single instance is passed without a leading batch dimension then the matrix returned will have shape `(1, n_train)`
- The similarity functions now expect two matrices with shapes: `(n_test, n_test_grads)` and `(n_train, n_train_grads)`. So the vectors of the gradients for each test instance and train instance. Note ` n_test_grads==n_train_grads`.
- I've also added tests for each of `grad_cos` and `grad_dot` for multiple samples with and without the gradients being precomputed. 

___

### Method

The explain method is now implemented as follows:

Note: If `precompute_grads` is true then the gradients for each of the training instances will have been computed already and stored in the `self.grad_X_train`.

1. First we preprocess the `X` and `Y` parameters so that they both have leading batch dimension. So if they're a single test instance they now are a member of a batch of size 1. 
2. We then compute the gradients for the test instances and accumulate them into a vector of shape `(batch_size, n_gradients)`. This is places in a variable `grads_X_test`
3. If `self.precompute_grads` is true then we pass `self.grads_X_train` to the similarity function to get the scores. The scores will be a matrix of shape `(n_test, n_train)`.
4. If `self.precompute_grads` is false then we compete the training gradients on the fly. 
    - We iterate through the training data and compute the gradients for each training instance.
    - for each instance we pass it to the similarity function along with all the test instances. This returns a vector of similarities for that training instance to each of the test instances. We accumulate these in a score vector of the correct size.
5. Finally the score values are passed to the `build_explanation` function.

___

### Examples:

1. [Tensorflow notebook](https://gist.github.com/mauicv/aab7233515cb7349f9620304be2911c3)
2. [Torch notebook](https://gist.github.com/mauicv/20263a3dd5746a17f89271bdad456830)
