### PR TITLE
Pin sphinx <5.1.0

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,6 @@
 # dependencies for building docs, separate from dev.txt as this is also used for builds on readthedocs.org
 # core dependencies
-sphinx>=4.2.0, <6.0.0 # Enforce 4.x sphinx version so that mathjax works correctly
+sphinx>=4.2.0, <5.1.0 # Enforce 4.x sphinx version so that mathjax works correctly
 sphinx-autodoc-typehints>=1.12.0, <=2.0.0 
 sphinx-rtd-theme>=1.0.0, <2.0.0
 myst-parser>=0.14, <0.19

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,6 @@
 # dependencies for building docs, separate from dev.txt as this is also used for builds on readthedocs.org
 # core dependencies
-sphinx>=4.2.0, <5.1.0 # Enforce 4.x sphinx version so that mathjax works correctly
+sphinx>=4.2.0, <5.1.0
 sphinx-autodoc-typehints>=1.12.0, <=2.0.0 
 sphinx-rtd-theme>=1.0.0, <2.0.0
 myst-parser>=0.14, <0.19


### PR DESCRIPTION
[CI failing due to `sphinx==5.1.0`](https://github.com/sphinx-doc/sphinx/issues/10701). Pin to less than.