### PR TITLE
Upgrade pip used in docs CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
       - name: Install dependencies
         run: |
           . $HOME/docs/bin/activate
+          python -m pip install --upgrade pip
           python -m pip install -r requirements/docs.txt
           python -m pip freeze
       - name: Build documentation to html


### PR DESCRIPTION
Our `docs` CI started failing last night ([example](https://github.com/SeldonIO/alibi-detect/actions/runs/3064583817/jobs/4950847279)). Upgrading `pip` before running `pip install -r requirements/docs.txt` appears to fix things. This is consistent with what we do in the main build CI anyway...

**Edit**: See @jk's comment, the pip upgrade fixing things was a coincidence. Lets upgrade anyway for consistency with the build CI.