### PR TITLE
Reinstate ray installation during Python 3.10 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,8 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt
           python -m pip install --upgrade --upgrade-strategy eager -e .
-          if [ "$RUNNER_OS" != "Windows" ] && [ ${{ matrix.python }} < '3.10' ]; then  
+          if [ "$RUNNER_OS" != "Windows" ]; then  
           # Windows support for ray is experimental (https://docs.ray.io/en/latest/installation.html#windows-support)
-          # Python 3.10 is not yet supported (https://github.com/ray-project/ray/blob/master/python/setup.py#L24) 
             python -m pip install --upgrade --upgrade-strategy eager -e .[ray]
           fi
           python -m pip install --upgrade --upgrade-strategy eager -e .[shap]

--- a/.github/workflows/test_all_notebooks.yml
+++ b/.github/workflows/test_all_notebooks.yml
@@ -41,9 +41,8 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt -r testing/requirements.txt
           python -m pip install --upgrade --upgrade-strategy eager -e .
-          if [ "$RUNNER_OS" != "Windows" ] && [ ${{ matrix.python }} < '3.10' ]; then  
+          if [ "$RUNNER_OS" != "Windows" ]; then  
           # Windows support for ray is experimental (https://docs.ray.io/en/latest/installation.html#windows-support)
-          # Python 3.10 is not yet supported (https://github.com/ray-project/ray/blob/master/python/setup.py#L24) 
             python -m pip install --upgrade --upgrade-strategy eager -e .[ray]
           fi
           python -m pip install --upgrade --upgrade-strategy eager -e .[shap,tensorflow]

--- a/.github/workflows/test_changed_notebooks.yml
+++ b/.github/workflows/test_changed_notebooks.yml
@@ -57,9 +57,8 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt -r testing/requirements.txt
           python -m pip install --upgrade --upgrade-strategy eager -e .
-          if [ "$RUNNER_OS" != "Windows" ] && [ ${{ matrix.python }} < '3.10' ]; then  
+          if [ "$RUNNER_OS" != "Windows" ]; then  
           # Windows support for ray is experimental (https://docs.ray.io/en/latest/installation.html#windows-support)
-          # Python 3.10 is not yet supported (https://github.com/ray-project/ray/blob/master/python/setup.py#L24) 
             python -m pip install --upgrade --upgrade-strategy eager -e .[ray]
           fi
           python -m pip install --upgrade --upgrade-strategy eager -e .[shap,tensorflow]


### PR DESCRIPTION
Ray [now supports Python 3.10](https://github.com/ray-project/ray/blob/96cceb08e8bf73df990437002e25883c5a72d30c/python/setup.py#L23), so adding it back into the Python 3.10 CI. 

Also note that any tests requiring `ray` were not running at all due to an issue with the syntax of this version check in the github action yaml files (see https://github.com/SeldonIO/alibi-detect/pull/615). This should now be fixed since the version does not need to be checked.