### PR TITLE
Check against numbers.Integral instead of int for Windows compatibility

### DIFF
--- a/alibi/explainers/integrated_gradients.py
+++ b/alibi/explainers/integrated_gradients.py
@@ -1,3 +1,5 @@
+import numbers
+
 import copy
 import logging
 import string
@@ -584,7 +586,7 @@ def _check_target(output_shape: Tuple,
 
     if target is not None:
 
-        if not (target.dtype == int):
+        if not isinstance(target.dtype, numbers.Integral):
             raise ValueError("Targets must be integers")
 
         if target.shape[0] != nb_samples:


### PR DESCRIPTION
Bug discovered in testing notebooks on Windows: https://github.com/SeldonIO/alibi/actions/runs/3106251974/jobs/5032894660

On Windows numpy integer types are `np.int32` which when compared to the built-in `int` type evaluate to `False`.