### PR TITLE
v0.8.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Added
 - **New feature** `PartialDependence` and `TreePartialDependence` explainers implementing partial dependence (PD) global explanations. Also included is a `plot_pd` utility function for flexible plotting of the resulting PD plots ([docs](https://docs.seldon.io/projects/alibi/en/stable/methods/PartialDependence.html), [#721](https://github.com/SeldonIO/alibi/pull/721)).
 - New `exceptions.NotFittedError` exception which is raised whenever a compulsory call to a `fit` method has not been carried out. Specifically, this is now raised in `AnchorTabular.explain` when `AnchorTabular.fit` has been skipped ([#732](https://github.com/SeldonIO/alibi/pull/732)).
-- Various improvements to docs and examples ([#695](https://github.com/SeldonIO/alibi/pull/695), [#701](https://github.com/SeldonIO/alibi/pull/701), [#698](https://github.com/SeldonIO/alibi/pull/698), [#703](https://github.com/SeldonIO/alibi/pull/703), [#717](https://github.com/SeldonIO/alibi/pull/717), [#711](https://github.com/SeldonIO/alibi/pull/711), [#750](https://github.com/SeldonIO/alibi/pull/750)).
+- Various improvements to docs and examples ([#695](https://github.com/SeldonIO/alibi/pull/695), [#701](https://github.com/SeldonIO/alibi/pull/701), [#698](https://github.com/SeldonIO/alibi/pull/698), [#703](https://github.com/SeldonIO/alibi/pull/703), [#717](https://github.com/SeldonIO/alibi/pull/717), [#711](https://github.com/SeldonIO/alibi/pull/711), [#750](https://github.com/SeldonIO/alibi/pull/750), [#784](https://github.com/SeldonIO/alibi/pull/784)).
 
 ### Fixed
 - Edge case in `AnchorTabular` where an error is raised during an `explain` call if the instance contains a categorical feature value not seen in the training data ([#742](https://github.com/SeldonIO/alibi/pull/742)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
-## [v0.7.1](https://github.com/SeldonIO/alibi/tree/v0.7.1) (2022-XX-XX)
-[Full Changelog](https://github.com/SeldonIO/alibi/compare/v0.7.0...v0.7.1)
+## [v0.8.0](https://github.com/SeldonIO/alibi/tree/v0.8.0) (2022-09-23)
+[Full Changelog](https://github.com/SeldonIO/alibi/compare/v0.7.0...v0.8.0)
 
 ### Added
 - **New feature** `PartialDependence` and `TreePartialDependence` explainers implementing partial dependence (PD) global explanations. Also included is a `plot_pd` utility function for flexible plotting of the resulting PD plots ([docs](https://docs.seldon.io/projects/alibi/en/stable/methods/PartialDependence.html), [#721](https://github.com/SeldonIO/alibi/pull/721)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,8 @@
 - Version of `ipykernel` bumped to `6.x` ([#431](https://github.com/SeldonIO/alibi/pull/572)).
 - Version of `ipython` bumped to `8.x` ([#572](https://github.com/SeldonIO/alibi/pull/572)).
 - Version of `pytest` bumped to `7.x` ([#591](https://github.com/SeldonIO/alibi/pull/591)).
-- Version of `sphinx-designe` bumped to `0.3.0` ([#739](https://github.com/SeldonIO/alibi/pull/739)).
+- Version of `sphinx-design` bumped to `0.3.0` ([#739](https://github.com/SeldonIO/alibi/pull/739)).
+- Version of `nbconvert` bumped to `7.x` ([#738](https://github.com/SeldonIO/alibi/pull/738)).
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Added
 - **New feature** `PartialDependence` and `TreePartialDependence` explainers implementing partial dependence (PD) global explanations. Also included is a `plot_pd` utility function for flexible plotting of the resulting PD plots ([docs](https://docs.seldon.io/projects/alibi/en/stable/methods/PartialDependence.html), [#721](https://github.com/SeldonIO/alibi/pull/721)).
 - New `exceptions.NotFittedError` exception which is raised whenever a compulsory call to a `fit` method has not been carried out. Specifically, this is now raised in `AnchorTabular.explain` when `AnchorTabular.fit` has been skipped ([#732](https://github.com/SeldonIO/alibi/pull/732)).
-- Various improvements to docs and examples ([#695](https://github.com/SeldonIO/alibi/pull/695), [#701](https://github.com/SeldonIO/alibi/pull/701), [#698](https://github.com/SeldonIO/alibi/pull/698), [#703](https://github.com/SeldonIO/alibi/pull/703), [#717](https://github.com/SeldonIO/alibi/commit/b0df37cb4c9afdbab35458d93f81583db24acb3d), [#711](https://github.com/SeldonIO/alibi/commit/69713b5347f83cc8f377eb0c048cf7e56c5e0b13), [#750](https://github.com/SeldonIO/alibi/pull/750)).
+- Various improvements to docs and examples ([#695](https://github.com/SeldonIO/alibi/pull/695), [#701](https://github.com/SeldonIO/alibi/pull/701), [#698](https://github.com/SeldonIO/alibi/pull/698), [#703](https://github.com/SeldonIO/alibi/pull/703), [#717](https://github.com/SeldonIO/alibi/pull/717), [#711](https://github.com/SeldonIO/alibi/pull/711), [#750](https://github.com/SeldonIO/alibi/pull/750)).
 
 ### Fixed
 - Edge case in `AnchorTabular` where an error is raised during an `explain` call if the instance contains a categorical feature value not seen in the training data ([#742](https://github.com/SeldonIO/alibi/pull/742)).
@@ -42,7 +42,7 @@
 - Version of `ipykernel` bumped to `6.x` ([#431](https://github.com/SeldonIO/alibi/pull/572)).
 - Version of `ipython` bumped to `8.x` ([#572](https://github.com/SeldonIO/alibi/pull/572)).
 - Version of `pytest` bumped to `7.x` ([#591](https://github.com/SeldonIO/alibi/pull/591)).
-- Version of `sphinx-designed` bumped to `0.3.0` ([#739](https://github.com/SeldonIO/alibi/pull/739)).
+- Version of `sphinx-designe` bumped to `0.3.0` ([#739](https://github.com/SeldonIO/alibi/pull/739)).
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 ### Added
 - **New feature** `PartialDependence` and `TreePartialDependence` explainers implementing partial dependence (PD) global explanations. Also included is a `plot_pd` utility function for flexible plotting of the resulting PD plots ([docs](https://docs.seldon.io/projects/alibi/en/stable/methods/PartialDependence.html), [#721](https://github.com/SeldonIO/alibi/pull/721)).
 - New `exceptions.NotFittedError` exception which is raised whenever a compulsory call to a `fit` method has not been carried out. Specifically, this is now raised in `AnchorTabular.explain` when `AnchorTabular.fit` has been skipped ([#732](https://github.com/SeldonIO/alibi/pull/732)).
-- Introduced a `NotFittedError` to be raised whenever a mandatory `fit` step has been skipped by the user ([#732](https://github.com/SeldonIO/alibi/pull/732)).
 - Various improvements to docs and examples ([#695](https://github.com/SeldonIO/alibi/pull/695), [#701](https://github.com/SeldonIO/alibi/pull/701), [#698](https://github.com/SeldonIO/alibi/pull/698), [#703](https://github.com/SeldonIO/alibi/pull/703), [#717](https://github.com/SeldonIO/alibi/commit/b0df37cb4c9afdbab35458d93f81583db24acb3d), [#711](https://github.com/SeldonIO/alibi/commit/69713b5347f83cc8f377eb0c048cf7e56c5e0b13), [#750](https://github.com/SeldonIO/alibi/pull/750)).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,48 @@
 ## [v0.7.1](https://github.com/SeldonIO/alibi/tree/v0.7.1) (2022-XX-XX)
 [Full Changelog](https://github.com/SeldonIO/alibi/compare/v0.7.0...v0.7.1)
 
-## Added
+### Added
+- **New feature** `PartialDependence` and `TreePartialDependence` explainers implementing partial dependence (PD) global explanations. Also included is a `plot_pd` utility function for flexible plotting of the resulting PD plots ([docs](https://docs.seldon.io/projects/alibi/en/stable/methods/PartialDependence.html), [#721](https://github.com/SeldonIO/alibi/pull/721)).
 - New `exceptions.NotFittedError` exception which is raised whenever a compulsory call to a `fit` method has not been carried out. Specifically, this is now raised in `AnchorTabular.explain` when `AnchorTabular.fit` has been skipped ([#732](https://github.com/SeldonIO/alibi/pull/732)).
+- Introduced a `NotFittedError` to be raised whenever a mandatory `fit` step has been skipped by the user ([#732](https://github.com/SeldonIO/alibi/pull/732)).
+- Various improvements to docs and examples ([#695](https://github.com/SeldonIO/alibi/pull/695), [#701](https://github.com/SeldonIO/alibi/pull/701), [#698](https://github.com/SeldonIO/alibi/pull/698), [#703](https://github.com/SeldonIO/alibi/pull/703), [#717](https://github.com/SeldonIO/alibi/commit/b0df37cb4c9afdbab35458d93f81583db24acb3d), [#711](https://github.com/SeldonIO/alibi/commit/69713b5347f83cc8f377eb0c048cf7e56c5e0b13), [#750](https://github.com/SeldonIO/alibi/pull/750)).
 
-## Fixed
+### Fixed
+- Edge case in `AnchorTabular` where an error is raised during an `explain` call if the instance contains a categorical feature value not seen in the training data ([#742](https://github.com/SeldonIO/alibi/pull/742)).
 
-## Changed
+### Changed
+- Improved handling of custom `grid_points` for the `ALE` explainer ([#731](https://github.com/SeldonIO/alibi/pull/731)).
 - Renamed our custom exception classes to remove the verbose `Alibi*` prefix and standardised the `*Error` suffix. Concretely:
   - `exceptions.AlibiPredictorCallException` is now `exceptions.PredictorCallError`
   - `exceptions.AlibiPredictorReturnTypeError` is now `exceptions.PredictorReturnTypeError`. Backwards compatibility has been maintained by subclassing the new exception classes by the old ones, **but these will likely be removed in a future version** ([#733](https://github.com/SeldonIO/alibi/pull/733)).
+- Warn users when `TreeShap` is used with more than 100 samples in the background dataset which is due to a limitation in the upstream `shap` package ([#710](https://github.com/SeldonIO/alibi/pull/710)).
+- Minimum version of `scikit-image` bumped to `0.17.2` to fix a possible bug when using the `slic` segmentation function with `AnchorImage` ([#753](https://github.com/SeldonIO/alibi/pull/753)).
+- Maximum supported version of `attrs` bumped to `22.x` ([#727](https://github.com/SeldonIO/alibi/pull/727)).
+- Maximum supported version of `tensorflow` bumped to `2.10.x` ([#745](https://github.com/SeldonIO/alibi/pull/745)).
+- Maximum supported version of `ray` bumped to `2.x` ([#740](https://github.com/SeldonIO/alibi/pull/740)).
+- Maximum supported version of `numba` bumped to `0.56.x` ([#724](https://github.com/SeldonIO/alibi/pull/724)).
+- Maximum supported version of `shap` bumped to `0.41.x` ([#702](https://github.com/SeldonIO/alibi/pull/702)).
+- Updated `shap` example notebooks to recommend installing `matplotlib==3.5.3` due to failure of `shap` plotting functions with `matplotlib==3.6.0` ([#776](https://github.com/SeldonIO/alibi/pull/776)).
 
-## Development
+### Development
+- Extend optional dependency checks to ensure the correct submodules are present ([#714](https://github.com/SeldonIO/alibi/pull/714)). 
+- Introduce `pytest-custom_exit_code` to let notebook CI pass when no notebooks are selected for tests ([#728](https://github.com/SeldonIO/alibi/pull/728)).
+- Use UTF-8 encoding when loading `README.md` in `setup.py` to avoid a possible failure of installation for some users ([#744](https://github.com/SeldonIO/alibi/pull/744)).
+- Updated guidance for class docstrings ([#743](https://github.com/SeldonIO/alibi/pull/743)).
+- Reinstate `ray` tests ([#756](https://github.com/SeldonIO/alibi/pull/756)).
+- We now exclude test files from test coverage for a more accurate representation of coverage ([#751](https://github.com/SeldonIO/alibi/pull/751)). Note that this has led to a drop in code covered which will be addressed in due course ([#760](https://github.com/SeldonIO/alibi/issues/760)).
+- The Python `3.10.x` version on CI has been pinned to `3.10.6` due to typechecking failures, pending a new release of `mypy` ([#761](https://github.com/SeldonIO/alibi/pull/761)).
+- The `test_changed_notebooks` workflow can now be triggered manually and is run on push/PR for any branch ([#762](https://github.com/SeldonIO/alibi/commit/98e962b32c31e7ee670147a44af032b593950b5d)).
+- Use `codecov` flags for more granular reporting of code coverage ([#759](https://github.com/SeldonIO/alibi/pull/759)).
+- Option to ssh into Github Actions runs for remote debugging of CI pipelines ([#770](https://github.com/SeldonIO/alibi/pull/770)).
+- Version of `sphinx` bumped to `5.x` but capped at `<5.1.0` to avoid CI failures ([#722](https://github.com/SeldonIO/alibi/pull/722)).
+- Version of `myst-parser` bumped to `0.18.x` ([#693](https://github.com/SeldonIO/alibi/pull/693)).
+- Version of `flake8` bumped to `5.x` ([#729](https://github.com/SeldonIO/alibi/pull/729)).
+- Version of `ipykernel` bumped to `6.x` ([#431](https://github.com/SeldonIO/alibi/pull/572)).
+- Version of `ipython` bumped to `8.x` ([#572](https://github.com/SeldonIO/alibi/pull/572)).
+- Version of `pytest` bumped to `7.x` ([#591](https://github.com/SeldonIO/alibi/pull/591)).
+- Version of `sphinx-designed` bumped to `0.3.0` ([#739](https://github.com/SeldonIO/alibi/pull/739)).
+
 
 
 ## [v0.7.0](https://github.com/SeldonIO/alibi/tree/v0.7.0) (2022-05-18)
@@ -21,23 +52,23 @@
 
 This release introduces two new methods, a `GradientSimilarity` explainer and a `ProtoSelect` data summarisation algorithm.
 
-## Added
+### Added
 - **New feature** `GradientSimilarity` explainer for explaining predictions of gradient-based (PyTorch and TensorFlow) models by returning the most similar training data points from the point of view of the model ([docs](https://docs.seldon.io/projects/alibi/en/stable/methods/Similarity.html)).
 - **New feature** We have introduced a new subpackage `alibi.prototypes` which contains the `ProtoSelect` algorithm for summarising datasets with a representative set of "prototypes" ([docs](https://docs.seldon.io/projects/alibi/en/stable/methods/ProtoSelect.html)).
 - `ALE` explainer now can take a custom grid-point per feature to evaluate the `ALE` on. This can help in certain situations when grid-points defined by quantiles might not be the best choice ([docs](https://docs.seldon.io/projects/alibi/en/stable/methods/ALE.html#Usage)).
 - Extended the `IntegratedGradients` method target selection to handle explaining any scalar dimension of tensors of any rank (previously only rank-1 and rank-2 were supported). See [#635](https://github.com/SeldonIO/alibi/pull/635).
 - Python 3.10 support. Note that `PyTorch` at the time of writing doesn't support Python 3.10 on Windows.
 
-## Fixed
+### Fixed
 - Fixed a bug which incorrectly handled multi-dimensional scaling in `CounterfactualProto` ([#646](https://github.com/SeldonIO/alibi/pull/646)).
 - Fixed a bug in the example using `CounterfactualRLTabular` ([#651](https://github.com/SeldonIO/alibi/pull/651)).
 
-## Changed
+### Changed
 - `tensorflow` is now an optional dependency. To use methods that require `tensorflow` you can install `alibi` using `pip install alibi[tensorflow]` which will pull in a supported version. For full instructions for the recommended way of installing optional dependencies please refer to [Installation docs](https://docs.seldon.io/projects/alibi/en/stable/overview/getting_started.html#installation).
 - Updated `sklearn` version bounds to `scikit-learn>=0.22.0, <2.0.0`.
 - Updated `tensorflow` maximum allowed version to `2.9.x`.
 
-## Development
+### Development
 - This release introduces a way to manage the absence of optional dependencies. In short, the design is such that if an optional dependency is required for an algorithm but missing, at import time the corresponding public (or private in the case of the optional dependency being required for a subset of the functionality of a private class) algorithm class will be replaced by a `MissingDependency` object. For full details on developing `alibi` with optional dependencies see [Contributing: Optional Dependencies](https://github.com/SeldonIO/alibi/blob/master/CONTRIBUTING.md#optional-dependencies).
 - The [CONTRIBUTING.md](https://github.com/SeldonIO/alibi/blob/master/CONTRIBUTING.md) has been updated with further instructions for managing optional dependencies (see point above) and more conventions around docstrings.
 - We have split the `Explainer` base class into `Base` and `Explainer` to facilitate reusability and better class hierarchy semantics with introducing methods that are not explainers ([#649](https://github.com/SeldonIO/alibi/pull/649)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - `exceptions.AlibiPredictorCallException` is now `exceptions.PredictorCallError`
   - `exceptions.AlibiPredictorReturnTypeError` is now `exceptions.PredictorReturnTypeError`. Backwards compatibility has been maintained by subclassing the new exception classes by the old ones, **but these will likely be removed in a future version** ([#733](https://github.com/SeldonIO/alibi/pull/733)).
 - Warn users when `TreeShap` is used with more than 100 samples in the background dataset which is due to a limitation in the upstream `shap` package ([#710](https://github.com/SeldonIO/alibi/pull/710)).
+- Minimum version of `scikit-learn` bumped to `1.0.0` mainly due to upcoming deprecations ([#776](https://github.com/SeldonIO/alibi/pull/776)).
 - Minimum version of `scikit-image` bumped to `0.17.2` to fix a possible bug when using the `slic` segmentation function with `AnchorImage` ([#753](https://github.com/SeldonIO/alibi/pull/753)).
 - Maximum supported version of `attrs` bumped to `22.x` ([#727](https://github.com/SeldonIO/alibi/pull/727)).
 - Maximum supported version of `tensorflow` bumped to `2.10.x` ([#745](https://github.com/SeldonIO/alibi/pull/745)).


### PR DESCRIPTION
Provisional version of the changelog for the release. Doesn't include links to all the PRs merged but most of them are mentioned.