### PR TITLE
Partial reversion of #759, add --cov-append back in

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ addopts =
     --tb native
     -W ignore
     --cov=alibi
+    --cov-append
 #    -n auto
 #    --forked
 markers =


### PR DESCRIPTION
Partially revert https://github.com/SeldonIO/alibi/pull/759 by adding the `pytest` `--cov-append` option back. This is needed in `alibi` because our build CI consists of two separate `pytest` calls:

```
  pytest -m tf1 alibi
  pytest -m "not tf1" alibi
```
