### PR TITLE
Add `NotFittedError` and use it in `AnchorTabular`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 [Full Changelog](https://github.com/SeldonIO/alibi/compare/v0.7.0...v0.7.1)
 
 ## Added
+- New `exceptions.NotFittedError` exception which is raised whenever a compulsory call to a `fit` method has not been carried out. Specifically, this is now raised in `AnchorTabular.explain` when `AnchorTabular.fit` has been skipped ([#732](https://github.com/SeldonIO/alibi/pull/732)).
 
 ## Fixed
 

--- a/alibi/exceptions.py
+++ b/alibi/exceptions.py
@@ -41,3 +41,9 @@ class PredictorReturnTypeError(AlibiException, AlibiPredictorReturnTypeError):
     an unexpected or unsupported type.
     """
     pass
+
+class NotFittedError(AlibiException):
+    """
+    This exception is raised whenever a compulsory call to a `fit` method has not been carried out.
+    """
+    pass

--- a/alibi/exceptions.py
+++ b/alibi/exceptions.py
@@ -42,6 +42,7 @@ class PredictorReturnTypeError(AlibiException, AlibiPredictorReturnTypeError):
     """
     pass
 
+
 class NotFittedError(AlibiException):
     """
     This exception is raised whenever a compulsory call to a `fit` method has not been carried out.

--- a/alibi/exceptions.py
+++ b/alibi/exceptions.py
@@ -47,4 +47,8 @@ class NotFittedError(AlibiException):
     """
     This exception is raised whenever a compulsory call to a `fit` method has not been carried out.
     """
-    pass
+
+    def __init__(self, object_name: str):
+        super().__init__(
+            f"This {object_name} instance is not fitted yet. Call 'fit' with appropriate arguments first."
+        )

--- a/alibi/explainers/anchors/anchor_tabular.py
+++ b/alibi/explainers/anchors/anchor_tabular.py
@@ -802,8 +802,7 @@ class AnchorTabular(Explainer, FitMixin):
             If `fit` has not been called prior to calling `explain`.
         """
         if not self._fitted:
-            msg = f"This {self.meta['name']} instance is not fitted yet. Call 'fit' with appropriate arguments first."
-            raise NotFittedError(msg)
+            raise NotFittedError(self.meta["name"])
 
         # transform one-hot encodings to labels if ohe == True
         X = ohe_to_ord(X_ohe=X.reshape(1, -1), cat_vars_ohe=self.cat_vars_ohe)[0].reshape(-1) if self.ohe else X

--- a/alibi/explainers/anchors/anchor_tabular.py
+++ b/alibi/explainers/anchors/anchor_tabular.py
@@ -8,7 +8,8 @@ import numpy as np
 
 from alibi.api.defaults import DEFAULT_DATA_ANCHOR, DEFAULT_META_ANCHOR
 from alibi.api.interfaces import Explainer, Explanation, FitMixin
-from alibi.exceptions import (PredictorCallError,
+from alibi.exceptions import (NotFittedError,
+                              PredictorCallError,
                               PredictorReturnTypeError)
 from alibi.utils.discretizer import Discretizer
 from alibi.utils.mapping import ohe_to_ord, ord_to_ohe
@@ -647,6 +648,8 @@ class AnchorTabular(Explainer, FitMixin):
         # update metadata
         self.meta['params'].update(seed=seed)
 
+        self._fitted = False
+
     def fit(self,  # type: ignore[override]
             train_data: np.ndarray,
             disc_perc: Tuple[Union[int, float], ...] = (25, 50, 75),
@@ -685,6 +688,8 @@ class AnchorTabular(Explainer, FitMixin):
 
         # update metadata
         self.meta['params'].update(disc_perc=disc_perc)
+
+        self._fitted = True
 
         return self
 
@@ -791,6 +796,10 @@ class AnchorTabular(Explainer, FitMixin):
             .. _AnchorTabular examples:
                 https://docs.seldon.io/projects/alibi/en/stable/methods/Anchors.html
         """
+        if not self._fitted:
+            msg = f"This {self.meta['name']} instance is not fitted yet. Call 'fit' with appropriate arguments first."
+            raise NotFittedError(msg)
+
         # transform one-hot encodings to labels if ohe == True
         X = ohe_to_ord(X_ohe=X.reshape(1, -1), cat_vars_ohe=self.cat_vars_ohe)[0].reshape(-1) if self.ohe else X
 

--- a/alibi/explainers/anchors/anchor_tabular.py
+++ b/alibi/explainers/anchors/anchor_tabular.py
@@ -795,6 +795,11 @@ class AnchorTabular(Explainer, FitMixin):
 
             .. _AnchorTabular examples:
                 https://docs.seldon.io/projects/alibi/en/stable/methods/Anchors.html
+
+        Raises
+        ------
+        :py:class:`alibi.exceptions.NotFittedError`
+            If `fit` has not been called prior to calling `explain`.
         """
         if not self._fitted:
             msg = f"This {self.meta['name']} instance is not fitted yet. Call 'fit' with appropriate arguments first."

--- a/alibi/explainers/tests/test_anchor_tabular.py
+++ b/alibi/explainers/tests/test_anchor_tabular.py
@@ -6,7 +6,7 @@ import pytest
 from pytest_lazyfixture import lazy_fixture
 
 from alibi.api.defaults import DEFAULT_META_ANCHOR, DEFAULT_DATA_ANCHOR
-from alibi.exceptions import PredictorCallError, PredictorReturnTypeError
+from alibi.exceptions import NotFittedError, PredictorCallError, PredictorReturnTypeError
 from alibi.explainers import AnchorTabular, DistributedAnchorTabular
 from alibi.explainers.tests.utils import predict_fcn
 
@@ -322,6 +322,13 @@ def bad_predictor(x: np.ndarray) -> list:
     return list(x)
 
 
+def good_predictor(x: np.ndarray) -> np.ndarray:
+    """
+    A dummy predictor returning a vector of random binary target labels.
+    """
+    return np.random.randint(low=0, high=2, size=x.shape[0])
+
+
 def test_anchor_tabular_fails_init_bad_feature_names_predictor_call():
     """
     In this test `feature_names` is misspecified leading to an exception calling the `predictor`.
@@ -336,3 +343,11 @@ def test_anchor_tabular_fails_bad_predictor_return_type():
     """
     with pytest.raises(PredictorReturnTypeError):
         explainer = AnchorTabular(bad_predictor, feature_names=['f1', 'f2', 'f3'])  # noqa: F841
+
+
+def test_anchor_tabular_explain_fails_not_fitted():
+    explainer = AnchorTabular(good_predictor, feature_names=['f1', 'f2'])
+    with pytest.raises(NotFittedError) as err:
+        explainer.explain(np.ones(2))
+    expected_msg = "This AnchorTabular instance is not fitted yet. Call 'fit' with appropriate arguments first."
+    assert str(err.value) == expected_msg


### PR DESCRIPTION
Whilst debugging #317 a few times I called the `explain` method without having called the `fit` method first which resulted in a cryptic stack trace:

```
Traceback (most recent call last):
  File "/opt/pycharm-professional/plugins/python/helpers/pydev/pydevd.py", line 1483, in _exec
    pydev_imports.execfile(file, globals, locals)  # execute the script
  File "/opt/pycharm-professional/plugins/python/helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "/home/janis/PycharmProjects/public-fork-alibi/dev_notebooks/#317-minimal.py", line 37, in <module>
    explanation = explainer.explain(bad_instance)  # breaks here
  File "/home/janis/PycharmProjects/public-fork-alibi/alibi/explainers/anchors/anchor_tabular.py", line 815, in explain
    self.instance_label = self.samplers[0].instance_label
IndexError: list index out of range
```

This PR introduces a `NotFittedError` and a private `_fitted` attribute to `AnchorTabular` to determine when to raise this error resulting in a much nicer error message:

```
Traceback (most recent call last):
  File "/opt/pycharm-professional/plugins/python/helpers/pydev/pydevd.py", line 1483, in _exec
    pydev_imports.execfile(file, globals, locals)  # execute the script
  File "/opt/pycharm-professional/plugins/python/helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "/home/janis/PycharmProjects/public-fork-alibi/dev_notebooks/#317-minimal.py", line 37, in <module>
    explanation = explainer.explain(bad_instance)  # breaks here
  File "/home/janis/PycharmProjects/public-fork-alibi/alibi/explainers/anchors/anchor_tabular.py", line 801, in explain
    raise NotFittedError(msg)
alibi.exceptions.NotFittedError: This AnchorTabular instance is not fitted yet. Call 'fit' with appropriate arguments first.
```

The reason for going with `NotFittedError` instead of `AlibiNotFittedError` is that the pre-fix `Alibi` makes for more verbose errors and should be unnecessary as all exceptions derive from `AlibiException` so that they can all be caught at once. My thinking is to open another PR to rename the 2 current exceptions with the `Alibi` prefix to have no prefix (but keep the old classes and inherit from them to prevent immediate breakage of existing user code).