### PR TITLE
Prune doc/ and examples/ from source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include alibi/data/cats.tar.gz
+prune doc/
+prune examples/


### PR DESCRIPTION
This PR explicitly prunes the `doc/` and `examples/` directories so that they are not packaged into the source distribution. This results in a much smaller `sdist` size.

The impact of this should be minimal as:
1. Most people would install the `bdist` wheel as we are a pure Python library.
2. I don't think anyone would ever rely on having docs and examples available in the `sdist`.