### PR TITLE
Update notebook CI to match #817

### DIFF
--- a/.github/workflows/test_all_notebooks.yml
+++ b/.github/workflows/test_all_notebooks.yml
@@ -40,12 +40,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt -r testing/requirements.txt
-          python -m pip install --upgrade --upgrade-strategy eager -e .
+          python -m pip install --upgrade --upgrade-strategy eager .[shap,tensorflow]
           if [ "$RUNNER_OS" != "Windows" ]; then  
           # Windows support for ray is experimental (https://docs.ray.io/en/latest/installation.html#windows-support)
-            python -m pip install --upgrade --upgrade-strategy eager -e .[ray]
+            python -m pip install --upgrade --upgrade-strategy eager .[shap,tensorflow,ray]
           fi
-          python -m pip install --upgrade --upgrade-strategy eager -e .[shap,tensorflow]
           python -m spacy download en_core_web_md
           python -m pip freeze
 

--- a/.github/workflows/test_changed_notebooks.yml
+++ b/.github/workflows/test_changed_notebooks.yml
@@ -56,12 +56,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt -r testing/requirements.txt
-          python -m pip install --upgrade --upgrade-strategy eager -e .
+          python -m pip install --upgrade --upgrade-strategy eager .[shap,tensorflow]
           if [ "$RUNNER_OS" != "Windows" ]; then  
           # Windows support for ray is experimental (https://docs.ray.io/en/latest/installation.html#windows-support)
-            python -m pip install --upgrade --upgrade-strategy eager -e .[ray]
+            python -m pip install --upgrade --upgrade-strategy eager .[shap,tensorflow,ray]
           fi
-          python -m pip install --upgrade --upgrade-strategy eager -e .[shap,tensorflow]
           python -m spacy download en_core_web_md
           python -m pip freeze
 


### PR DESCRIPTION
@jklaise @mauicv I probably should have updated the notebook CI workflows in #817, so following up here instead. Notebook CI is being tested [here](https://github.com/ascillitoe/alibi/actions/runs/3419994591/jobs/5694232176).