### PR TITLE
Fix `asym_sim_fn` incorrect denominator 

### DIFF
--- a/alibi/explainers/similarity/metrics.py
+++ b/alibi/explainers/similarity/metrics.py
@@ -50,8 +50,8 @@ def cos(X: np.ndarray, Y: np.ndarray, eps: float = 1e-7) -> Union[float, np.ndar
 
 def asym_dot(X: np.ndarray, Y: np.ndarray, eps: float = 1e-7) -> Union[float, np.ndarray]:
     """
-    Computes the influence of instances `X` to instances `Y`. This is an asymmetric kernel.
-    (:math:`X^T Y//\\|X\\|^2`). See the `paper <https://arxiv.org/abs/2102.05262>`_ for more details. Each of `X` and
+    Computes the influence of training instances `Y` to test instances `X`. This is an asymmetric kernel.
+    (:math:`X^T Y//\\|Y\\|^2`). See the `paper <https://arxiv.org/abs/2102.05262>`_ for more details. Each of `X` and
     `Y` should have a leading batch dimension of size at least 1.
 
     Parameters
@@ -70,5 +70,5 @@ def asym_dot(X: np.ndarray, Y: np.ndarray, eps: float = 1e-7) -> Union[float, np
 
     assert len(X.shape) > 1 and len(Y.shape) > 1, "The vectors `X` and `Y` should have a leading batch dimension."
     assert X.shape[1] == Y.shape[1], "The second dimension of `X` needs to be the same as the dimension of `Y`."
-    denominator = np.linalg.norm(X, axis=1) ** 2
-    return np.dot(X, Y.T) / (denominator + eps)[:, None]
+    denominator = np.linalg.norm(Y, axis=1) ** 2
+    return np.dot(X, Y.T) / (denominator + eps)[None, :]

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
@@ -284,16 +284,22 @@ def test_multiple_test_instances_stored_grads_asym_dot(precompute_grads):
 
     # In the case of `grad_asym_dot` we manually check the similarities as the asymmetry of the metric means ordering
     # is important.
-    sim_ds_0 = np.array([(1 * 1 + 0 * 0), (1 * 0.9 + 0 * 0.1), (1 * 50 + 0 * 50)]) / (1 + 1e-7)
+    denoms = np.array([1, (0.9**2 + 0.1**2), 2 * 50**2])
+    sim_ds_0 = np.array([
+        (1 * 1 + 0 * 0),
+        (1 * 0.9 + 0 * 0.1),
+        (1 * 50 + 0 * 50)
+    ]) / (denoms + 1e-7)
     sim_ds_0.sort()
+
     np.testing.assert_allclose(explanation.scores[0], sim_ds_0[::-1], atol=1e-6)
-
-    d = (0.9**2 + 0.1**2)
-    sim_ds_1 = np.array([(0.9 * 1 + 0.1 * 0), (0.9 * 0.9 + 0.1 * 0.1), (0.9 * 50 + 0.1 * 50)]) / (d + 1e-7)
+    sim_ds_1 = np.array([(0.9 * 1 + 0.1 * 0), (0.9 * 0.9 + 0.1 * 0.1), (0.9 * 50 + 0.1 * 50)]) / (denoms + 1e-7)
     sim_ds_1.sort()
-    np.testing.assert_allclose(explanation.scores[1], sim_ds_1[::-1], atol=1e-6)
 
-    np.testing.assert_array_equal(ds[explanation['ordered_indices'][0][0]], ds[-1])
-    np.testing.assert_array_equal(ds[explanation['ordered_indices'][1][0]], ds[-1])
+    np.testing.assert_allclose(explanation.scores[1], sim_ds_1[::-1], atol=1e-6)
+    np.testing.assert_array_equal(ds[explanation['ordered_indices'][0][0]], ds[1])
+    np.testing.assert_array_equal(ds[explanation['ordered_indices'][1][0]], ds[1])
     explanation = explainer.explain(ds[-1], Y=ds[-1])
-    np.testing.assert_array_equal(explanation.scores, np.array([[1., 0.01, 0.01]], dtype=np.float32))
+    scores = np.array([[50, 50 / (0.9 ** 2 + 0.1 ** 2), 1]], dtype=np.float32)
+    scores.sort()
+    np.testing.assert_allclose(explanation.scores, scores[:, ::-1], atol=1e-4)

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
@@ -300,6 +300,6 @@ def test_multiple_test_instances_stored_grads_asym_dot(precompute_grads):
     np.testing.assert_array_equal(ds[explanation['ordered_indices'][0][0]], ds[1])
     np.testing.assert_array_equal(ds[explanation['ordered_indices'][1][0]], ds[1])
     explanation = explainer.explain(ds[-1], Y=ds[-1])
-    scores = np.array([[50, 50 / (0.9 ** 2 + 0.1 ** 2), 1]], dtype=np.float32)
+    scores = np.array([[50, 50, 2*50**2]], dtype=np.float32) / (denoms + 1e-7)
     scores.sort()
     np.testing.assert_allclose(explanation.scores, scores[:, ::-1], atol=1e-4)


### PR DESCRIPTION
Previously denominator was the test instance where it should be the training instance. Fix changes this and corrects tests to match.