### PR TITLE
Export prototypes subpackage into alibi namespace

### DIFF
--- a/alibi/__init__.py
+++ b/alibi/__init__.py
@@ -1,4 +1,4 @@
-from . import confidence, datasets, explainers, utils
+from . import confidence, datasets, explainers, prototypes, utils
 from .version import __version__  # noqa F401
 
-__all__ = ['confidence', 'datasets', 'explainers', 'utils']
+__all__ = ['confidence', 'datasets', 'explainers', 'prototypes', 'utils']

--- a/doc/source/overview/getting_started.md
+++ b/doc/source/overview/getting_started.md
@@ -180,7 +180,8 @@ For dataset summarization
 alibi.prototypes.__all__
 ```
 ```
-['ProtoSelect']
+['ProtoSelect',
+ 'visualize_image_prototypes']
 ```
 
 


### PR DESCRIPTION
Noticed that `alibi.prototypes` wasn't exported into `alibi` so things like `alibi.prototypes.__all__` would fail. Adjusted the docs also.

For future, I think we can remove the `*__all__` lists from the getting started docs as it doesn't add much and introduces another place that needs to be manually maintained.