### PR TITLE
Add ascillitoe and mauicv as dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
   open-pull-requests-limit: 10
   reviewers:
     - "jklaise"
+    - "ascillitoe"
+    - "mauicv"


### PR DESCRIPTION
Updating dependabot reviewers to match `alibi-detect`.