### PR TITLE
Fix incorrect dependency message

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,7 +177,7 @@ you will need to:
 
 1. Add it to `extras_require` in `setup.py`.
 2. Create a new `tox` environment in `setup.cfg` with the new dependency.
-3. Add a new dependency name to `ERROR_TYPES` in `alibi/utils/missing_optional_dependency.py`. 
+3. Add a new dependency mapping for `ERROR_TYPES` in `alibi/utils/missing_optional_dependency.py`. 
 4. Make sure any public functionality is protected by the `import_optional` function.
 5. Make sure the new dependency is tested in `alibi/tests/test_dep_mangement.py`.
 

--- a/alibi/utils/missing_optional_dependency.py
+++ b/alibi/utils/missing_optional_dependency.py
@@ -19,7 +19,14 @@ err_msg_template = Template((
 ))
 
 
-ERROR_TYPES = {'ray', 'tensorflow', 'torch', 'shap', 'numba'}
+# Map from specific missing dependency to the name of the optional dependency bucket
+ERROR_TYPES = {
+    'ray': 'ray',
+    'tensorflow': 'tensorflow',
+    'torch': 'torch',
+    'shap': 'shap',
+    'numba': 'shap'
+}
 
 
 class MissingDependency:
@@ -43,8 +50,6 @@ class MissingDependency:
         err
             Error to be raised when the class is initialized or used
         """
-        if missing_dependency not in ERROR_TYPES:
-            raise ValueError(f"missing_dependency must be one of {ERROR_TYPES}")
         self.missing_dependency = missing_dependency
         self.object_name = object_name
         self.err = err
@@ -98,8 +103,15 @@ def import_optional(module_name: str, names: Optional[List[str]] = None) -> Any:
             raise TypeError()
         if err.name not in ERROR_TYPES:
             raise err
+        missing_dependency = ERROR_TYPES[err.name]
         if names is not None:
             missing_dependencies = \
-                tuple(MissingDependency(missing_dependency=err.name, object_name=name, err=err) for name in names)
+                tuple(MissingDependency(
+                    missing_dependency=missing_dependency,
+                    object_name=name,
+                    err=err) for name in names)
             return missing_dependencies if len(missing_dependencies) > 1 else missing_dependencies[0]
-        return MissingDependency(missing_dependency=err.name, object_name=module_name, err=err)
+        return MissingDependency(
+            missing_dependency=missing_dependency,
+            object_name=module_name,
+            err=err)

--- a/alibi/utils/tests/test_import_optional.py
+++ b/alibi/utils/tests/test_import_optional.py
@@ -8,11 +8,11 @@ class TestImportOptional:
 
     def setup_method(self):
         # mock missing dependency error for non existent module
-        ERROR_TYPES.add('non_existent_module')
+        ERROR_TYPES['non_existent_module'] = 'optional-deps'
 
     def teardown_method(self):
         # remove mock missing dependency error for other tests
-        ERROR_TYPES.remove('non_existent_module')
+        del ERROR_TYPES['non_existent_module']
 
     def test_import_optional_module(self):
         """Test import_optional correctly imports installed module."""
@@ -35,12 +35,12 @@ class TestImportOptional:
         with pytest.raises(ImportError) as err:
             package.__version__  # noqa
         assert 'alibi.utils.tests.mocked_opt_dep' in str(err.value)
-        assert 'pip install alibi[non_existent_module]' in str(err.value)
+        assert 'pip install alibi[optional-deps]' in str(err.value)
 
         with pytest.raises(ImportError) as err:
             package(0, 'test')  # noqa
         assert 'alibi.utils.tests.mocked_opt_dep' in str(err.value)
-        assert 'pip install alibi[non_existent_module]' in str(err.value)
+        assert 'pip install alibi[optional-deps]' in str(err.value)
 
     def test_import_optional_names_missing(self):
         """Test import_optional correctly replaces names from module that doesn't exist with MissingDependencies."""
@@ -51,10 +51,10 @@ class TestImportOptional:
         with pytest.raises(ImportError) as err:
             MockedClassWithoutRequiredDeps.__version__  # noqa
         assert 'MockedClassWithoutRequiredDeps' in str(err.value)
-        assert 'pip install alibi[non_existent_module]' in str(err.value)
+        assert 'pip install alibi[optional-deps]' in str(err.value)
 
         assert isinstance(mocked_function_without_required_deps, MissingDependency)
         with pytest.raises(ImportError) as err:
             mocked_function_without_required_deps.__version__  # noqa
         assert 'mocked_function_without_required_deps' in str(err.value)
-        assert 'pip install alibi[non_existent_module]' in str(err.value)
+        assert 'pip install alibi[optional-deps]' in str(err.value)


### PR DESCRIPTION
# Fix error message issue

This PR fixes the potential for incorrect optional dependency pip install messages to be issued for certain missing dependencies. Previously we used `ERROR_TYPES = {'ray', 'tensorflow', 'torch', 'shap', 'numba'}` for validation of the error type. We used the `err.name` as the optional dependency bucket name within the `pip install` command we give in the import error message. This means that if `numba` was not installed but `shap` was and a user tried to import something like `KernelShap` that's dependent on both then they'd get the message `pip install alibi[numba]` instead of the correct, `pip install alibi[shap]`. 

I've updated the `ERROR_TYPES` set to be a map from the missing dependency to the optional install bucket name and updated the tests to check for this behaviour. 