### PR TITLE
Updated algorithms.md and getting_started.md with ProtoSelect

### DIFF
--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -33,8 +33,8 @@ methods/IntegratedGradients.ipynb
 methods/KernelSHAP.ipynb
 methods/LinearityMeasure.ipynb
 methods/ProtoSelect.ipynb
-methods/TrustScores.ipynb
 methods/TreeSHAP.ipynb
+methods/TrustScores.ipynb
 ```
 
 ```{toctree}

--- a/doc/source/methods/ProtoSelect.ipynb
+++ b/doc/source/methods/ProtoSelect.ipynb
@@ -58,9 +58,9 @@
    "source": [
     "A desirable prototype set for a class $l$ would satisfy the following properties:\n",
     "\n",
-    "* cover as many training points as possible of a class $l$.\n",
+    "* cover as many training points as possible of the class $l$.\n",
     "\n",
-    "* covers as few training points as possible of classes different than $l$.\n",
+    "* covers as few training points as possible of classes different from $l$.\n",
     "\n",
     "* is sparse (i.e., contains as few prototypes instances as possible). \n",
     "\n",
@@ -286,7 +286,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/doc/source/overview/algorithms.md
+++ b/doc/source/overview/algorithms.md
@@ -81,7 +81,7 @@ straight line from the baseline to the input.
 [Documentation](../methods/IntegratedGradients.ipynb),
 [MNIST example](../examples/integrated_gradients_mnist.ipynb),
 [Imagenet example](../examples/integrated_gradients_imagenet.ipynb),
-[IMDB example](../examples/integrated_gradients_imdb.ipynb).
+[IMDB example](../examples/integrated_gradients_imdb.ipynb),
 [Transformers example](../examples/integrated_gradients_transformers.ipynb).
 
 **Kernel Shapley Additive Explanations (Kernel SHAP)**: attribute the change of a model output with respect
@@ -93,7 +93,7 @@ dataset. This algorithm can be used to explain regression models and it is optim
 [continuous data](../examples/kernel_shap_wine_intro.ipynb),
 [more continuous data](../examples/kernel_shap_wine_lr.ipynb),
 [categorical data](../examples/kernel_shap_adult_lr.ipynb),
-[distributed_batch_explanations](../examples/distributed_kernel_shap_adult_lr.ipynb)
+[distributed_batch_explanations](../examples/distributed_kernel_shap_adult_lr.ipynb).
 
 **Tree Shapley Additive Explanations (Tree SHAP)**: attribute the change of a model output with respect to a baseline
 (e.g., average over a reference set or inferred from node data) to each of the input features. Similar to Kernel SHAP,
@@ -123,17 +123,17 @@ between the distance to the nearest class different from the predicted class and
 predicted class, higher scores correspond to more trustworthy predictions.
 [Documentation](../methods/TrustScores.ipynb),
 [tabular example](../examples/trustscore_iris.ipynb),
-[image classification](../examples/trustscore_mnist.ipynb)
+[image classification](../examples/trustscore_mnist.ipynb).
 
 **Linearity measure**: produces a score quantifying how linear the model is around a test instance.
 The linearity score measures the model linearity around a test instance by feeding the model linear
 superpositions of inputs and comparing the outputs with the linear combination of outputs from
 predictions on single inputs.
-[Documentation](../methods/LinearityMeasure.ipynb)
+[Documentation](../methods/LinearityMeasure.ipynb),
 [Tabular example](../examples/linearity_measure_iris.ipynb),
-[image classification](../examples/linearity_measure_fashion_mnist.ipynb)
+[image classification](../examples/linearity_measure_fashion_mnist.ipynb).
 
-### Prototypes
+## Prototypes
 These algorithms provide a **distilled** view of the dataset and help construct a 1-KNN **interpretable** classifier.
 
 |Method|Classification|Regression|Tabular|Text|Images|Categorical Features| Reference set labels |
@@ -146,5 +146,5 @@ constructed to encourage the following three properties: i) covers as many train
 class *k*; ii) covers as few training points as possible of classes different from *k*; iii) is sparse - contains as
 few prototypes as possible. The method can be applied to any data modality as long as there is a meaningful way of
 defining a "distance" between data points which can often be done using a domain-specific pre-processing function.
-[Documentation](../methods/ProtoSelect.ipynb)
-[Tabular and image example](../examples/protoselect_adult_cifar10.ipynb),
+[Documentation](../methods/ProtoSelect.ipynb),
+[Tabular and image example](../examples/protoselect_adult_cifar10.ipynb).

--- a/doc/source/overview/algorithms.md
+++ b/doc/source/overview/algorithms.md
@@ -132,3 +132,19 @@ predictions on single inputs.
 [Documentation](../methods/LinearityMeasure.ipynb)
 [Tabular example](../examples/linearity_measure_iris.ipynb),
 [image classification](../examples/linearity_measure_fashion_mnist.ipynb)
+
+### Prototypes
+These algorithms provide a **distilled** view of the dataset and help construct a 1-KNN **interpretable** classifier.
+
+|Method|Classification|Regression|Tabular|Text|Images|Categorical Features| Reference set labels |
+|:-----|:-------------|:---------|:------|:---|:-----|:-------------------|:---------------------|
+|[ProtoSelect](https://docs.seldon.io/projects/alibi/en/latest/methods/ProtoSelect.html)|✔| |✔|✔|✔|✔|Optional|
+
+**ProtoSelect**: produces a condensed view of the training dataset and facilitates the construction of an interpretable
+classification model through 1-KNN. Every class *k* of the training dataset is summarised by a prototype set
+constructed to encourage the following three properties: i) covers as many training points as possible of the
+class *k*; ii) covers as few training points as possible of classes different from *k*; iii) is sparse - contains as
+few prototypes as possible. The method can be applied to any data modality as long as there is a meaningful way of
+defining a "distance" between data points which can often be done using a domain-specific pre-processing function.
+[Documentation](../methods/ProtoSelect.ipynb)
+[Tabular and image example](../examples/protoselect_adult_cifar10.ipynb),

--- a/doc/source/overview/getting_started.md
+++ b/doc/source/overview/getting_started.md
@@ -174,6 +174,13 @@ alibi.confidence.__all__
  'TrustScore']
 ```
 
+For dataset summarization
+```python
+alibi.prototypes.__all__
+```
+```
+['ProtoSelect']
+```
 
 
 For detailed information on the methods:
@@ -184,9 +191,11 @@ For detailed information on the methods:
     * [Counterfactual Instances](../methods/CF.ipynb)
     * [Counterfactuals Guided by Prototypes](../methods/CFProto.ipynb)
     * [Counterfactuals with RL](../methods/CFRL.ipynb)
-    * [Kernel SHAP](../methods/KernelSHAP.ipynb)
     * [Integrated gradients](../methods/IntegratedGradients.ipynb)
+    * [Kernel SHAP](../methods/KernelSHAP.ipynb)
     * [Linearity Measure](../methods/LinearityMeasure.ipynb)
+    * [ProtoSelect](../methods/ProtoSelect.ipynb)
+    * [TreeShap](../methods/TreeSHAP.ipynb)
     * [Trust Scores](../methods/TrustScores.ipynb)
 
 ## Basic Usage


### PR DESCRIPTION
Besides updated `algorithms.md` and `getting_started.md` with `ProtoSelect`, the PR includes other minor fixes such as: reordering methods in alphabetical order, included missing `ThreeShap` notebooks, minor rephrasing in `ProtoSelect` method description.