### PR TITLE
bump sklearn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ if __name__ == '__main__':
           install_requires=[
               'numpy>=1.16.2, <2.0.0',
               'pandas>=0.23.3, <2.0.0',
-              'scikit-learn>=0.20.2, <2.0.0',
+              'scikit-learn>=0.22.0, <2.0.0',
               'spacy[lookups]>=2.0.0, <4.0.0',
               'scikit-image>=0.14.2, !=0.17.1, <0.20',  # https://github.com/SeldonIO/alibi/issues/215
               'requests>=2.21.0, <3.0.0',


### PR DESCRIPTION
Bump `scikit-learn >= 0.22.0`.
Earlier version might not work for `GradientSimilarity` notebook examples.
