### PR TITLE
Limit sphinx-autodoc-typehints upper bound

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,7 @@
 # dependencies for building docs, separate from dev.txt as this is also used for builds on readthedocs.org
 # core dependencies
 sphinx>=4.2.0, <5.1.0
-sphinx-autodoc-typehints>=1.12.0, <=2.0.0 
+sphinx-autodoc-typehints>=1.12.0, <1.19.3  # limited due to https://github.com/tox-dev/sphinx-autodoc-typehints/issues/259 and 260 
 sphinx-rtd-theme>=1.0.0, <2.0.0
 myst-parser>=0.14, <0.19
 sphinxcontrib-apidoc>=0.3.0, <0.4.0


### PR DESCRIPTION
Limit `sphinx-autodoc-typehints` to `<1.19.3` due to https://github.com/tox-dev/sphinx-autodoc-typehints/issues/259 and https://github.com/tox-dev/sphinx-autodoc-typehints/issues/260.

`alibi-detect` equivalent: https://github.com/SeldonIO/alibi-detect/pull/633