### PR TITLE
[WIP] Check compatible optional dependency versions

### DIFF
--- a/alibi/utils/missing_optional_dependency.py
+++ b/alibi/utils/missing_optional_dependency.py
@@ -12,10 +12,10 @@ from string import Template
 from importlib import import_module
 
 err_msg_template = Template((
-    "Attempted to use $object_name without the correct optional dependencies installed. To install "
-    + "the correct optional dependencies, run `pip install alibi[$missing_dependency]` "
-    + "from the command line. For more information, check the Installation documentation "
-    + "at https://docs.seldon.io/projects/alibi/en/latest/overview/getting_started.html."
+    "Attempted to use $object_name without the correct optional dependencies installed. This may be due to missing"
+    + " or incompatible versions of dependencies. To install the correct optional dependencies, run"
+    + "`pip install alibi[$missing_dependency]` from the command line. For more information, check the installation"
+    + "documentation at https://docs.seldon.io/projects/alibi/en/latest/overview/getting_started.html."
 ))
 
 

--- a/alibi/utils/missing_optional_dependency.py
+++ b/alibi/utils/missing_optional_dependency.py
@@ -13,7 +13,7 @@ from importlib import import_module
 
 err_msg_template = Template((
     "Attempted to use $object_name without the correct optional dependencies installed. This may be due to missing"
-    + " or incompatible versions of dependencies. To install the correct optional dependencies, run"
+    + " or incompatible versions of dependencies. To install the correct optional dependencies, run "
     + "`pip install alibi[$missing_dependency]` from the command line. For more information, check the installation"
     + "documentation at https://docs.seldon.io/projects/alibi/en/latest/overview/getting_started.html."
 ))

--- a/alibi/utils/missing_optional_dependency.py
+++ b/alibi/utils/missing_optional_dependency.py
@@ -99,11 +99,12 @@ def import_optional(module_name: str, names: Optional[List[str]] = None) -> Any:
             return objs if len(objs) > 1 else objs[0]
         return module
     except (ImportError, ModuleNotFoundError) as err:
-        if err.name is None:
+        name, *_ = err.name.split('.')
+        if name is None:
             raise TypeError()
-        if err.name not in ERROR_TYPES:
+        if name not in ERROR_TYPES:
             raise err
-        missing_dependency = ERROR_TYPES[err.name]
+        missing_dependency = ERROR_TYPES[name]
         if names is not None:
             missing_dependencies = \
                 tuple(MissingDependency(

--- a/alibi/utils/missing_optional_dependency.py
+++ b/alibi/utils/missing_optional_dependency.py
@@ -99,9 +99,9 @@ def import_optional(module_name: str, names: Optional[List[str]] = None) -> Any:
             return objs if len(objs) > 1 else objs[0]
         return module
     except (ImportError, ModuleNotFoundError) as err:
-        name, *_ = err.name.split('.')
-        if name is None:
+        if err.name is None:
             raise TypeError()
+        name, *_ = err.name.split('.')
         if name not in ERROR_TYPES:
             raise err
         missing_dependency = ERROR_TYPES[name]


### PR DESCRIPTION
# What is this:

This draft PR addresses #709 and adds checks for compatibility of optional dependencies in `import_optional`. Note that at the moment this functionality just checks that the correct submodels are present in the imported dependency. This solves the issue described in #709 where Shap throws an error on account of the version installed in Kaggle having an incompatible module structure.

# Todo:

- [x] Rewrite warning to reflect incompatible versions not just uninstalled dependency

# Open Questions:

Should we be checking the version compatibility explicitly instead?