### PR TITLE
Remove incorrect empty anchor justification

### DIFF
--- a/doc/source/overview/faq.md
+++ b/doc/source/overview/faq.md
@@ -35,9 +35,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 ### Why is my anchor explanation empty (tabular or text data) or black (image data)?
 
-This is expected behaviour and signals that there is no salient subset of features that is necessary for the prediction to hold. This can happen in two ways:
- - The predicted class of the data point does not change regardless of the perturbations applied to it.
- - The predicted class of the data point always changes regardless of the perturbations applied to it.
+This is expected behaviour and signals that there is no salient subset of features that is necessary for the prediction to hold. In other words, the predicted class of the data point does not change regardless of the perturbations applied to it.
 
 **Note:** this behaviour can be typical for very imbalanced datasets, [see comment from the author](https://github.com/marcotcr/anchor/issues/71#issuecomment-863591122).
 

--- a/doc/source/overview/faq.md
+++ b/doc/source/overview/faq.md
@@ -35,7 +35,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 ### Why is my anchor explanation empty (tabular or text data) or black (image data)?
 
-This is expected behaviour and signals that there is no salient subset of features that is necessary for the prediction to hold. In other words, the predicted class of the data point does not change regardless of the perturbations applied to it.
+This is expected behaviour and signals that there is no salient subset of features that is necessary for the prediction to hold. In other words, with high probability (as measured by the precision), the predicted class of the data point does not change regardless of the perturbations applied to it.
 
 **Note:** this behaviour can be typical for very imbalanced datasets, [see comment from the author](https://github.com/marcotcr/anchor/issues/71#issuecomment-863591122).
 


### PR DESCRIPTION
The second point in the current version of the docs should not be possible because if it was (empty anchor returned and the prediction always changes, regardless of perturbation), the empty anchor would have precision ~0 and hence would not be returned in the first place. In fact, if the prediction does change a lot regardless of the perturbation, the data point is likely near the decision boundary and the algorithm will try longer and longer anchors to find something that satisfies the precision threshold.