### PR TITLE
Add option to ssh into GitHub Actions for debugging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ on:
     - cron: '0 0 * * *'
   # Trigger the workflow on manual dispatch
   workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'     
+        required: false
+        default: false
 
 jobs:
   build:
@@ -39,6 +45,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        with:
+          limit-access-to-actor: true
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ on:
   # Trigger the workflow on manual dispatch
   workflow_dispatch:
     inputs:
-      debug_enabled:
+      tmate_enabled:
         type: boolean
-        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'     
+        description: 'Enable tmate debugging?'
         required: false
         default: false
 
@@ -46,12 +46,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
-        with:
-          limit-access-to-actor: true
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -69,6 +63,12 @@ jobs:
           python -m pip install --upgrade --upgrade-strategy eager -e .[shap]
           python -m spacy download en_core_web_md
           python -m pip freeze
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.tmate_enabled }}
+        with:
+          limit-access-to-actor: true
 
       - name: Lint with flake8
         run: |


### PR DESCRIPTION
This PR adds an option to ssh into GitHub Actions for debugging. The ssh support is only enabled when CI is triggered via manual dispatch, and the option is selected.

## Instructions

1. Go to the "CI" workflows section on the Alibi GitHub Actions page ([direct link](https://github.com/ascillitoe/alibi/actions/workflows/ci.yml)).

2. Click on "Run Workflow", and select the "Enable tmate debugging" toggle: 
![image](https://user-images.githubusercontent.com/32061685/190621822-c87ce082-ec83-4603-92b6-73d740c45437.png)

3. Select the workflow once it starts, and then select the build of interest (e.g. `ubuntu-latest, 3.10.6`):
![image](https://user-images.githubusercontent.com/32061685/190622244-c062fbc3-c586-4cdd-bdbb-d99adab98995.png)

4. Once the workflow reaches the `Setup tmate session` step, click on the toggle to expand it:
![image](https://user-images.githubusercontent.com/32061685/190622436-07a48416-32ad-4f63-ad9d-c40b4e4da0f5.png)

5. Copy and paste the `ssh` command that is being printed to your terminal e.g. `ssh TaHAR65KFbjbSdrkwxNz996TL@nyc1.tmate.io` in this case.

6. Run the ssh command. Assuming your ssh keys are properly set up for github, you should now be inside the GutHub Action runner:
![image](https://user-images.githubusercontent.com/32061685/190622699-0933087d-a4ed-46fc-904b-6a0eba5267b4.png)

7. The tmate session is opened after the Python and pip installs are completed, so you should be ready to run `alibi` and debug as required. 

### Additional instructions

- If the registered public SSH key is not your default private SSH key, you will need to specify the path manually, like so: ssh -i <path-to-key> <tmate-connection-string>.
- Once you have finished debugging, you can continue the workflow (i.e. let the full build CI run) by running `touch continue` whilst in the root directory (`~/work/alibi/alibi`). This will close the tmate session.
- This new capability is currently temperamental on the `MacOS` build due to this https://github.com/mxschmitt/action-tmate/issues/69. If the MacOS build fails all the builds are failed. You will need to retrigger the workflow if this happens.

## TODO's

- [ ] Fix the temperamental issue with the MacOS build, or just disable on MacOS for now.
- [ ] Move above instructions to `CONTRIBUTING.md` once finalised. 


