### PR TITLE
Use pytest-custom_exit_code to not flag empty notebook test suite as …

### DIFF
--- a/.github/workflows/test_all_notebooks.yml
+++ b/.github/workflows/test_all_notebooks.yml
@@ -22,9 +22,9 @@ jobs:
         os: [ubuntu-latest]
         python-version: [ '3.7', '3.8', '3.9', '3.10' ]
         include: # Run macos and windows tests on only one python version
-          - os: windows-latest 
-            python-version:  '3.9'  # PyTorch doesn't yet have 3.10 support on Windows (https://pytorch.org/get-started/locally/#windows-python) 
-          - os: macos-latest 
+          - os: windows-latest
+            python-version:  '3.9'  # PyTorch doesn't yet have 3.10 support on Windows (https://pytorch.org/get-started/locally/#windows-python)
+          - os: macos-latest
             python-version:  '3.10'
 
     steps:
@@ -52,4 +52,4 @@ jobs:
 
       - name: Run notebooks
         run: |
-          pytest --no-cov -rA --durations=0 -vv testing/test_notebooks.py
+          pytest -suppress-no-test-exit-code --no-cov -rA --durations=0 -vv testing/test_notebooks.py

--- a/.github/workflows/test_all_notebooks.yml
+++ b/.github/workflows/test_all_notebooks.yml
@@ -52,4 +52,4 @@ jobs:
 
       - name: Run notebooks
         run: |
-          pytest -suppress-no-test-exit-code --no-cov -rA --durations=0 -vv testing/test_notebooks.py
+          pytest --suppress-no-test-exit-code --no-cov -rA --durations=0 -vv testing/test_notebooks.py

--- a/.github/workflows/test_changed_notebooks.yml
+++ b/.github/workflows/test_changed_notebooks.yml
@@ -29,9 +29,9 @@ jobs:
         os: [ubuntu-latest]
         python-version: [ '3.7', '3.8', '3.9', '3.10' ]
         include: # Run macos and windows tests on only one python version
-          - os: windows-latest 
-            python-version:  '3.9'  # PyTorch doesn't yet have 3.10 support on Windows (https://pytorch.org/get-started/locally/#windows-python) 
-          - os: macos-latest 
+          - os: windows-latest
+            python-version:  '3.9'  # PyTorch doesn't yet have 3.10 support on Windows (https://pytorch.org/get-started/locally/#windows-python)
+          - os: macos-latest
             python-version:  '3.10'
 
     steps:
@@ -73,4 +73,4 @@ jobs:
         # adding the `or` quantifier between the names and concatenating with the test name `test_notebook_execution`.
         run: |
           tests="test_notebook_execution[$(echo ${FILES} | sed 's|doc/source/examples/||g' | sed 's| | or |g')]" &&
-          pytest --no-cov -rA --durations=0 -vv testing/test_notebooks.py -k "$tests"
+          pytest -suppress-no-test-exit-code --no-cov -rA --durations=0 -vv testing/test_notebooks.py -k "$tests"

--- a/.github/workflows/test_changed_notebooks.yml
+++ b/.github/workflows/test_changed_notebooks.yml
@@ -73,4 +73,4 @@ jobs:
         # adding the `or` quantifier between the names and concatenating with the test name `test_notebook_execution`.
         run: |
           tests="test_notebook_execution[$(echo ${FILES} | sed 's|doc/source/examples/||g' | sed 's| | or |g')]" &&
-          pytest -suppress-no-test-exit-code --no-cov -rA --durations=0 -vv testing/test_notebooks.py -k "$tests"
+          pytest --suppress-no-test-exit-code --no-cov -rA --durations=0 -vv testing/test_notebooks.py -k "$tests"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,6 +8,7 @@ pytest>=5.3.5, <7.0.0
 pytest-cov>=2.6.1, <4.0.0
 pytest-xdist>=1.28.0, <3.0.0 # for distributed testing, currently unused (see setup.cfg)
 pytest-lazy-fixture>=0.6.3, <0.7.0
+pytest-custom_exit_code>=0.3.0 # for notebook tests
 pytest-timeout>=1.4.2, <3.0.0 # for notebook tests
 jupytext>=1.12.0, <2.0.0 # for notebook tests
 ipykernel>=5.1.0, <6.0.0 # for notebook tests


### PR DESCRIPTION
…a CI failure

Resolves #647. @ascillitoe if happy with implementation I'll open an identical PR for alibi-detect.