### PR TITLE
Fix/integrated gradients int check 2

### DIFF
--- a/alibi/explainers/integrated_gradients.py
+++ b/alibi/explainers/integrated_gradients.py
@@ -1,5 +1,3 @@
-import numbers
-
 import copy
 import logging
 import string

--- a/alibi/explainers/integrated_gradients.py
+++ b/alibi/explainers/integrated_gradients.py
@@ -586,7 +586,7 @@ def _check_target(output_shape: Tuple,
 
     if target is not None:
 
-        if not isinstance(target.dtype, numbers.Integral):
+        if not np.issubdtype(target.dtype, np.integer):
             raise ValueError("Targets must be integers")
 
         if target.shape[0] != nb_samples:


### PR DESCRIPTION
#779 was a mistake... this is the actual fix. It seems that this is the canonical way of checking if a `numpy` array consists of integer values: https://github.com/numpy/numpy/issues/17325#issuecomment-693297036