### PR TITLE
Add backend verification for GradientSimilarity

### DIFF
--- a/alibi/explainers/similarity/backends/__init__.py
+++ b/alibi/explainers/similarity/backends/__init__.py
@@ -12,7 +12,7 @@ if has_tensorflow:
 
 
 def _select_backend(backend: Framework = Framework.TENSORFLOW) \
-        -> Union[Type[_TensorFlowBackend], Type[_PytorchBackend]]:
+        -> Union[Type['_TensorFlowBackend'], Type['_PytorchBackend']]:
     """
     Selects the backend according to the `backend` flag.
 
@@ -21,4 +21,14 @@ def _select_backend(backend: Framework = Framework.TENSORFLOW) \
     backend
         Deep learning backend.
     """
+    # Check if pytorch/tensorflow backend supported.
+    if (backend == Framework.PYTORCH and not has_pytorch) or \
+            (backend == Framework.TENSORFLOW and not has_tensorflow):
+        raise ImportError(f'{backend} not installed. Cannot initialize and run the GradientExplainer'
+                          f' with {backend} backend.')
+
+    # Allow only pytorch and tensorflow.
+    elif backend not in [Framework.PYTORCH, Framework.TENSORFLOW]:
+        raise NotImplementedError(f'{backend} not implemented. Use `tensorflow` or `pytorch` instead.')
+
     return _TensorFlowBackend if backend == Framework.TENSORFLOW else _PytorchBackend


### PR DESCRIPTION
Fixes:
1. _TensorFlowBackend is used for typing and is not importable when tensorflow is not installed. This PR fixes an error that arises in the optional dependency tests by forward referencing `_TensorFlowBackend`
2. Add checks for correct backend installation in line with the approach taken for CounterFactaulRL implementation. Now if you run `make repl tox-env=tensorflow` and then import gradient similarity and init with `backend='torch'` you'll get the correct `backend no installed` error