### PR TITLE
Temporary fix for mypy issue in Python 3.10 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10.6' ]
         include: # Run macos and windows tests on only one python version
           - os: windows-latest 
             python-version:  '3.9'  # PyTorch doesn't yet have 3.10 support on Windows (https://pytorch.org/get-started/locally/#windows-python) 
           - os: macos-latest 
-            python-version:  '3.10'
+            python-version:  '3.10.6'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
A mypy error occurs due to a `numpy` file with `mypy 0.97x` and the new `Python 3.10.7` (see https://github.com/python/mypy/issues/13627). This will hopefully be fixed by `mypy 0.980` or `mypy 0.990`. Until then, this PR explicitly sets the CI to use `Python 3.10.6`. 

I've opened issue #763  to remind us to revert this change when possible.