### PR TITLE
Fix optional deps installs during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt
-          python -m pip install --upgrade --upgrade-strategy eager -e .[tensorflow,torch]
+          python -m pip install --upgrade --upgrade-strategy eager .[tensorflow,torch,shap]
           if [ "$RUNNER_OS" != "Windows" ]; then  
           # Windows support for ray is experimental (https://docs.ray.io/en/latest/installation.html#windows-support)
-            python -m pip install --upgrade --upgrade-strategy eager -e .[ray]
+            python -m pip install --upgrade --upgrade-strategy only-if-needed .[ray]
           fi
-          python -m pip install --upgrade --upgrade-strategy eager -e .[shap]
           python -m spacy download en_core_web_md
           python -m pip freeze
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           python -m pip install --upgrade --upgrade-strategy eager .[tensorflow,torch,shap]
           if [ "$RUNNER_OS" != "Windows" ]; then  
           # Windows support for ray is experimental (https://docs.ray.io/en/latest/installation.html#windows-support)
-            python -m pip install --upgrade --upgrade-strategy only-if-needed .[ray]
+            python -m pip install --upgrade --upgrade-strategy eager .[tensorflow,torch,shap,ray]  # include other deps so that they are taking into account during ray install
           fi
           python -m spacy download en_core_web_md
           python -m pip freeze

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt
-          python -m pip install --upgrade --upgrade-strategy eager -e .
+          python -m pip install --upgrade --upgrade-strategy eager -e .[tensorflow,torch]
           if [ "$RUNNER_OS" != "Windows" ]; then  
           # Windows support for ray is experimental (https://docs.ray.io/en/latest/installation.html#windows-support)
             python -m pip install --upgrade --upgrade-strategy eager -e .[ray]


### PR DESCRIPTION
This PR fixes an issue with our CI failing after the `ray 2.1.0` release. 

## Issue
https://github.com/ray-project/ray/pull/29224 removed the `protobuf < 4.0` bound from `ray`. However, `tensorflow` still requires `protobuf < 4.0`, and this was not respected by pip during our CI install, leading to:

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
tensorflow 2.10.0 requires protobuf<3.20,>=3.9.2, but you have protobuf 4.21.9 which is incompatible.
```

This is due to this line in our `ci.yaml`:

```
python -m pip install --upgrade --upgrade-strategy eager -e .[ray]
```

As stated by the pip documentation for `upgrade-strategy eager`:

> It should be noted here that pip’s current resolution algorithm isn’t even aware of packages other than those specified on the command line, and those identified as dependencies.

In other words, pip is not aware of `tensorflow`'s requirements when installing `ray` in isolation, so `protobuf` is eagerly upgraded to `>4.0`.

## Solutions

### Current proposed solution
Including `tensorflow` (and other optional deps) in the problem pip install means that pip is aware of `tensorflow`'s deps. For example:

```
          python -m pip install --upgrade pip setuptools wheel
          python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt
          python -m pip install --upgrade --upgrade-strategy eager .[tensorflow,torch,shap]
          if [ "$RUNNER_OS" != "Windows" ]; then
          # Windows support for ray is experimental (https://docs.ray.io/en/latest/installation.html#windows-support)
            python -m pip install --upgrade --upgrade-strategy eager .[tensorflow,torch,shap,ray]  # include other deps so that they are taking into account during ray install
          fi
```

There is some additional duplication, however this shouldn't slow down the install too much since `tensorflow` etc have already been installed.


### Alternative solution

We can avoid the duplication of `tensorflow` etc in the `ray` pip install if we change the `upgrade-strategy` to `only-if-needed`:

```
          python -m pip install --upgrade pip setuptools wheel
          python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt
          python -m pip install --upgrade --upgrade-strategy eager .[tensorflow,torch,shap]
          if [ "$RUNNER_OS" != "Windows" ]; then
          # Windows support for ray is experimental (https://docs.ray.io/en/latest/installation.html#windows-support)
            python -m pip install --upgrade --upgrade-strategy only-if-needed .[ray]  
          fi
```

The downside of this is that we might not install the latest `ray` version (and its deps) if there were older cached dependencies...