### PR TITLE
Remove --cov-append and add codecov tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Upload coverage to Codecov
         if: ${{ success() }}
         run: |
-          codecov
+          codecov -F ${{ matrix.os }}-${{ matrix.python-version }}
 
       - name: Build Python package
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,6 @@ addopts =
     --tb native
     -W ignore
     --cov=alibi
-    --cov-append
 #    -n auto
 #    --forked
 markers =


### PR DESCRIPTION
Removes `--cov-append` and add codecov tags for sync with https://github.com/SeldonIO/alibi-detect/pull/615.