### PR TITLE
Rename exception classes to be more concise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## [v0.7.1](https://github.com/SeldonIO/alibi/tree/v0.7.1) (2022-XX-XX)
+[Full Changelog](https://github.com/SeldonIO/alibi/compare/v0.7.0...v0.7.1)
+
+## Added
+
+## Fixed
+
+## Changed
+- Renamed our custom exception classes to remove the verbose `Alibi*` prefix and standardised the `*Error` suffix. Concretely:
+  - `exceptions.AlibiPredictorCallException` is now `exceptions.PredictorCallError`
+  - `exceptions.AlibiPredictorReturnTypeError` is now `exceptions.PredictorReturnTypeError`. Backwards compatibility has been maintained by subclassing the new exception classes by the old ones, **but these will likely be removed in a future version** ([#733](https://github.com/SeldonIO/alibi/pull/733)).
+
+## Development
+
+
 ## [v0.7.0](https://github.com/SeldonIO/alibi/tree/v0.7.0) (2022-05-18)
 [Full Changelog](https://github.com/SeldonIO/alibi/compare/v0.6.5...v0.7.0)
 

--- a/alibi/exceptions.py
+++ b/alibi/exceptions.py
@@ -14,14 +14,28 @@ class AlibiException(Exception, ABC):
         super().__init__(message)
 
 
-class AlibiPredictorCallException(AlibiException):
+# Legacy exception classes starting with the prefix `Alibi`.
+# These have been kept around for backwards compatibility.
+# Any new exception classes should not start with the `Alibi` prefix.
+class AlibiPredictorCallException:
+    pass
+
+
+class AlibiPredictorReturnTypeError:
+    pass
+
+
+# Exception classes. These should only inherit from `AlibiException`. Ones inheriting from
+# other classes beginning with the prefix `Alibi` are to do with backwards compatibility as
+# exception classes used to all start with the prefix `Alibi`.`
+class PredictorCallError(AlibiException, AlibiPredictorCallException):
     """
     This exception is raised whenever a call to a user supplied predictor fails at runtime.
     """
     pass
 
 
-class AlibiPredictorReturnTypeError(AlibiException):
+class PredictorReturnTypeError(AlibiException, AlibiPredictorReturnTypeError):
     """
     This exception is raised whenever the return type of a user supplied predictor is of
     an unexpected or unsupported type.

--- a/alibi/explainers/anchors/anchor_image.py
+++ b/alibi/explainers/anchors/anchor_image.py
@@ -8,8 +8,8 @@ from skimage.segmentation import felzenszwalb, quickshift, slic
 
 from alibi.api.defaults import DEFAULT_DATA_ANCHOR_IMG, DEFAULT_META_ANCHOR
 from alibi.api.interfaces import Explainer, Explanation
-from alibi.exceptions import (AlibiPredictorCallException,
-                              AlibiPredictorReturnTypeError)
+from alibi.exceptions import (PredictorCallError,
+                              PredictorReturnTypeError)
 from alibi.utils.wrappers import ArgmaxTransformer
 
 from .anchor_base import AnchorBaseBeam
@@ -342,9 +342,9 @@ class AnchorImage(Explainer):
 
         Raises
         ------
-        :py:class:`alibi.exceptions.AlibiPredictorCallException`
+        :py:class:`alibi.exceptions.PredictorCallError`
             If calling `predictor` fails at runtime.
-        :py:class:`alibi.exceptions.AlibiPredictorReturnTypeError`
+        :py:class:`alibi.exceptions.PredictorReturnTypeError`
             If the return type of `predictor` is not `np.ndarray`.
         """
         super().__init__(meta=copy.deepcopy(DEFAULT_META_ANCHOR))
@@ -665,11 +665,11 @@ class AnchorImage(Explainer):
         except Exception as e:
             msg = f"Predictor failed to be called on {type(x)} of shape {x.shape} and dtype {x.dtype}. " \
                   f"Check that the parameter `image_shape` is correctly specified."
-            raise AlibiPredictorCallException(msg) from e
+            raise PredictorCallError(msg) from e
 
         if not isinstance(prediction, np.ndarray):
             msg = f"Excepted predictor return type to be {np.ndarray} but got {type(prediction)}."
-            raise AlibiPredictorReturnTypeError(msg)
+            raise PredictorReturnTypeError(msg)
 
         if np.argmax(prediction.shape) == 0:
             return predictor

--- a/alibi/explainers/anchors/anchor_tabular.py
+++ b/alibi/explainers/anchors/anchor_tabular.py
@@ -8,8 +8,8 @@ import numpy as np
 
 from alibi.api.defaults import DEFAULT_DATA_ANCHOR, DEFAULT_META_ANCHOR
 from alibi.api.interfaces import Explainer, Explanation, FitMixin
-from alibi.exceptions import (AlibiPredictorCallException,
-                              AlibiPredictorReturnTypeError)
+from alibi.exceptions import (PredictorCallError,
+                              PredictorReturnTypeError)
 from alibi.utils.discretizer import Discretizer
 from alibi.utils.mapping import ohe_to_ord, ord_to_ohe
 from alibi.utils.wrappers import ArgmaxTransformer
@@ -610,9 +610,9 @@ class AnchorTabular(Explainer, FitMixin):
 
         Raises
         ------
-        :py:class:`alibi.exceptions.AlibiPredictorCallException`
+        :py:class:`alibi.exceptions.PredictorCallError`
             If calling `predictor` fails at runtime.
-        :py:class:`alibi.exceptions.AlibiPredictorReturnTypeError`
+        :py:class:`alibi.exceptions.PredictorReturnTypeError`
             If the return type of `predictor` is not `np.ndarray`.
         """
         super().__init__(meta=copy.deepcopy(DEFAULT_META_ANCHOR))
@@ -984,11 +984,11 @@ class AnchorTabular(Explainer, FitMixin):
         except Exception as e:
             msg = f"Predictor failed to be called on {type(x)} of shape {x.shape} and dtype {x.dtype}. " \
                   f"Check that the parameter `feature_names` is correctly specified."
-            raise AlibiPredictorCallException(msg) from e
+            raise PredictorCallError(msg) from e
 
         if not isinstance(prediction, np.ndarray):
             msg = f"Excepted predictor return type to be {np.ndarray} but got {type(prediction)}."
-            raise AlibiPredictorReturnTypeError(msg)
+            raise PredictorReturnTypeError(msg)
 
         if np.argmax(prediction.shape) == 0:
             return predictor

--- a/alibi/explainers/anchors/anchor_text.py
+++ b/alibi/explainers/anchors/anchor_text.py
@@ -7,12 +7,11 @@ from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, U
 import numpy as np
 import spacy
 
-
 from alibi.utils.missing_optional_dependency import import_optional
 from alibi.api.defaults import DEFAULT_DATA_ANCHOR, DEFAULT_META_ANCHOR
 from alibi.api.interfaces import Explainer, Explanation
-from alibi.exceptions import (AlibiPredictorCallException,
-                              AlibiPredictorReturnTypeError)
+from alibi.exceptions import (PredictorCallError,
+                              PredictorReturnTypeError)
 
 from alibi.utils.wrappers import ArgmaxTransformer
 from .anchor_base import AnchorBaseBeam
@@ -31,7 +30,6 @@ else:
     from alibi.utils import LanguageModel
 
 logger = logging.getLogger(__name__)
-
 
 DEFAULT_SAMPLING_UNKNOWN = {
     "sample_proba": 0.5
@@ -172,9 +170,9 @@ class AnchorText(Explainer):
 
         Raises
         ------
-        :py:class:`alibi.exceptions.AlibiPredictorCallException`
+        :py:class:`alibi.exceptions.PredictorCallError`
             If calling `predictor` fails at runtime.
-        :py:class:`alibi.exceptions.AlibiPredictorReturnTypeError`
+        :py:class:`alibi.exceptions.PredictorReturnTypeError`
             If the return type of `predictor` is not `np.ndarray`.
         """
         super().__init__(meta=copy.deepcopy(DEFAULT_META_ANCHOR))
@@ -522,11 +520,11 @@ class AnchorText(Explainer):
         except Exception as e:
             msg = f"Predictor failed to be called on x={x}. " \
                   f"Check that `predictor` works with inputs of type List[str]."
-            raise AlibiPredictorCallException(msg) from e
+            raise PredictorCallError(msg) from e
 
         if not isinstance(prediction, np.ndarray):
             msg = f"Excepted predictor return type to be {np.ndarray} but got {type(prediction)}."
-            raise AlibiPredictorReturnTypeError(msg)
+            raise PredictorReturnTypeError(msg)
 
         if np.argmax(prediction.shape) == 0:
             return predictor

--- a/alibi/explainers/tests/test_anchor_image.py
+++ b/alibi/explainers/tests/test_anchor_image.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 import torch
 
 from alibi.api.defaults import DEFAULT_META_ANCHOR, DEFAULT_DATA_ANCHOR_IMG
-from alibi.exceptions import AlibiPredictorCallException, AlibiPredictorReturnTypeError
+from alibi.exceptions import PredictorCallError, PredictorReturnTypeError
 from alibi.explainers.anchors.anchor_image import AnchorImage, AnchorImageSampler, scale_image
 
 
@@ -167,7 +167,7 @@ def test_anchor_image(predict_fn, models, mnist_data, images_background):
 @pytest.mark.parametrize('predict_fn', [lazy_fixture('models'), ], indirect=True)
 @pytest.mark.parametrize('models', [("mnist-cnn-pt1.9.1.pt",)], indirect=True)
 def test_anchor_image_fails_init_torch_float64(predict_fn, models):
-    with pytest.raises(AlibiPredictorCallException):
+    with pytest.raises(PredictorCallError):
         explainer = AnchorImage(predict_fn, image_shape=(28, 28, 1), dtype=np.float64)  # noqa: F841
 
 
@@ -187,7 +187,7 @@ def test_anchor_image_fails_init_bad_image_shape_predictor_call():
     """
     In this test `image_shape` is misspecified leading to an exception calling the `predictor`.
     """
-    with pytest.raises(AlibiPredictorCallException):
+    with pytest.raises(PredictorCallError):
         explainer = AnchorImage(bad_predictor, image_shape=(28, 28))  # noqa: F841
 
 
@@ -195,5 +195,5 @@ def test_anchor_image_fails_bad_predictor_return_type():
     """
     In this test `image_shape` is specified correctly, but the predictor returns the wrong type.
     """
-    with pytest.raises(AlibiPredictorReturnTypeError):
+    with pytest.raises(PredictorReturnTypeError):
         explainer = AnchorImage(bad_predictor, image_shape=(28, 28, 1))  # noqa: F841

--- a/alibi/explainers/tests/test_anchor_tabular.py
+++ b/alibi/explainers/tests/test_anchor_tabular.py
@@ -6,7 +6,7 @@ import pytest
 from pytest_lazyfixture import lazy_fixture
 
 from alibi.api.defaults import DEFAULT_META_ANCHOR, DEFAULT_DATA_ANCHOR
-from alibi.exceptions import AlibiPredictorCallException, AlibiPredictorReturnTypeError
+from alibi.exceptions import PredictorCallError, PredictorReturnTypeError
 from alibi.explainers import AnchorTabular, DistributedAnchorTabular
 from alibi.explainers.tests.utils import predict_fcn
 
@@ -326,7 +326,7 @@ def test_anchor_tabular_fails_init_bad_feature_names_predictor_call():
     """
     In this test `feature_names` is misspecified leading to an exception calling the `predictor`.
     """
-    with pytest.raises(AlibiPredictorCallException):
+    with pytest.raises(PredictorCallError):
         explainer = AnchorTabular(bad_predictor, feature_names=['f1', 'f2'])  # noqa: F841
 
 
@@ -334,5 +334,5 @@ def test_anchor_tabular_fails_bad_predictor_return_type():
     """
     In this test `feature_names` is specified correctly, but the predictor returns the wrong type.
     """
-    with pytest.raises(AlibiPredictorReturnTypeError):
+    with pytest.raises(PredictorReturnTypeError):
         explainer = AnchorTabular(bad_predictor, feature_names=['f1', 'f2', 'f3'])  # noqa: F841

--- a/alibi/explainers/tests/test_anchor_text.py
+++ b/alibi/explainers/tests/test_anchor_text.py
@@ -6,7 +6,7 @@ import numpy as np
 from typing import List
 
 from alibi.api.defaults import DEFAULT_META_ANCHOR, DEFAULT_DATA_ANCHOR
-from alibi.exceptions import AlibiPredictorCallException, AlibiPredictorReturnTypeError
+from alibi.exceptions import PredictorCallError, PredictorReturnTypeError
 from alibi.explainers import AnchorText
 from alibi.explainers.anchors.text_samplers import Neighbors, load_spacy_lexeme_prob
 from alibi.explainers.anchors.language_model_text_sampler import LanguageModelSampler
@@ -469,10 +469,10 @@ def bad_predictor_input_type(x: np.ndarray) -> np.ndarray:
 
 
 def test_anchor_text_fails_init_bad_predictor_input_type_call():
-    with pytest.raises(AlibiPredictorCallException):
+    with pytest.raises(PredictorCallError):
         explainer = AnchorText(bad_predictor_input_type)  # noqa: F841
 
 
 def test_anchor_text_fails_wrong_predictor_return_type():
-    with pytest.raises(AlibiPredictorReturnTypeError):
+    with pytest.raises(PredictorReturnTypeError):
         explainer = AnchorText(bad_predictor_return_type)  # noqa: F841


### PR DESCRIPTION
This PR renames exception classes to be more concise, specifically removing the `Alibi` prefix. This should not be necessary as all exceptions already inherit from `AlibiException` and the traceback also shows that the specific exceptions are defined in `alibi.exceptions`.

I've kept the old classes around for backwards compatibility just in case any application code already relies on the previously defined exceptions.

This is an accompaniment to #732.