### PR TITLE
Pin protobuf < 4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,10 @@ def readme():
 exec(open('alibi/version.py').read())
 
 extras_require = {
-    'ray': ['ray>=0.8.7, <2.0.0'],
+    'ray': [
+        'ray>=0.8.7, <2.0.0',
+        'protobuf<4'
+    ],
     # shap is separated due to build issues, see https://github.com/slundberg/shap/pull/1802
     'shap': [
         'shap>=0.40.0, <0.41.0',  # versioning: https://github.com/SeldonIO/alibi/issues/333


### PR DESCRIPTION
Fixes ray dependency issue in CI due to [protobuf release 4.21.1](https://github.com/protocolbuffers/protobuf/issues/10051). Should be reverted once [this issue](https://github.com/ray-project/ray/issues/25282) is resolved.