### PR TITLE
Included .pymon entry in .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+.pymon
 
 # Translations
 *.mo


### PR DESCRIPTION
This PR includes the `.pymon` entry in the `.gitingore`. The `.pymon` is generated by `pytest`.