### PR TITLE
Skip windows `save_AnchorText` test as failing

### DIFF
--- a/alibi/tests/test_saving.py
+++ b/alibi/tests/test_saving.py
@@ -1,3 +1,4 @@
+import sys
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
@@ -340,6 +341,7 @@ def test_save_AnchorImage(ai_explainer, mnist_predictor):
         assert exp0.meta == exp1.meta
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Test fails intermittently on windows platform")
 @pytest.mark.parametrize('lr_classifier', [lazy_fixture('movie_sentiment_data')], indirect=True)
 @pytest.mark.parametrize('atext_explainer', [lazy_fixture('atext_explainer_nlp'), lazy_fixture('atext_explainer_lm')])
 def test_save_AnchorText(atext_explainer, lr_classifier, movie_sentiment_data):


### PR DESCRIPTION
# What is this

The `test_save_anchortext` in `alibi/tests/test_saving.py` intermittently fails on windows. This PR marks it as `skipif` on windows.
