### PR TITLE
Fix numpy1.22 typing issues

### DIFF
--- a/alibi/confidence/trustscore.py
+++ b/alibi/confidence/trustscore.py
@@ -179,7 +179,7 @@ class TrustScore:
             X = X.reshape(X.shape[0], -1)
 
         # init distance matrix: [nb instances, nb classes]
-        d = np.tile(None, (X.shape[0], self.classes))  # type: np.ndarray
+        d = np.tile(np.nan, (X.shape[0], self.classes))  # type: np.ndarray
 
         for c in range(self.classes):
             d_tmp = self.kdtrees[c].query(X, k=k)[0]  # get k nearest neighbors for each class

--- a/alibi/explainers/cfproto.py
+++ b/alibi/explainers/cfproto.py
@@ -179,7 +179,7 @@ class CounterfactualProto(Explainer, FitMixin):
         self.c_init = c_init
         self.c_steps = c_steps
         self.feature_range = tuple([(np.ones(shape[1:]) * feature_range[_])[None, :]
-                                    if isinstance(feature_range[_], float) else feature_range[_]
+                                    if isinstance(feature_range[_], float) else np.array(feature_range[_])
                                     for _ in range(2)])
         self.update_num_grad = update_num_grad
         self.eps = eps

--- a/alibi/explainers/cfrl_base.py
+++ b/alibi/explainers/cfrl_base.py
@@ -860,8 +860,9 @@ class CounterfactualRL(Explainer, FitMixin):
 
             # Append the new batch off results.
             for key in all_results:
-                if all_results[key] is not None:
-                    all_results[key] = np.concatenate([all_results[key], results[key]], axis=0)
+                all_results_val, results_val = all_results[key], results[key]
+                if all_results_val is not None and results_val is not None:
+                    all_results[key] = np.concatenate([all_results_val, results_val], axis=0)
 
         # see https://github.com/python/mypy/issues/5382 for the type ignore
         return self._build_explanation(**all_results)  # type: ignore[arg-type]

--- a/alibi/prototypes/protoselect.py
+++ b/alibi/prototypes/protoselect.py
@@ -403,7 +403,7 @@ def cv_protoselect_euclidean(trainset: Tuple[np.ndarray, np.ndarray],
             if quantiles[0] > quantiles[1]:
                 raise ValueError('The quantile lower-bound is greater then the quantile upper-bound.')
             quantiles = np.clip(quantiles, a_min=0, a_max=1)
-            min_dist, max_dist = np.quantile(a=dist, q=quantiles)
+            min_dist, max_dist = np.quantile(a=dist, q=np.array(quantiles))
         else:
             min_dist, max_dist = np.min(dist), np.max(dist)
         # define list of values for eps


### PR DESCRIPTION
With the release of numba 0.55.2 (https://github.com/numba/numba/blob/0.55.2/CHANGE_LOG) numpy 1.22 is now installable. This PR fixes typing issues that arose as a result of this version of numpy. See also [Related pr in alibi-detect](https://github.com/SeldonIO/alibi-detect/pull/520)