### PR TITLE
Filter gradients of IndexedSlices in tf grad sim backend, fixes #828

### DIFF
--- a/alibi/explainers/similarity/backends/pytorch/base.py
+++ b/alibi/explainers/similarity/backends/pytorch/base.py
@@ -91,7 +91,7 @@ class _PytorchBackend:
         elif isinstance(device, torch.device):
             _PytorchBackend.device = device
         elif device is not None:
-            raise TypeError(("`device` must be a ``None``, ``string``, ``integer`` or "
+            raise TypeError(("`device` must be a ``None``, `string`, `integer` or "
                             f"`torch.device` object. Got {type(device)} instead."))
 
     @staticmethod

--- a/alibi/explainers/similarity/backends/pytorch/base.py
+++ b/alibi/explainers/similarity/backends/pytorch/base.py
@@ -96,10 +96,9 @@ class _PytorchBackend:
         return torch.argmax(X, dim=dim)
 
     @staticmethod
-    def check_all_layers_trainable(model: nn.Module) -> None:
+    def check_all_layers_trainable(model: nn.Module) -> bool:
         """Checks that all layers in a model are trainable."""
         for param in model.parameters():
             if not param.requires_grad:
                 return False
         return True
-                

--- a/alibi/explainers/similarity/backends/pytorch/base.py
+++ b/alibi/explainers/similarity/backends/pytorch/base.py
@@ -57,7 +57,11 @@ class _PytorchBackend:
 
     @staticmethod
     def _grad_to_numpy(grad: torch.Tensor) -> torch.Tensor:
-        """Flattens a gradient tensor."""
+        """Convert graidient to numpy array.
+
+        Converts gradient tensor to flat numpy array. If the gradient is a sparse tensor, it is converted to a dense \
+        tensor first.
+        """
         if grad.is_sparse:
             grad = grad.to_dense()
         grad = grad.reshape(-1).detach().cpu()

--- a/alibi/explainers/similarity/backends/pytorch/base.py
+++ b/alibi/explainers/similarity/backends/pytorch/base.py
@@ -59,7 +59,7 @@ class _PytorchBackend:
     def _grad_to_numpy(grad: torch.Tensor, name: Optional[str] = None) -> torch.Tensor:
         """Convert graidient to numpy array.
 
-        Converts gradient tensor to flat numpy array. If the gradient is a sparse tensor, it is converted to a dense \
+        Converts gradient tensor to flat numpy array. If the gradient is a sparse tensor, it is converted to a dense
         tensor first.
         """
         if grad.is_sparse:

--- a/alibi/explainers/similarity/backends/pytorch/base.py
+++ b/alibi/explainers/similarity/backends/pytorch/base.py
@@ -106,7 +106,11 @@ class _PytorchBackend:
 
     @staticmethod
     def get_non_trainable(model: nn.Module) -> List[Optional[str]]:
-        """Checks that all layers in a model are trainable."""
+        """Returns a list of non trainable parameters.
+
+        Returns a list of names of parameters that are non trainable. If no trainable parameter exist we raise
+        a ValueError.
+        """
 
         params = [name if name else None for name, param in model.named_parameters()
                   if not param.requires_grad]

--- a/alibi/explainers/similarity/backends/pytorch/base.py
+++ b/alibi/explainers/similarity/backends/pytorch/base.py
@@ -108,7 +108,7 @@ class _PytorchBackend:
     def _get_non_trainable(model: nn.Module) -> List[Optional[str]]:
         """Returns a list of non trainable parameters.
 
-        Returns a list of names of parameters that are non trainable. If no trainable parameter exist we raise
+        Returns a list of names of parameters that are non trainable. If no trainable parameter exists we raise
         a `ValueError`.
         """
 

--- a/alibi/explainers/similarity/backends/pytorch/base.py
+++ b/alibi/explainers/similarity/backends/pytorch/base.py
@@ -4,7 +4,7 @@ Methods unique to the `pytorch` backend are defined here. The interface this cla
 backend in order to ensure that the similarity methods only require to match this interface.
 """
 
-from typing import Callable, Union, Optional
+from typing import Callable, Union, Optional, List
 
 import numpy as np
 import torch.nn as nn
@@ -104,9 +104,7 @@ class _PytorchBackend:
         return torch.argmax(X, dim=dim)
 
     @staticmethod
-    def check_all_layers_trainable(model: nn.Module) -> bool:
+    def get_non_trainable(model: nn.Module) -> List[Union[int, str]]:
         """Checks that all layers in a model are trainable."""
-        for param in model.parameters():
-            if not param.requires_grad:
-                return False
-        return True
+        return [name if name else i for i, (name, param) in enumerate(model.named_parameters())
+                if not param.requires_grad]

--- a/alibi/explainers/similarity/backends/pytorch/base.py
+++ b/alibi/explainers/similarity/backends/pytorch/base.py
@@ -56,8 +56,8 @@ class _PytorchBackend:
                                if param.grad is not None])
 
     @staticmethod
-    def _grad_to_numpy(grad: torch.Tensor, name: Optional[str] = None) -> torch.Tensor:
-        """Convert graidient to `np.ndarray`.
+    def _grad_to_numpy(grad: torch.Tensor, name: Optional[str] = None) -> np.ndarray:
+        """Convert gradient to `np.ndarray`.
 
         Converts gradient tensor to flat `numpy` array. If the gradient is a sparse tensor, it is converted to a dense
         tensor first.

--- a/alibi/explainers/similarity/backends/pytorch/base.py
+++ b/alibi/explainers/similarity/backends/pytorch/base.py
@@ -94,3 +94,12 @@ class _PytorchBackend:
     def argmax(X: torch.Tensor, dim=-1) -> torch.Tensor:
         """Returns the index of the maximum value in a tensor."""
         return torch.argmax(X, dim=dim)
+
+    @staticmethod
+    def check_all_layers_trainable(model: nn.Module) -> None:
+        """Checks that all layers in a model are trainable."""
+        for param in model.parameters():
+            if not param.requires_grad:
+                return False
+        return True
+                

--- a/alibi/explainers/similarity/backends/pytorch/base.py
+++ b/alibi/explainers/similarity/backends/pytorch/base.py
@@ -105,7 +105,7 @@ class _PytorchBackend:
         return torch.argmax(X, dim=dim)
 
     @staticmethod
-    def get_non_trainable(model: nn.Module) -> List[Optional[str]]:
+    def _get_non_trainable(model: nn.Module) -> List[Optional[str]]:
         """Returns a list of non trainable parameters.
 
         Returns a list of names of parameters that are non trainable. If no trainable parameter exist we raise

--- a/alibi/explainers/similarity/backends/pytorch/base.py
+++ b/alibi/explainers/similarity/backends/pytorch/base.py
@@ -68,7 +68,7 @@ class _PytorchBackend:
         if not hasattr(grad, 'numpy'):
             name = f' for the named tensor: {name}' if name else ''
             raise TypeError((f'Could not convert gradient to `numpy` array{name}. To ignore these '
-                             'gradients in the similarity computation set `requires_grad=False` on the '
+                             'gradients in the similarity computation set ``requires_grad=False`` on the '
                              'corresponding parameter.'))
         return grad.reshape(-1).cpu().numpy()
 
@@ -91,7 +91,7 @@ class _PytorchBackend:
         elif isinstance(device, torch.device):
             _PytorchBackend.device = device
         elif device is not None:
-            raise TypeError(("`device` must be a `None`, `string`, `integer` or "
+            raise TypeError(("`device` must be a ``None``, ``string``, ``integer`` or "
                             f"`torch.device` object. Got {type(device)} instead."))
 
     @staticmethod
@@ -116,8 +116,8 @@ class _PytorchBackend:
                   if not param.requires_grad]
 
         if len(params) == len(list(model.parameters())):
-            raise ValueError('The model has no trainable parameters. This method requires at least'
-                             'one trainable parameter to compute the gradients for. '
-                             "Try setting `.requires_grad_(True)` on the model or one of it's parameters")
+            raise ValueError("The model has no trainable parameters. This method requires at least "
+                             "one trainable parameter to compute the gradients for. "
+                             "Try setting ``.requires_grad_(True)`` on the model or one of its parameters.")
 
         return params

--- a/alibi/explainers/similarity/backends/pytorch/base.py
+++ b/alibi/explainers/similarity/backends/pytorch/base.py
@@ -67,9 +67,9 @@ class _PytorchBackend:
 
         if not hasattr(grad, 'numpy'):
             name = f' for the named tensor: {name}' if name else ''
-            # add comment for devs
             raise TypeError((f'Could not convert gradient to numpy array{name}. To ignore these '
-                             'gradients in the similarity computation use `requires_grad=False`.'))
+                             'gradients in the similarity computation set `requires_grad=False` on the '
+                             'corresponding parameter.'))
         return grad.reshape(-1).cpu().numpy()
 
     @staticmethod

--- a/alibi/explainers/similarity/backends/pytorch/base.py
+++ b/alibi/explainers/similarity/backends/pytorch/base.py
@@ -4,7 +4,7 @@ Methods unique to the `pytorch` backend are defined here. The interface this cla
 backend in order to ensure that the similarity methods only require to match this interface.
 """
 
-from typing import Callable, Union, Optional, List
+from typing import Callable, Union, Optional
 
 import numpy as np
 import torch.nn as nn
@@ -105,19 +105,18 @@ class _PytorchBackend:
         return torch.argmax(X, dim=dim)
 
     @staticmethod
-    def _get_non_trainable(model: nn.Module) -> List[Optional[str]]:
-        """Returns a list of non trainable parameters.
+    def _count_non_trainable(model: nn.Module) -> int:
+        """Returns number of non trainable parameters.
 
-        Returns a list of names of parameters that are non trainable. If no trainable parameter exists we raise
+        Returns the number of parameters that are non trainable. If no trainable parameter exists we raise
         a `ValueError`.
         """
 
-        params = [name if name else None for name, param in model.named_parameters()
-                  if not param.requires_grad]
+        num_non_trainable_params = len([param for param in model.parameters() if not param.requires_grad])
 
-        if len(params) == len(list(model.parameters())):
+        if num_non_trainable_params == len(list(model.parameters())):
             raise ValueError("The model has no trainable parameters. This method requires at least "
                              "one trainable parameter to compute the gradients for. "
                              "Try setting ``.requires_grad_(True)`` on the model or one of its parameters.")
 
-        return params
+        return num_non_trainable_params

--- a/alibi/explainers/similarity/backends/pytorch/base.py
+++ b/alibi/explainers/similarity/backends/pytorch/base.py
@@ -57,9 +57,9 @@ class _PytorchBackend:
 
     @staticmethod
     def _grad_to_numpy(grad: torch.Tensor, name: Optional[str] = None) -> torch.Tensor:
-        """Convert graidient to numpy array.
+        """Convert graidient to `np.ndarray`.
 
-        Converts gradient tensor to flat numpy array. If the gradient is a sparse tensor, it is converted to a dense
+        Converts gradient tensor to flat `numpy` array. If the gradient is a sparse tensor, it is converted to a dense
         tensor first.
         """
         if grad.is_sparse:
@@ -67,7 +67,7 @@ class _PytorchBackend:
 
         if not hasattr(grad, 'numpy'):
             name = f' for the named tensor: {name}' if name else ''
-            raise TypeError((f'Could not convert gradient to numpy array{name}. To ignore these '
+            raise TypeError((f'Could not convert gradient to `numpy` array{name}. To ignore these '
                              'gradients in the similarity computation set `requires_grad=False` on the '
                              'corresponding parameter.'))
         return grad.reshape(-1).cpu().numpy()
@@ -91,12 +91,12 @@ class _PytorchBackend:
         elif isinstance(device, torch.device):
             _PytorchBackend.device = device
         elif device is not None:
-            raise TypeError(("`device` must be a None, string, integer or "
-                            f"torch.device object. Got {type(device)} instead."))
+            raise TypeError(("`device` must be a `None`, `string`, `integer` or "
+                            f"`torch.device` object. Got {type(device)} instead."))
 
     @staticmethod
     def to_numpy(X: torch.Tensor) -> np.ndarray:
-        """Maps a `pytorch` tensor to a `numpy` array."""
+        """Maps a `pytorch` tensor to `np.ndarray`."""
         return X.detach().cpu().numpy()
 
     @staticmethod
@@ -109,7 +109,7 @@ class _PytorchBackend:
         """Returns a list of non trainable parameters.
 
         Returns a list of names of parameters that are non trainable. If no trainable parameter exist we raise
-        a ValueError.
+        a `ValueError`.
         """
 
         params = [name if name else None for name, param in model.named_parameters()
@@ -118,6 +118,6 @@ class _PytorchBackend:
         if len(params) == len(list(model.parameters())):
             raise ValueError('The model has no trainable parameters. This method requires at least'
                              'one trainable parameter to compute the gradients for. '
-                             'Set `.requires_grad_(True)` on the model')
+                             "Try setting `.requires_grad_(True)` on the model or one of it's parameters")
 
         return params

--- a/alibi/explainers/similarity/backends/tensorflow/base.py
+++ b/alibi/explainers/similarity/backends/tensorflow/base.py
@@ -101,9 +101,10 @@ class _TensorFlowBackend:
 
     @staticmethod
     def get_non_trainable(model: keras.Model) -> List[Optional[str]]:
-        """Checks if all layers in a model are trainable.
+        """Returns a list of non trainable parameters.
 
-        Note: batch normalization layers are ignored as they are not trainable by default.
+        Returns a list of names of parameters that are non trainable. If no trainable parameter exist we raise
+        a ValueError.
         """
 
         if len(model.trainable_weights) == 0:

--- a/alibi/explainers/similarity/backends/tensorflow/base.py
+++ b/alibi/explainers/similarity/backends/tensorflow/base.py
@@ -8,7 +8,7 @@ from typing import Callable, Optional, Union, List
 
 import numpy as np
 import tensorflow as tf
-import tensorflow.keras as keras
+from tensorflow import keras
 
 
 class _TensorFlowBackend:
@@ -100,9 +100,15 @@ class _TensorFlowBackend:
         return X
 
     @staticmethod
-    def get_non_trainable(model: keras.Model) -> List[Union[int, str]]:
+    def get_non_trainable(model: keras.Model) -> List[Optional[str]]:
         """Checks if all layers in a model are trainable.
 
         Note: batch normalization layers are ignored as they are not trainable by default.
         """
-        return [getattr(layer, 'name', i) for i, layer in enumerate(model.layers) if not layer.trainable]
+
+        if len(model.trainable_weights) == 0:
+            raise ValueError('The model has no trainable weights. This method requires at least'
+                             'one trainable parameter to compute the gradients for. '
+                             'Set `trainable=True` on the model or a model weight')
+
+        return [getattr(weight, 'name', None) for weight in model.non_trainable_weights]

--- a/alibi/explainers/similarity/backends/tensorflow/base.py
+++ b/alibi/explainers/similarity/backends/tensorflow/base.py
@@ -4,7 +4,7 @@ Methods unique to the `tensorflow` backend are defined here. The interface this 
 backend in order to ensure that the similarity methods only require to match this interface.
 """
 
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, Union, List
 
 import numpy as np
 import tensorflow as tf
@@ -100,13 +100,9 @@ class _TensorFlowBackend:
         return X
 
     @staticmethod
-    def check_all_layers_trainable(model: keras.Model) -> bool:
+    def get_non_trainable(model: keras.Model) -> List[Union[int, str]]:
         """Checks if all layers in a model are trainable.
 
         Note: batch normalization layers are ignored as they are not trainable by default.
         """
-        for weight in model.non_trainable_weights:
-            if weight.name.startswith('batch_normalization'):
-                continue
-            return False
-        return True
+        return [getattr(layer, 'name', i) for i, layer in enumerate(model.layers) if not layer.trainable]

--- a/alibi/explainers/similarity/backends/tensorflow/base.py
+++ b/alibi/explainers/similarity/backends/tensorflow/base.py
@@ -56,9 +56,9 @@ class _TensorFlowBackend:
 
     @staticmethod
     def _grad_to_numpy(grad: Union[tf.IndexedSlices, tf.Tensor], name: Optional[str] = None) -> tf.Tensor:
-        """Convert graidient to numpy array.
+        """Convert graidient to `np.ndarray`.
 
-        Converts gradient tensor to flat numpy array. If the gradient is a sparse tensor, it is converted to a dense
+        Converts gradient tensor to flat `numpy` array. If the gradient is a sparse tensor, it is converted to a dense
         tensor first.
         """
 
@@ -68,7 +68,7 @@ class _TensorFlowBackend:
 
         if not hasattr(grad, 'numpy'):
             name = f' for the named tensor: {name}' if name else ''
-            raise TypeError((f'Could not convert gradient to numpy array{name}. To ignore these '
+            raise TypeError((f'Could not convert gradient to `numpy` array{name}. To ignore these '
                              'gradients in the similarity computation set `trainable=False` on the '
                              'corresponding parameter.'))
         return grad.numpy().reshape(-1)
@@ -87,11 +87,11 @@ class _TensorFlowBackend:
         if device is None or isinstance(device, str):
             _TensorFlowBackend.device = device
         else:
-            raise TypeError(f"`device` must be a string or None. Got {type(device)} instead.")
+            raise TypeError(f"`device` must be a `string` or `None`. Got {type(device)} instead.")
 
     @staticmethod
     def to_numpy(X: tf.Tensor) -> tf.Tensor:
-        """Converts a tensor to a `numpy` array."""
+        """Converts a tensor to `np.ndarray`."""
         return X.numpy()
 
     @staticmethod
@@ -105,7 +105,7 @@ class _TensorFlowBackend:
         """Returns a list of non trainable parameters.
 
         Returns a list of names of parameters that are non trainable. If no trainable parameter exist we raise
-        a ValueError.
+        a `ValueError`.
         """
 
         if len(model.trainable_weights) == 0:

--- a/alibi/explainers/similarity/backends/tensorflow/base.py
+++ b/alibi/explainers/similarity/backends/tensorflow/base.py
@@ -101,7 +101,7 @@ class _TensorFlowBackend:
         return X
 
     @staticmethod
-    def get_non_trainable(model: keras.Model) -> List[Optional[str]]:
+    def _get_non_trainable(model: keras.Model) -> List[Optional[str]]:
         """Returns a list of non trainable parameters.
 
         Returns a list of names of parameters that are non trainable. If no trainable parameter exist we raise

--- a/alibi/explainers/similarity/backends/tensorflow/base.py
+++ b/alibi/explainers/similarity/backends/tensorflow/base.py
@@ -87,3 +87,10 @@ class _TensorFlowBackend:
         """Returns the index of the maximum value in a tensor."""
         X = tf.math.argmax(X, axis=dim)
         return X
+
+    @staticmethod
+    def check_all_layers_trainable(model: keras.Model) -> None:
+        """Checks if all layers in a model are trainable."""
+        if len(model.weights) != len(model.trainable_weights):
+            return False
+        return True

--- a/alibi/explainers/similarity/backends/tensorflow/base.py
+++ b/alibi/explainers/similarity/backends/tensorflow/base.py
@@ -91,6 +91,8 @@ class _TensorFlowBackend:
     @staticmethod
     def check_all_layers_trainable(model: keras.Model) -> bool:
         """Checks if all layers in a model are trainable."""
-        if len(model.weights) != len(model.trainable_weights):
+        for weight in model.non_trainable_weights:
+            if weight.name.startswith('batch_normalization'):
+                continue
             return False
         return True

--- a/alibi/explainers/similarity/backends/tensorflow/base.py
+++ b/alibi/explainers/similarity/backends/tensorflow/base.py
@@ -55,7 +55,7 @@ class _TensorFlowBackend:
         return grad_X_train
 
     @staticmethod
-    def _grad_to_numpy(grad: tf.Tensor, name: Optional[str] = None) -> tf.Tensor:
+    def _grad_to_numpy(grad: Union[tf.IndexedSlices, tf.Tensor], name: Optional[str] = None) -> tf.Tensor:
         """Convert graidient to numpy array.
 
         Converts gradient tensor to flat numpy array. If the gradient is a sparse tensor, it is converted to a dense

--- a/alibi/explainers/similarity/backends/tensorflow/base.py
+++ b/alibi/explainers/similarity/backends/tensorflow/base.py
@@ -4,7 +4,7 @@ Methods unique to the `tensorflow` backend are defined here. The interface this 
 backend in order to ensure that the similarity methods only require to match this interface.
 """
 
-from typing import Callable, Optional, Union, List
+from typing import Callable, Optional, Union
 
 import numpy as np
 import tensorflow as tf
@@ -101,10 +101,10 @@ class _TensorFlowBackend:
         return X
 
     @staticmethod
-    def _get_non_trainable(model: keras.Model) -> List[Optional[str]]:
-        """Returns a list of non trainable parameters.
+    def _count_non_trainable(model: keras.Model) -> int:
+        """Returns number of non trainable parameters.
 
-        Returns a list of names of parameters that are non trainable. If no trainable parameter exists we raise
+        Returns the number of parameters that are non trainable. If no trainable parameter exists we raise
         a `ValueError`.
         """
 
@@ -112,4 +112,4 @@ class _TensorFlowBackend:
             raise ValueError("The model has no trainable weights. This method requires at least "
                              "one trainable parameter to compute the gradients for. "
                              "Set ``trainable=True`` on the model or a model weight.")
-        return [getattr(weight, 'name', None) for weight in model.non_trainable_weights]
+        return len(model.non_trainable_weights)

--- a/alibi/explainers/similarity/backends/tensorflow/base.py
+++ b/alibi/explainers/similarity/backends/tensorflow/base.py
@@ -89,7 +89,7 @@ class _TensorFlowBackend:
         return X
 
     @staticmethod
-    def check_all_layers_trainable(model: keras.Model) -> None:
+    def check_all_layers_trainable(model: keras.Model) -> bool:
         """Checks if all layers in a model are trainable."""
         if len(model.weights) != len(model.trainable_weights):
             return False

--- a/alibi/explainers/similarity/backends/tensorflow/base.py
+++ b/alibi/explainers/similarity/backends/tensorflow/base.py
@@ -87,7 +87,7 @@ class _TensorFlowBackend:
         if device is None or isinstance(device, str):
             _TensorFlowBackend.device = device
         else:
-            raise TypeError(f"`device` must be a ``string`` or ``None``. Got {type(device)} instead.")
+            raise TypeError(f"`device` must be a `string` or ``None``. Got {type(device)} instead.")
 
     @staticmethod
     def to_numpy(X: tf.Tensor) -> np.ndarray:

--- a/alibi/explainers/similarity/backends/tensorflow/base.py
+++ b/alibi/explainers/similarity/backends/tensorflow/base.py
@@ -50,7 +50,9 @@ class _TensorFlowBackend:
 
             # compute gradients of the loss w.r.t the weights
             grad_X_train = tape.gradient(loss, model.trainable_weights)
-            grad_X_train = np.concatenate([w.numpy().reshape(-1) for w in grad_X_train])
+            # see https://github.com/SeldonIO/alibi/issues/828 w.r.t. filtering out tf.IndexedSlices
+            grad_X_train = np.concatenate([w.numpy().reshape(-1) for w in grad_X_train
+                                           if not isinstance(w, tf.IndexedSlices)])
         return grad_X_train
 
     @staticmethod

--- a/alibi/explainers/similarity/backends/tensorflow/base.py
+++ b/alibi/explainers/similarity/backends/tensorflow/base.py
@@ -69,7 +69,7 @@ class _TensorFlowBackend:
         if not hasattr(grad, 'numpy'):
             name = f' for the named tensor: {name}' if name else ''
             raise TypeError((f'Could not convert gradient to `numpy` array{name}. To ignore these '
-                             'gradients in the similarity computation set `trainable=False` on the '
+                             'gradients in the similarity computation set ``trainable=False`` on the '
                              'corresponding parameter.'))
         return grad.numpy().reshape(-1)
 
@@ -87,7 +87,7 @@ class _TensorFlowBackend:
         if device is None or isinstance(device, str):
             _TensorFlowBackend.device = device
         else:
-            raise TypeError(f"`device` must be a `string` or `None`. Got {type(device)} instead.")
+            raise TypeError(f"`device` must be a ``string`` or ``None``. Got {type(device)} instead.")
 
     @staticmethod
     def to_numpy(X: tf.Tensor) -> np.ndarray:
@@ -109,8 +109,7 @@ class _TensorFlowBackend:
         """
 
         if len(model.trainable_weights) == 0:
-            raise ValueError('The model has no trainable weights. This method requires at least'
-                             'one trainable parameter to compute the gradients for. '
-                             'Set `trainable=True` on the model or a model weight')
-
+            raise ValueError("The model has no trainable weights. This method requires at least "
+                             "one trainable parameter to compute the gradients for. "
+                             "Set ``trainable=True`` on the model or a model weight.")
         return [getattr(weight, 'name', None) for weight in model.non_trainable_weights]

--- a/alibi/explainers/similarity/backends/tensorflow/base.py
+++ b/alibi/explainers/similarity/backends/tensorflow/base.py
@@ -58,7 +58,7 @@ class _TensorFlowBackend:
     def _grad_to_numpy(grad: tf.Tensor, name: Optional[str] = None) -> tf.Tensor:
         """Convert graidient to numpy array.
 
-        Converts gradient tensor to flat numpy array. If the gradient is a sparse tensor, it is converted to a dense \
+        Converts gradient tensor to flat numpy array. If the gradient is a sparse tensor, it is converted to a dense
         tensor first.
         """
 

--- a/alibi/explainers/similarity/backends/tensorflow/base.py
+++ b/alibi/explainers/similarity/backends/tensorflow/base.py
@@ -104,7 +104,7 @@ class _TensorFlowBackend:
     def _get_non_trainable(model: keras.Model) -> List[Optional[str]]:
         """Returns a list of non trainable parameters.
 
-        Returns a list of names of parameters that are non trainable. If no trainable parameter exist we raise
+        Returns a list of names of parameters that are non trainable. If no trainable parameter exists we raise
         a `ValueError`.
         """
 

--- a/alibi/explainers/similarity/backends/tensorflow/base.py
+++ b/alibi/explainers/similarity/backends/tensorflow/base.py
@@ -55,8 +55,8 @@ class _TensorFlowBackend:
         return grad_X_train
 
     @staticmethod
-    def _grad_to_numpy(grad: Union[tf.IndexedSlices, tf.Tensor], name: Optional[str] = None) -> tf.Tensor:
-        """Convert graidient to `np.ndarray`.
+    def _grad_to_numpy(grad: Union[tf.IndexedSlices, tf.Tensor], name: Optional[str] = None) -> np.ndarray:
+        """Convert gradient to `np.ndarray`.
 
         Converts gradient tensor to flat `numpy` array. If the gradient is a sparse tensor, it is converted to a dense
         tensor first.
@@ -90,7 +90,7 @@ class _TensorFlowBackend:
             raise TypeError(f"`device` must be a `string` or `None`. Got {type(device)} instead.")
 
     @staticmethod
-    def to_numpy(X: tf.Tensor) -> tf.Tensor:
+    def to_numpy(X: tf.Tensor) -> np.ndarray:
         """Converts a tensor to `np.ndarray`."""
         return X.numpy()
 

--- a/alibi/explainers/similarity/backends/tensorflow/base.py
+++ b/alibi/explainers/similarity/backends/tensorflow/base.py
@@ -69,7 +69,8 @@ class _TensorFlowBackend:
         if not hasattr(grad, 'numpy'):
             name = f' for the named tensor: {name}' if name else ''
             raise TypeError((f'Could not convert gradient to numpy array{name}. To ignore these '
-                             'gradients in the similarity computation use `trainable=False`.'))
+                             'gradients in the similarity computation set `trainable=False` on the '
+                             'corresponding parameter.'))
         return grad.numpy().reshape(-1)
 
     @staticmethod

--- a/alibi/explainers/similarity/backends/tensorflow/base.py
+++ b/alibi/explainers/similarity/backends/tensorflow/base.py
@@ -51,9 +51,15 @@ class _TensorFlowBackend:
             # compute gradients of the loss w.r.t the weights
             grad_X_train = tape.gradient(loss, model.trainable_weights)
             # see https://github.com/SeldonIO/alibi/issues/828 w.r.t. filtering out tf.IndexedSlices
-            grad_X_train = np.concatenate([w.numpy().reshape(-1) for w in grad_X_train
-                                           if not isinstance(w, tf.IndexedSlices)])
+            grad_X_train = np.concatenate([_TensorFlowBackend._grad_to_numpy(w) for w in grad_X_train])
         return grad_X_train
+
+    @staticmethod
+    def _grad_to_numpy(grad: tf.Tensor) -> tf.Tensor:
+        """Flattens a gradient tensor."""
+        if isinstance(grad, tf.IndexedSlices):
+            grad = tf.convert_to_tensor(grad)
+        return grad.numpy().reshape(-1)
 
     @staticmethod
     def to_tensor(X: np.ndarray) -> tf.Tensor:

--- a/alibi/explainers/similarity/grad.py
+++ b/alibi/explainers/similarity/grad.py
@@ -7,6 +7,7 @@ import copy
 from typing import TYPE_CHECKING, Callable, Optional, Union, Dict, Tuple
 from typing_extensions import Literal
 from enum import Enum
+import warnings
 
 import numpy as np
 
@@ -127,6 +128,10 @@ class GradientSimilarity(BaseSimilarityExplainer):
             backend_name=backend,
             task_name=task
         )
+
+        if not self.backend.check_all_layers_trainable(self.predictor):
+            warnings.warn(("Some layers in the model are not trainable. These layer gradients will not be "
+                           "included in the computation of gradient similarity."))
 
     def fit(self,
             X_train: np.ndarray,

--- a/alibi/explainers/similarity/grad.py
+++ b/alibi/explainers/similarity/grad.py
@@ -133,8 +133,9 @@ class GradientSimilarity(BaseSimilarityExplainer):
         if non_trainable_layers:
             layers_msg = 'The following tensors are not trainable: '
             layers = ", ".join([f"'{layer}'" for layer in non_trainable_layers if layer is not None])
-            warning_msg = ("Some layers in the model are not trainable. These layer gradients will not be "
-                           f"included in the computation of gradient similarity. {layers_msg}{layers}")
+            warning_msg = ("Some layers in the model are not trainable. These layers don't have gradients "
+                           "and will not be included in the computation of gradient similarity. "
+                           f"{layers_msg}{layers}")
             warnings.warn(warning_msg)  # todo: scope warning to this location
 
     def fit(self,

--- a/alibi/explainers/similarity/grad.py
+++ b/alibi/explainers/similarity/grad.py
@@ -143,7 +143,7 @@ class GradientSimilarity(BaseSimilarityExplainer):
             Y_train: np.ndarray) -> "Explainer":
         """Fit the explainer.
 
-        The GradientSimilarity explainer requires the model gradients over the training data. In the explain method it
+        The `GradientSimilarity` explainer requires the model gradients over the training data. In the explain method it
         compares them to the model gradients for the test instance(s). If ``store_grads`` was set to ``True`` on
         initialization then the gradients are precomputed here and stored. This will speed up the explain method call
         but storing the gradients may not be feasible for large models.

--- a/alibi/explainers/similarity/grad.py
+++ b/alibi/explainers/similarity/grad.py
@@ -129,7 +129,7 @@ class GradientSimilarity(BaseSimilarityExplainer):
             task_name=task
         )
 
-        non_trainable_layers = self.backend.get_non_trainable(self.predictor)
+        non_trainable_layers = self.backend._get_non_trainable(self.predictor)
         if non_trainable_layers:
             layers_msg = 'The following tensors are not trainable: '
             layers = ", ".join([f"'{layer}'" for layer in non_trainable_layers if layer is not None])

--- a/alibi/explainers/similarity/grad.py
+++ b/alibi/explainers/similarity/grad.py
@@ -144,7 +144,7 @@ class GradientSimilarity(BaseSimilarityExplainer):
         """Fit the explainer.
 
         The ``GradientSimilarity`` explainer requires the model gradients over the training data. In the explain method
-        it compares them to the model gradients for the test instance(s). If ``store_grads`` was set to ``True`` on
+        it compares them to the model gradients for the test instance(s). If ``precompute_grads`` was set to ``True`` on
         initialization then the gradients are precomputed here and stored. This will speed up the explain method call
         but storing the gradients may not be feasible for large models.
 

--- a/alibi/explainers/similarity/grad.py
+++ b/alibi/explainers/similarity/grad.py
@@ -129,14 +129,15 @@ class GradientSimilarity(BaseSimilarityExplainer):
             task_name=task
         )
 
-        non_trainable_layers = self.backend._get_non_trainable(self.predictor)
-        if non_trainable_layers:
-            layers_msg = 'The following tensors are non-trainable: '
-            layers = ", ".join([f"'{layer}'" for layer in non_trainable_layers if layer is not None])
-            warning_msg = ("Some layers in the model are non-trainable. These layers don't have gradients "
-                           "and will not be included in the computation of gradient similarity. "
-                           f"{layers_msg}{layers}")
-            warnings.warn(warning_msg)  # todo: scope warning to this location
+        num_non_trainable = self.backend._count_non_trainable(self.predictor)
+        if num_non_trainable:
+            warning_msg = (f"Found {num_non_trainable} non-trainable parameters in the model. These parameters "
+                           "don't have gradients and will not be included in the computation of gradient similarity."
+                           " This might be because your model has layers that track statistics using non-trainable "
+                           "parameters such as batch normalization layers. In this case, you don't need to worry. "
+                           "Otherwise it's because you have set some parameters to be non-trainable and alibi is "
+                           "letting you know.")
+            warnings.warn(warning_msg)
 
     def fit(self,
             X_train: np.ndarray,

--- a/alibi/explainers/similarity/grad.py
+++ b/alibi/explainers/similarity/grad.py
@@ -129,9 +129,13 @@ class GradientSimilarity(BaseSimilarityExplainer):
             task_name=task
         )
 
-        if not self.backend.check_all_layers_trainable(self.predictor):
-            warnings.warn(("Some layers in the model are not trainable. These layer gradients will not be "
-                           "included in the computation of gradient similarity."))
+        non_trainable_layers = self.backend.get_non_trainable(self.predictor)
+        if non_trainable_layers:
+            layers_msg = 'The following layers are not trainable: '
+            layers = ", ".join([f"'{layer}'" for layer in non_trainable_layers if layer is not None])
+            warning_msg = ("Some layers in the model are not trainable. These layer gradients will not be "
+                           f"included in the computation of gradient similarity. {layers_msg}{layers}")
+            warnings.warn(warning_msg)
 
     def fit(self,
             X_train: np.ndarray,

--- a/alibi/explainers/similarity/grad.py
+++ b/alibi/explainers/similarity/grad.py
@@ -131,11 +131,11 @@ class GradientSimilarity(BaseSimilarityExplainer):
 
         non_trainable_layers = self.backend.get_non_trainable(self.predictor)
         if non_trainable_layers:
-            layers_msg = 'The following layers are not trainable: '
+            layers_msg = 'The following tensors are not trainable: '
             layers = ", ".join([f"'{layer}'" for layer in non_trainable_layers if layer is not None])
             warning_msg = ("Some layers in the model are not trainable. These layer gradients will not be "
                            f"included in the computation of gradient similarity. {layers_msg}{layers}")
-            warnings.warn(warning_msg)
+            warnings.warn(warning_msg)  # todo: scope warning to this location
 
     def fit(self,
             X_train: np.ndarray,

--- a/alibi/explainers/similarity/grad.py
+++ b/alibi/explainers/similarity/grad.py
@@ -45,7 +45,7 @@ class GradientSimilarity(BaseSimilarityExplainer):
                  device: 'Union[int, str, torch.device, None]' = None,
                  verbose: bool = False,
                  ):
-        """GradientSimilarity explainer.
+        """``GradientSimilarity`` explainer.
 
         The gradient similarity explainer is used to find examples in the training data that the predictor considers
         similar to test instances the user wants to explain. It uses the gradients of the loss between the model output
@@ -143,7 +143,7 @@ class GradientSimilarity(BaseSimilarityExplainer):
             Y_train: np.ndarray) -> "Explainer":
         """Fit the explainer.
 
-        The `GradientSimilarity` explainer requires the model gradients over the training data. In the explain method it
+        The ``GradientSimilarity`` explainer requires the model gradients over the training data. In the explain method it
         compares them to the model gradients for the test instance(s). If ``store_grads`` was set to ``True`` on
         initialization then the gradients are precomputed here and stored. This will speed up the explain method call
         but storing the gradients may not be feasible for large models.

--- a/alibi/explainers/similarity/grad.py
+++ b/alibi/explainers/similarity/grad.py
@@ -145,7 +145,7 @@ class GradientSimilarity(BaseSimilarityExplainer):
         """Fit the explainer.
 
         The `GradientSimilarity` explainer requires the model gradients over the training data. In the explain method
-        it compares them to the model gradients for the test instance(s). If `precompute_grads` was set to ``True`` on
+        it compares them to the model gradients for the test instance(s). If ``precompute_grads=True`` on
         initialization then the gradients are precomputed here and stored. This will speed up the explain method call
         but storing the gradients may not be feasible for large models.
 

--- a/alibi/explainers/similarity/grad.py
+++ b/alibi/explainers/similarity/grad.py
@@ -45,12 +45,12 @@ class GradientSimilarity(BaseSimilarityExplainer):
                  device: 'Union[int, str, torch.device, None]' = None,
                  verbose: bool = False,
                  ):
-        """``GradientSimilarity`` explainer.
+        """`GradientSimilarity` explainer.
 
         The gradient similarity explainer is used to find examples in the training data that the predictor considers
         similar to test instances the user wants to explain. It uses the gradients of the loss between the model output
         and the training data labels. These are compared using the similarity function specified by ``sim_fn``. The
-        GradientSimilarity can be applied to models trained for both classification and regression tasks.
+        `GradientSimilarity` explainer can be applied to models trained for both classification and regression tasks.
 
 
         Parameters
@@ -131,9 +131,9 @@ class GradientSimilarity(BaseSimilarityExplainer):
 
         non_trainable_layers = self.backend._get_non_trainable(self.predictor)
         if non_trainable_layers:
-            layers_msg = 'The following tensors are not trainable: '
+            layers_msg = 'The following tensors are non-trainable: '
             layers = ", ".join([f"'{layer}'" for layer in non_trainable_layers if layer is not None])
-            warning_msg = ("Some layers in the model are not trainable. These layers don't have gradients "
+            warning_msg = ("Some layers in the model are non-trainable. These layers don't have gradients "
                            "and will not be included in the computation of gradient similarity. "
                            f"{layers_msg}{layers}")
             warnings.warn(warning_msg)  # todo: scope warning to this location
@@ -143,8 +143,8 @@ class GradientSimilarity(BaseSimilarityExplainer):
             Y_train: np.ndarray) -> "Explainer":
         """Fit the explainer.
 
-        The ``GradientSimilarity`` explainer requires the model gradients over the training data. In the explain method
-        it compares them to the model gradients for the test instance(s). If ``precompute_grads`` was set to ``True`` on
+        The `GradientSimilarity` explainer requires the model gradients over the training data. In the explain method
+        it compares them to the model gradients for the test instance(s). If `precompute_grads` was set to ``True`` on
         initialization then the gradients are precomputed here and stored. This will speed up the explain method call
         but storing the gradients may not be feasible for large models.
 

--- a/alibi/explainers/similarity/grad.py
+++ b/alibi/explainers/similarity/grad.py
@@ -143,8 +143,8 @@ class GradientSimilarity(BaseSimilarityExplainer):
             Y_train: np.ndarray) -> "Explainer":
         """Fit the explainer.
 
-        The ``GradientSimilarity`` explainer requires the model gradients over the training data. In the explain method it
-        compares them to the model gradients for the test instance(s). If ``store_grads`` was set to ``True`` on
+        The ``GradientSimilarity`` explainer requires the model gradients over the training data. In the explain method
+        it compares them to the model gradients for the test instance(s). If ``store_grads`` was set to ``True`` on
         initialization then the gradients are precomputed here and stored. This will speed up the explain method call
         but storing the gradients may not be feasible for large models.
 

--- a/alibi/explainers/tests/test_simiarlity/conftest.py
+++ b/alibi/explainers/tests/test_simiarlity/conftest.py
@@ -82,11 +82,10 @@ def linear_cls_model(request):
     input_shape = request.param.get('input_shape', (10,))
     output_shape = request.param.get('output_shape', 10)
     framework = request.param.get('framework', 'tensorflow')
-    batch_norm = request.param.get('batch_norm', False)
 
     model = {
-        'tensorflow': lambda i_shape, o_shape: tf_linear_model(i_shape, o_shape, batch_norm),
-        'pytorch': lambda i_shape, o_shape: torch_linear_model(i_shape, o_shape, batch_norm)
+        'tensorflow': lambda i_shape, o_shape: tf_linear_model(i_shape, o_shape),
+        'pytorch': lambda i_shape, o_shape: torch_linear_model(i_shape, o_shape)
     }[framework](input_shape, output_shape)
 
     loss_fn = {
@@ -144,26 +143,21 @@ def linear_models(request):
     return tf_model, tf_loss, torch_model, torch_loss
 
 
-def tf_linear_model(input_shape, output_shape, batch_norm=False):
+def tf_linear_model(input_shape, output_shape):
     """
     Constructs a linear model for `tensorflow`.
     """
     layers = [
         tf.keras.layers.InputLayer(input_shape=input_shape),
         tf.keras.layers.Flatten(),
-    ]
-    if batch_norm:
-        layers.append(tf.keras.layers.BatchNormalization())
-    layers.extend([
-        tf.keras.layers.Dense(output_shape),
         tf.keras.layers.Dense(output_shape),
         tf.keras.layers.Softmax()
-    ])
+    ]
 
     return keras.Sequential(layers)
 
 
-def torch_linear_model(input_shape_arg, output_shape_arg, batch_norm=False):
+def torch_linear_model(input_shape_arg, output_shape_arg):
     """
     Constructs a linear model for `torch`.
     """
@@ -174,9 +168,7 @@ def torch_linear_model(input_shape_arg, output_shape_arg, batch_norm=False):
             super(Model, self).__init__()
             self.linear_stack = nn.Sequential(
                 nn.Flatten(start_dim=1),
-                nn.BatchNorm1d(input_shape) if batch_norm else nn.Identity(),
                 nn.Linear(input_shape, output_shape),
-                nn.Linear(output_shape, output_shape),
                 nn.Softmax()
             )
 

--- a/alibi/explainers/tests/test_simiarlity/conftest.py
+++ b/alibi/explainers/tests/test_simiarlity/conftest.py
@@ -156,6 +156,7 @@ def tf_linear_model(input_shape, output_shape, batch_norm=False):
         layers.append(tf.keras.layers.BatchNormalization())
     layers.extend([
         tf.keras.layers.Dense(output_shape),
+        tf.keras.layers.Dense(output_shape),
         tf.keras.layers.Softmax()
     ])
 
@@ -175,6 +176,7 @@ def torch_linear_model(input_shape_arg, output_shape_arg, batch_norm=False):
                 nn.Flatten(start_dim=1),
                 nn.BatchNorm1d(input_shape) if batch_norm else nn.Identity(),
                 nn.Linear(input_shape, output_shape),
+                nn.Linear(output_shape, output_shape),
                 nn.Softmax()
             )
 

--- a/alibi/explainers/tests/test_simiarlity/conftest.py
+++ b/alibi/explainers/tests/test_simiarlity/conftest.py
@@ -147,14 +147,12 @@ def tf_linear_model(input_shape, output_shape):
     """
     Constructs a linear model for `tensorflow`.
     """
-    layers = [
+    return keras.Sequential([
         tf.keras.layers.InputLayer(input_shape=input_shape),
         tf.keras.layers.Flatten(),
         tf.keras.layers.Dense(output_shape),
         tf.keras.layers.Softmax()
-    ]
-
-    return keras.Sequential(layers)
+    ])
 
 
 def torch_linear_model(input_shape_arg, output_shape_arg):

--- a/alibi/explainers/tests/test_simiarlity/conftest.py
+++ b/alibi/explainers/tests/test_simiarlity/conftest.py
@@ -82,10 +82,11 @@ def linear_cls_model(request):
     input_shape = request.param.get('input_shape', (10,))
     output_shape = request.param.get('output_shape', 10)
     framework = request.param.get('framework', 'tensorflow')
+    batch_norm = request.param.get('batch_norm', False)
 
     model = {
-        'tensorflow': lambda i_shape, o_shape: tf_linear_model(i_shape, o_shape),
-        'pytorch': lambda i_shape, o_shape: torch_linear_model(i_shape, o_shape)
+        'tensorflow': lambda i_shape, o_shape: tf_linear_model(i_shape, o_shape, batch_norm),
+        'pytorch': lambda i_shape, o_shape: torch_linear_model(i_shape, o_shape, batch_norm)
     }[framework](input_shape, output_shape)
 
     loss_fn = {
@@ -143,18 +144,25 @@ def linear_models(request):
     return tf_model, tf_loss, torch_model, torch_loss
 
 
-def tf_linear_model(input_shape, output_shape):
+def tf_linear_model(input_shape, output_shape, batch_norm=False):
     """
     Constructs a linear model for `tensorflow`.
     """
-    return keras.Sequential([
-        keras.layers.InputLayer(input_shape=input_shape),
-        keras.layers.Dense(output_shape),
-        keras.layers.Softmax()
+    layers = [
+        tf.keras.layers.InputLayer(input_shape=input_shape),
+        tf.keras.layers.Flatten(),
+    ]
+    if batch_norm:
+        layers.append(tf.keras.layers.BatchNormalization())
+    layers.extend([
+        tf.keras.layers.Dense(output_shape),
+        tf.keras.layers.Softmax()
     ])
 
+    return keras.Sequential(layers)
 
-def torch_linear_model(input_shape_arg, output_shape_arg):
+
+def torch_linear_model(input_shape_arg, output_shape_arg, batch_norm=False):
     """
     Constructs a linear model for `torch`.
     """
@@ -165,6 +173,7 @@ def torch_linear_model(input_shape_arg, output_shape_arg):
             super(Model, self).__init__()
             self.linear_stack = nn.Sequential(
                 nn.Flatten(start_dim=1),
+                nn.BatchNorm1d(input_shape) if batch_norm else nn.Identity(),
                 nn.Linear(input_shape, output_shape),
                 nn.Softmax()
             )

--- a/alibi/explainers/tests/test_simiarlity/test_backends.py
+++ b/alibi/explainers/tests/test_simiarlity/test_backends.py
@@ -62,7 +62,7 @@ def test_tf_embedding_similarity(trainable_emd, grads_shape):
     Y = tf.random.uniform(shape=(1, 1), minval=0, maxval=10, dtype=tf.float32)
     loss_fn = tf.keras.losses.MeanSquaredError()
     tf_grads = _TensorFlowBackend.get_grads(model, X, Y, loss_fn)
-    assert tf_grads.shape == grads_shape  # (4 * 10) + (5 * 4) + 1
+    assert tf_grads.shape == grads_shape  # (4 * 10) * trainable_emd + (5 * 4) + 1
 
 
 @pytest.mark.parametrize('trainable_emd, grads_shape', [(True, (61, )), (False, (21, ))])
@@ -85,8 +85,8 @@ def test_pytorch_embedding_similarity(trainable_emd, grads_shape, sparse):
     X = torch.randint(0, 10, (1, 5))
     Y = torch.randint(0, 10, (1, 1), dtype=torch.float32)
     loss_fn = torch.nn.MSELoss()
-    tf_grads = _PytorchBackend.get_grads(model, X, Y, loss_fn)
-    assert tf_grads.shape == grads_shape  # (4 * 10) + (5 * 4) + 1
+    pt_grads = _PytorchBackend.get_grads(model, X, Y, loss_fn)
+    assert pt_grads.shape == grads_shape  # (4 * 10) * trainable_emd + (5 * 4) + 1
 
 
 def test_non_numpy_grads_pytorch():

--- a/alibi/explainers/tests/test_simiarlity/test_backends.py
+++ b/alibi/explainers/tests/test_simiarlity/test_backends.py
@@ -46,7 +46,7 @@ def test_backends(random_cls_dataset, linear_models):
 
 @pytest.mark.parametrize('trainable_emd, grads_shape', [(True, (61, )), (False, (21, ))])
 def test_tf_embedding_similarity(trainable_emd, grads_shape):
-    """Test GradSim explainer correctly handles sparcity and non-trainable layers for tensorflow.
+    """Test GradSim explainer correctly handles sparsity and non-trainable layers for tensorflow.
 
     Test that `tensorflow` embedding layers work as expected and also that layers
     marked as non-trainable are not included in the gradients.
@@ -68,7 +68,7 @@ def test_tf_embedding_similarity(trainable_emd, grads_shape):
 @pytest.mark.parametrize('trainable_emd, grads_shape', [(True, (61, )), (False, (21, ))])
 @pytest.mark.parametrize('sparse', [True, False])
 def test_pytorch_embedding_similarity(trainable_emd, grads_shape, sparse):
-    """Test GradSim explainer correctly handles sparcity and non-trainable layers for pytorch.
+    """Test GradSim explainer correctly handles sparsity and non-trainable layers for pytorch.
 
     Tests that the `pytorch` embedding layers work as expected and that layers marked as
     non-trainable are not included in the gradients.

--- a/alibi/explainers/tests/test_simiarlity/test_backends.py
+++ b/alibi/explainers/tests/test_simiarlity/test_backends.py
@@ -100,14 +100,14 @@ def test_non_numpy_grads_pytorch():
     with pytest.raises(TypeError) as err:
         _PytorchBackend._grad_to_numpy(MockTensor())
 
-    assert ("Could not convert gradient to numpy array. To ignore these gradients in the "
+    assert ("Could not convert gradient to `numpy` array. To ignore these gradients in the "
             "similarity computation set `requires_grad=False` on the corresponding parameter.") \
         in str(err.value)
 
     with pytest.raises(TypeError) as err:
         _PytorchBackend._grad_to_numpy(MockTensor(), 'test')
 
-    assert ("Could not convert gradient to numpy array for the named tensor: test. "
+    assert ("Could not convert gradient to `numpy` array for the named tensor: test. "
             "To ignore these gradients in the similarity computation set `requires_grad=False`"
             " on the corresponding parameter.") in str(err.value)
 
@@ -123,13 +123,13 @@ def test_non_numpy_grads_tensorflow():
     with pytest.raises(TypeError) as err:
         _TensorFlowBackend._grad_to_numpy(MockTensor())
 
-    assert ("Could not convert gradient to numpy array. To ignore these gradients "
+    assert ("Could not convert gradient to `numpy` array. To ignore these gradients "
             "in the similarity computation set `trainable=False` on the corresponding parameter.") \
         in str(err.value)
 
     with pytest.raises(TypeError) as err:
         _TensorFlowBackend._grad_to_numpy(MockTensor(), 'test')
 
-    assert ("Could not convert gradient to numpy array for the named tensor: test."
+    assert ("Could not convert gradient to `numpy` array for the named tensor: test."
             " To ignore these gradients in the similarity computation set "
             "`trainable=False` on the corresponding parameter.") in str(err.value)

--- a/alibi/explainers/tests/test_simiarlity/test_backends.py
+++ b/alibi/explainers/tests/test_simiarlity/test_backends.py
@@ -100,14 +100,16 @@ def test_non_numpy_grads_pytorch():
     with pytest.raises(TypeError) as err:
         _PytorchBackend._grad_to_numpy(MockTensor())
 
-    assert ("Could not convert gradient to numpy array. To ignore these gradients in"
-            " the similarity computation use `requires_grad=False`.") in str(err.value)
+    assert ("Could not convert gradient to numpy array. To ignore these gradients in the "
+            "similarity computation set `requires_grad=False` on the corresponding parameter.") \
+        in str(err.value)
 
     with pytest.raises(TypeError) as err:
         _PytorchBackend._grad_to_numpy(MockTensor(), 'test')
 
     assert ("Could not convert gradient to numpy array for the named tensor: test. "
-            "To ignore these gradients in the similarity computation use `requires_grad=False`.") in str(err.value)
+            "To ignore these gradients in the similarity computation set `requires_grad=False`"
+            " on the corresponding parameter.") in str(err.value)
 
 
 def test_non_numpy_grads_tensorflow():
@@ -122,10 +124,12 @@ def test_non_numpy_grads_tensorflow():
         _TensorFlowBackend._grad_to_numpy(MockTensor())
 
     assert ("Could not convert gradient to numpy array. To ignore these gradients "
-            "in the similarity computation use `trainable=False`.") in str(err.value)
+            "in the similarity computation set `trainable=False` on the corresponding parameter.") \
+        in str(err.value)
 
     with pytest.raises(TypeError) as err:
         _TensorFlowBackend._grad_to_numpy(MockTensor(), 'test')
 
     assert ("Could not convert gradient to numpy array for the named tensor: test."
-            " To ignore these gradients in the similarity computation use `trainable=False`.") in str(err.value)
+            " To ignore these gradients in the similarity computation set "
+            "`trainable=False` on the corresponding parameter.") in str(err.value)

--- a/alibi/explainers/tests/test_simiarlity/test_backends.py
+++ b/alibi/explainers/tests/test_simiarlity/test_backends.py
@@ -46,7 +46,7 @@ def test_backends(random_cls_dataset, linear_models):
 
 @pytest.mark.parametrize('trainable_emd, grads_shape', [(True, (61, )), (False, (21, ))])
 def test_tf_embedding_similarity(trainable_emd, grads_shape):
-    """Test GradSim explainer correctly handles sparsity and non-trainable layers for tensorflow.
+    """Test `GradientSimilarity` explainer correctly handles sparsity and non-trainable layers for `tensorflow`.
 
     Test that `tensorflow` embedding layers work as expected and also that layers
     marked as non-trainable are not included in the gradients.
@@ -68,7 +68,7 @@ def test_tf_embedding_similarity(trainable_emd, grads_shape):
 @pytest.mark.parametrize('trainable_emd, grads_shape', [(True, (61, )), (False, (21, ))])
 @pytest.mark.parametrize('sparse', [True, False])
 def test_pytorch_embedding_similarity(trainable_emd, grads_shape, sparse):
-    """Test GradSim explainer correctly handles sparsity and non-trainable layers for pytorch.
+    """Test GradientSimilarity explainer correctly handles sparsity and non-trainable layers for pytorch.
 
     Tests that the `pytorch` embedding layers work as expected and that layers marked as
     non-trainable are not included in the gradients.
@@ -90,9 +90,9 @@ def test_pytorch_embedding_similarity(trainable_emd, grads_shape, sparse):
 
 
 def test_non_numpy_grads_pytorch():
-    """Test that the `pytorch` backend handles non-numpy gradients correctly.
+    """Test that the `pytorch` backend handles gradients withtout `numpy` methods correctly.
 
-    _PytorchBackend should throw an error if the gradients cannot be converted to numpy arrays.
+    `_PytorchBackend` should throw an error if the gradients cannot be converted to numpy arrays.
     """
     class MockTensor():
         is_sparse = False
@@ -101,21 +101,21 @@ def test_non_numpy_grads_pytorch():
         _PytorchBackend._grad_to_numpy(MockTensor())
 
     assert ("Could not convert gradient to `numpy` array. To ignore these gradients in the "
-            "similarity computation set `requires_grad=False` on the corresponding parameter.") \
+            "similarity computation set ``requires_grad=False`` on the corresponding parameter.") \
         in str(err.value)
 
     with pytest.raises(TypeError) as err:
         _PytorchBackend._grad_to_numpy(MockTensor(), 'test')
 
     assert ("Could not convert gradient to `numpy` array for the named tensor: test. "
-            "To ignore these gradients in the similarity computation set `requires_grad=False`"
+            "To ignore these gradients in the similarity computation set ``requires_grad=False``"
             " on the corresponding parameter.") in str(err.value)
 
 
 def test_non_numpy_grads_tensorflow():
-    """Test that the `tensorflow` backend handles non-numpy gradients correctly.
+    """Test that the `tensorflow` backend handles gradients without `numpy` methods correctly.
 
-    _TensorFlowBackend should throw an error if the gradients cannot be converted to numpy arrays.
+    `_TensorFlowBackend` should throw an error if the gradients cannot be converted to `numpy` arrays.
     """
     class MockTensor():
         is_sparse = False
@@ -124,7 +124,7 @@ def test_non_numpy_grads_tensorflow():
         _TensorFlowBackend._grad_to_numpy(MockTensor())
 
     assert ("Could not convert gradient to `numpy` array. To ignore these gradients "
-            "in the similarity computation set `trainable=False` on the corresponding parameter.") \
+            "in the similarity computation set ``trainable=False`` on the corresponding parameter.") \
         in str(err.value)
 
     with pytest.raises(TypeError) as err:
@@ -132,4 +132,4 @@ def test_non_numpy_grads_tensorflow():
 
     assert ("Could not convert gradient to `numpy` array for the named tensor: test."
             " To ignore these gradients in the similarity computation set "
-            "`trainable=False` on the corresponding parameter.") in str(err.value)
+            "``trainable=False`` on the corresponding parameter.") in str(err.value)

--- a/alibi/explainers/tests/test_simiarlity/test_backends.py
+++ b/alibi/explainers/tests/test_simiarlity/test_backends.py
@@ -70,7 +70,7 @@ def test_tf_embedding_similarity(trainable_emd, grads_shape):
 def test_pytorch_embedding_similarity(trainable_emd, grads_shape, sparse):
     """Test GradSim explainer correctly handles sparcity and non-trainable layers for pytorch.
 
-    Tests that the `pytorch` embedding layers work as expected and that layers marked as 
+    Tests that the `pytorch` embedding layers work as expected and that layers marked as
     non-trainable are not included in the gradients.
     """
 

--- a/alibi/explainers/tests/test_simiarlity/test_backends.py
+++ b/alibi/explainers/tests/test_simiarlity/test_backends.py
@@ -46,8 +46,10 @@ def test_backends(random_cls_dataset, linear_models):
 
 @pytest.mark.parametrize('trainable_emd, grads_shape', [(True, (61, )), (False, (21, ))])
 def test_tf_embedding_similarity(trainable_emd, grads_shape):
-    """Test that the `tensorflow` embedding similarity backend works as expected.
+    """Test GradSim explainer correctly handles sparcity and non-trainable layers for tensorflow.
 
+    Test that `tensorflow` embedding layers work as expected and also that layers
+    marked as non-trainable are not included in the gradients.
     See https://github.com/SeldonIO/alibi/issues/828.
     """
     model = tf.keras.models.Sequential([
@@ -66,7 +68,11 @@ def test_tf_embedding_similarity(trainable_emd, grads_shape):
 @pytest.mark.parametrize('trainable_emd, grads_shape', [(True, (61, )), (False, (21, ))])
 @pytest.mark.parametrize('sparse', [True, False])
 def test_pytorch_embedding_similarity(trainable_emd, grads_shape, sparse):
-    """Test that the `pytorch` embedding similarity backend works as expected."""
+    """Test GradSim explainer correctly handles sparcity and non-trainable layers for pytorch.
+
+    Tests that the `pytorch` embedding layers work as expected and that layers marked as 
+    non-trainable are not included in the gradients.
+    """
 
     model = torch.nn.Sequential(
         torch.nn.Embedding(10, 4, 5, sparse=sparse),

--- a/alibi/explainers/tests/test_simiarlity/test_backends.py
+++ b/alibi/explainers/tests/test_simiarlity/test_backends.py
@@ -74,10 +74,7 @@ def test_pytorch_embedding_similarity(trainable_emd, grads_shape, sparse):
         torch.nn.LazyLinear(1)
     )
 
-    if trainable_emd:
-        model[0].weight.requires_grad = True
-    else:
-        model[0].weight.requires_grad = False
+    model[0].weight.requires_grad = trainable_emd
 
     X = torch.randint(0, 10, (1, 5))
     Y = torch.randint(0, 10, (1, 1), dtype=torch.float32)

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
@@ -348,8 +348,9 @@ def test_non_trainable_layer_warnings_tf():
             backend='tensorflow',
         )
 
-    assert ("Some layers in the model are not trainable. These layer gradients will not be "
-            "included in the computation of gradient similarity.") in str(record[0].message)
+    assert ("Some layers in the model are not trainable. These layers don't have "
+            "gradients and will not be included in the computation of gradient similarity.") \
+            in str(record[0].message)
 
     assert "The following tensors are not trainable:" \
         in str(record[0].message)
@@ -399,8 +400,9 @@ def test_non_trainable_layer_warnings_pt():
             backend='pytorch'
         )
 
-    assert ("Some layers in the model are not trainable. These layer gradients will not be "
-            "included in the computation of gradient similarity.") in str(record[0].message)
+    assert ("Some layers in the model are not trainable. These layers don't have "
+            "gradients and will not be included in the computation of gradient similarity.") \
+            in str(record[0].message)
 
     assert "The following tensors are not trainable:" \
         in str(record[0].message)

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
@@ -362,10 +362,6 @@ def test_non_trainable_layer_warnings_tf():
 
     model.layers[1].trainable = False
     model.layers[-1].layers[1].trainable = False
-
-    # tensor_names = [tensor.name for tensor in model.layers[1].non_trainable_weights]
-    # tensor_names.extend([tensor.name for tensor in model.layers[-1].layers[1].non_trainable_weights])
-    # tensor_names.extend([tensor.name for tensor in model.layers[2].non_trainable_weights])
     num_params_non_trainable = len(model.non_trainable_weights)
     loss_fn = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)
 

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
@@ -348,8 +348,10 @@ def test_non_trainable_layer_warnings(linear_cls_model):
 
     if backend == 'pytorch':
         model.linear_stack[2].weight.requires_grad = False
+        model.linear_stack[3].weight.requires_grad = False
     elif backend == 'tensorflow':
         model.layers[1].trainable = False
+        model.layers[2].trainable = False
 
     with pytest.warns(Warning) as record:
         GradientSimilarity(
@@ -358,5 +360,13 @@ def test_non_trainable_layer_warnings(linear_cls_model):
             loss_fn=loss_fn,
             backend=backend,
         )
-    assert str(record[0].message) == ("Some layers in the model are not trainable. These layer gradients will not be "
-                                      "included in the computation of gradient similarity.")
+
+    assert ("Some layers in the model are not trainable. These layer gradients will not be "
+            "included in the computation of gradient similarity.") in str(record[0].message)
+
+    if backend == 'pytorch':
+        assert "The following layers are not trainable: 'linear_stack.2.weight', 'linear_stack.3.weight'" \
+                in str(record[0].message)
+    if backend == 'tensorflow':
+        assert "The following layers are not trainable: 'dense_24', 'dense_25'" \
+                in str(record[0].message)

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
@@ -141,7 +141,7 @@ def test_correct_grad_dot_sim_result_tf(seed, normed_ds):
     """
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
 
-    # GradSim method checks weights are trainable so we need to build the model before passing it to the
+    # GradientSimilarity method checks weights are trainable so we need to build the model before passing it to the
     # method
     model.build((None, 2))
 
@@ -167,7 +167,7 @@ def test_correct_grad_cos_sim_result_tf(seed, ds):
     `tensorflow` backend.
     """
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
-    # GradSim method checks weights are trainable so we need to build the model before passing it to the
+    # GradientSimilarity method checks weights are trainable so we need to build the model before passing it to the
     # method
     model.build((None, 2))
 
@@ -193,7 +193,7 @@ def test_grad_dot_result_order_tf(seed):
     """
     ds = np.array([[1, 0], [0.9, 0.1], [0.5 * 100, 0.5 * 100]]).astype('float32')
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
-    # GradSim method checks weights are trainable so we need to build the model before passing it to the
+    # GradientSimilarity method checks weights are trainable so we need to build the model before passing it to the
     # method
     model.build((None, 2))
 
@@ -217,7 +217,7 @@ def test_grad_cos_result_order_tf(seed):
     """
     ds = np.array([[1, 0], [0.9, 0.1], [0.5 * 100, 0.5 * 100]]).astype('float32')
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
-    # GradSim method checks weights are trainable so we need to build the model before passing it to the
+    # GradientSimilarity method checks weights are trainable so we need to build the model before passing it to the
     # method
     model.build((None, 2))
 
@@ -241,7 +241,7 @@ def test_multiple_test_instances_grad_cos(precompute_grads):
     """
     ds = np.array([[1, 0], [0.9, 0.1], [0.5 * 100, 0.5 * 100]]).astype('float32')
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
-    # GradSim method checks weights are trainable so we need to build the model before passing it to the
+    # GradientSimilarity method checks weights are trainable so we need to build the model before passing it to the
     # method
     model.build((None, 2))
 
@@ -271,7 +271,7 @@ def test_multiple_test_instances_grad_dot(precompute_grads):
     """
     ds = np.array([[1, 0], [0.9, 0.1], [0.5 * 100, 0.5 * 100]]).astype('float32')
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
-    # GradSim method checks weights are trainable so we need to build the model before passing it to the
+    # GradientSimilarity method checks weights are trainable so we need to build the model before passing it to the
     # method
     model.build((None, 2))
 
@@ -298,7 +298,7 @@ def test_multiple_test_instances_stored_grads_asym_dot(precompute_grads):
     """
     ds = np.array([[1, 0], [0.9, 0.1], [0.5 * 100, 0.5 * 100]]).astype('float32')
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
-    # GradSim method checks weights are trainable so we need to build the model before passing it to the
+    # GradientSimilarity method checks weights are trainable so we need to build the model before passing it to the
     # method
     model.build((None, 2))
 
@@ -337,14 +337,14 @@ def test_multiple_test_instances_stored_grads_asym_dot(precompute_grads):
 
 
 def test_non_trainable_layer_warnings_tf():
-    """Test Non trainable layer warnings tensorflow.
+    """Test non-trainable layer warnings `tensorflow`.
 
-    Test that warnings are raised when user passes non-trainable layers to grad sim method for
-    tensorflow models.
+    Test that warnings are raised when user passes non-trainable layers to `GradientSimilarity` method for
+    `tensorflow` models.
 
-    Note: Keras batch norm layers register non-trainable weights by default and so will raise the
-    warning we test for here. This is different to the pytorch behavour which doesn't include
-    the batch norm parameters in model.parameters().
+    Note: `Keras` batch norm layers register non-trainable weights by default and so will raise the
+    warning we test for here. This is different to the `pytorch` behavour which doesn't include
+    the batch norm parameters in ``model.parameters()``.
     """
     model = keras.Sequential([
         keras.layers.Dense(10),
@@ -356,7 +356,7 @@ def test_non_trainable_layer_warnings_tf():
         ])
     ])
 
-    # GradSim method checks weights are trainable so we need to build the model before passing it to the
+    # GradientSimilarity method checks weights are trainable so we need to build the model before passing it to the
     # method
     model.build((None, 10))
 
@@ -377,11 +377,11 @@ def test_non_trainable_layer_warnings_tf():
             backend='tensorflow',
         )
 
-    assert ("Some layers in the model are not trainable. These layers don't have "
+    assert ("Some layers in the model are non-trainable. These layers don't have "
             "gradients and will not be included in the computation of gradient similarity.") \
         in str(record[0].message)
 
-    assert "The following tensors are not trainable:" \
+    assert "The following tensors are non-trainable:" \
         in str(record[0].message)
     for tensor_name in tensor_names:
         # print(tensor_name, str(record[0].message).split(':')[-1])
@@ -389,10 +389,10 @@ def test_non_trainable_layer_warnings_tf():
 
 
 def test_non_trainable_layer_warnings_pt():
-    """Test Non trainable layer warnings pytorch.
+    """Test non-trainable layer warnings `pytorch`.
 
-    Test that warnings are raised when user passes non-trainbable layers to grad sim method for
-    pytorch models.
+    Test that warnings are raised when user passes non-trainbable layers to to `GradientSimilarity` method for
+    `pytorch` models.
     """
 
     class Model(nn.Module):
@@ -429,21 +429,21 @@ def test_non_trainable_layer_warnings_pt():
             backend='pytorch'
         )
 
-    assert ("Some layers in the model are not trainable. These layers don't have "
+    assert ("Some layers in the model are non-trainable. These layers don't have "
             "gradients and will not be included in the computation of gradient similarity.") \
         in str(record[0].message)
 
-    assert "The following tensors are not trainable:" \
+    assert "The following tensors are non-trainable:" \
         in str(record[0].message)
     for tensor_name in tensor_names:
         assert tensor_name in str(record[0].message)
 
 
 def test_not_trainable_model_error_tf():
-    """Test Not trainable model error tensorflow."""
+    """Test non-trainable model error `tensorflow`."""
 
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
-    # GradSim method checks weights are trainable so we need to build the model before passing it to the
+    # GradientSimilarity method checks weights are trainable so we need to build the model before passing it to the
     # method
     model.build((None, 2))
     model.trainable = False
@@ -455,13 +455,13 @@ def test_not_trainable_model_error_tf():
             sim_fn='grad_dot',
             backend='tensorflow'
         )
-    assert err.value.args[0] == ('The model has no trainable weights. This method requires at least'
+    assert err.value.args[0] == ('The model has no trainable weights. This method requires at least '
                                  'one trainable parameter to compute the gradients for. '
-                                 'Set `trainable=True` on the model or a model weight')
+                                 'Set ``trainable=True`` on the model or a model weight.')
 
 
 def test_not_trainable_model_error_torch():
-    """Test Not trainable model error pytorch."""
+    """Test non-trainable model error `pytorch`."""
 
     model = nn.Linear(2, 1, bias=False)
     model.requires_grad_(False)
@@ -475,6 +475,6 @@ def test_not_trainable_model_error_torch():
             backend='pytorch'
         )
 
-    assert err.value.args[0] == ('The model has no trainable parameters. This method requires at least'
+    assert err.value.args[0] == ('The model has no trainable parameters. This method requires at least '
                                  'one trainable parameter to compute the gradients for. '
-                                 "Try setting `.requires_grad_(True)` on the model or one of it's parameters")
+                                 "Try setting ``.requires_grad_(True)`` on the model or one of its parameters.")

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
@@ -341,6 +341,10 @@ def test_non_trainable_layer_warnings_tf():
 
     Test that warnings are raised when user passes non-trainable layers to grad sim method for
     tensorflow models.
+
+    Note: Keras batch norm layers register non-trainable weights by default and so will raise the
+    warning we test for here. This is different to the pytorch behavour which doesn't include
+    the batch norm parameters in model.parameters().
     """
     model = keras.Sequential([
         keras.layers.Dense(10),

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
@@ -317,7 +317,7 @@ def test_multiple_test_instances_stored_grads_asym_dot(precompute_grads):
 def test_non_trainable_layer_warnings_tf():
     """Test Non trainable layer warnings tensorflow.
 
-    Test that warnings are raised when user passes non-trainbable layers to grad sim method for
+    Test that warnings are raised when user passes non-trainable layers to grad sim method for
     tensorflow models.
     """
     model = keras.Sequential([

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
@@ -350,7 +350,7 @@ def test_non_trainable_layer_warnings_tf():
 
     assert ("Some layers in the model are not trainable. These layers don't have "
             "gradients and will not be included in the computation of gradient similarity.") \
-            in str(record[0].message)
+        in str(record[0].message)
 
     assert "The following tensors are not trainable:" \
         in str(record[0].message)
@@ -402,7 +402,7 @@ def test_non_trainable_layer_warnings_pt():
 
     assert ("Some layers in the model are not trainable. These layers don't have "
             "gradients and will not be included in the computation of gradient similarity.") \
-            in str(record[0].message)
+        in str(record[0].message)
 
     assert "The following tensors are not trainable:" \
         in str(record[0].message)

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
@@ -342,7 +342,7 @@ def test_no_warnings_batch_norm(linear_cls_model):
                          indirect=True, ids=['torch-model', 'tf-model'])
 def test_non_trainable_layer_warnings(linear_cls_model):
     """
-    Test that no warnings are raised when using batch norm layers.
+    Test that warnings are raised when user passes non-trainbable layers to grad sim method.
     """
     backend, model, loss_fn, target_fn = linear_cls_model
 

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
@@ -477,4 +477,4 @@ def test_not_trainable_model_error_torch():
 
     assert err.value.args[0] == ('The model has no trainable parameters. This method requires at least'
                                  'one trainable parameter to compute the gradients for. '
-                                 'Set `.requires_grad_(True)` on the model')
+                                 "Try setting `.requires_grad_(True)` on the model or one of it's parameters")

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
@@ -141,7 +141,7 @@ def test_correct_grad_dot_sim_result_tf(seed, normed_ds):
     """
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
 
-    # GradSim method checks weights are trainable so we need to build the model before passing it to the 
+    # GradSim method checks weights are trainable so we need to build the model before passing it to the
     # method
     model.build((None, 2))
 
@@ -167,7 +167,7 @@ def test_correct_grad_cos_sim_result_tf(seed, ds):
     `tensorflow` backend.
     """
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
-    # GradSim method checks weights are trainable so we need to build the model before passing it to the 
+    # GradSim method checks weights are trainable so we need to build the model before passing it to the
     # method
     model.build((None, 2))
 
@@ -193,7 +193,7 @@ def test_grad_dot_result_order_tf(seed):
     """
     ds = np.array([[1, 0], [0.9, 0.1], [0.5 * 100, 0.5 * 100]]).astype('float32')
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
-    # GradSim method checks weights are trainable so we need to build the model before passing it to the 
+    # GradSim method checks weights are trainable so we need to build the model before passing it to the
     # method
     model.build((None, 2))
 
@@ -217,7 +217,7 @@ def test_grad_cos_result_order_tf(seed):
     """
     ds = np.array([[1, 0], [0.9, 0.1], [0.5 * 100, 0.5 * 100]]).astype('float32')
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
-    # GradSim method checks weights are trainable so we need to build the model before passing it to the 
+    # GradSim method checks weights are trainable so we need to build the model before passing it to the
     # method
     model.build((None, 2))
 
@@ -241,7 +241,7 @@ def test_multiple_test_instances_grad_cos(precompute_grads):
     """
     ds = np.array([[1, 0], [0.9, 0.1], [0.5 * 100, 0.5 * 100]]).astype('float32')
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
-    # GradSim method checks weights are trainable so we need to build the model before passing it to the 
+    # GradSim method checks weights are trainable so we need to build the model before passing it to the
     # method
     model.build((None, 2))
 
@@ -271,7 +271,7 @@ def test_multiple_test_instances_grad_dot(precompute_grads):
     """
     ds = np.array([[1, 0], [0.9, 0.1], [0.5 * 100, 0.5 * 100]]).astype('float32')
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
-    # GradSim method checks weights are trainable so we need to build the model before passing it to the 
+    # GradSim method checks weights are trainable so we need to build the model before passing it to the
     # method
     model.build((None, 2))
 
@@ -298,7 +298,7 @@ def test_multiple_test_instances_stored_grads_asym_dot(precompute_grads):
     """
     ds = np.array([[1, 0], [0.9, 0.1], [0.5 * 100, 0.5 * 100]]).astype('float32')
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
-    # GradSim method checks weights are trainable so we need to build the model before passing it to the 
+    # GradSim method checks weights are trainable so we need to build the model before passing it to the
     # method
     model.build((None, 2))
 
@@ -356,7 +356,7 @@ def test_non_trainable_layer_warnings_tf():
         ])
     ])
 
-    # GradSim method checks weights are trainable so we need to build the model before passing it to the 
+    # GradSim method checks weights are trainable so we need to build the model before passing it to the
     # method
     model.build((None, 10))
 
@@ -443,7 +443,7 @@ def test_not_trainable_model_error_tf():
     """Test Not trainable model error tensorflow."""
 
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
-    # GradSim method checks weights are trainable so we need to build the model before passing it to the 
+    # GradSim method checks weights are trainable so we need to build the model before passing it to the
     # method
     model.build((None, 2))
     model.trainable = False

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_integration.py
@@ -140,7 +140,11 @@ def test_correct_grad_dot_sim_result_tf(seed, normed_ds):
     `tensorflow` backend.
     """
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
+
+    # GradSim method checks weights are trainable so we need to build the model before passing it to the 
+    # method
     model.build((None, 2))
+
     explainer = GradientSimilarity(
         model,
         task='regression',
@@ -163,7 +167,10 @@ def test_correct_grad_cos_sim_result_tf(seed, ds):
     `tensorflow` backend.
     """
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
+    # GradSim method checks weights are trainable so we need to build the model before passing it to the 
+    # method
     model.build((None, 2))
+
     explainer = GradientSimilarity(
         model,
         task='regression',
@@ -186,7 +193,10 @@ def test_grad_dot_result_order_tf(seed):
     """
     ds = np.array([[1, 0], [0.9, 0.1], [0.5 * 100, 0.5 * 100]]).astype('float32')
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
+    # GradSim method checks weights are trainable so we need to build the model before passing it to the 
+    # method
     model.build((None, 2))
+
     explainer = GradientSimilarity(
         model,
         task='regression',
@@ -207,7 +217,10 @@ def test_grad_cos_result_order_tf(seed):
     """
     ds = np.array([[1, 0], [0.9, 0.1], [0.5 * 100, 0.5 * 100]]).astype('float32')
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
+    # GradSim method checks weights are trainable so we need to build the model before passing it to the 
+    # method
     model.build((None, 2))
+
     explainer = GradientSimilarity(
         model,
         task='regression',
@@ -228,7 +241,10 @@ def test_multiple_test_instances_grad_cos(precompute_grads):
     """
     ds = np.array([[1, 0], [0.9, 0.1], [0.5 * 100, 0.5 * 100]]).astype('float32')
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
+    # GradSim method checks weights are trainable so we need to build the model before passing it to the 
+    # method
     model.build((None, 2))
+
     explainer = GradientSimilarity(
         model,
         task='regression',
@@ -255,7 +271,10 @@ def test_multiple_test_instances_grad_dot(precompute_grads):
     """
     ds = np.array([[1, 0], [0.9, 0.1], [0.5 * 100, 0.5 * 100]]).astype('float32')
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
+    # GradSim method checks weights are trainable so we need to build the model before passing it to the 
+    # method
     model.build((None, 2))
+
     explainer = GradientSimilarity(
         model,
         task='regression',
@@ -279,7 +298,10 @@ def test_multiple_test_instances_stored_grads_asym_dot(precompute_grads):
     """
     ds = np.array([[1, 0], [0.9, 0.1], [0.5 * 100, 0.5 * 100]]).astype('float32')
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
+    # GradSim method checks weights are trainable so we need to build the model before passing it to the 
+    # method
     model.build((None, 2))
+
     explainer = GradientSimilarity(
         model,
         task='regression',
@@ -329,6 +351,9 @@ def test_non_trainable_layer_warnings_tf():
             keras.layers.Dense(40),
         ])
     ])
+
+    # GradSim method checks weights are trainable so we need to build the model before passing it to the 
+    # method
     model.build((None, 10))
 
     model.layers[1].trainable = False
@@ -414,6 +439,8 @@ def test_not_trainable_model_error_tf():
     """Test Not trainable model error tensorflow."""
 
     model = keras.Sequential([keras.layers.Dense(1, use_bias=False)])
+    # GradSim method checks weights are trainable so we need to build the model before passing it to the 
+    # method
     model.build((None, 2))
     model.trainable = False
     with pytest.raises(ValueError) as err:

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_unit.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_unit.py
@@ -74,7 +74,7 @@ def test_explainer_method_preprocessing(linear_cls_model, random_cls_dataset):
     assert X.shape == (1, 10)
 
     grad_X_test = explainer.backend.get_grads(model, X, Y, loss_fn)
-    assert grad_X_test.shape == (220, )
+    assert grad_X_test.shape == (110, )
 
 
 @pytest.mark.parametrize('linear_cls_model',

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_unit.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_unit.py
@@ -233,7 +233,7 @@ def test_device_error_msgs(linear_reg_model):
             device=[0]
         )
     if backend == 'pytorch':
-        assert ("`device` must be a None, string, integer or torch.device object."
+        assert ("`device` must be a `None`, `string`, `integer` or `torch.device` object."
                " Got <class 'list'> instead.") in str(err.value)
     elif backend == 'tensorflow':
-        assert "`device` must be a string or None. Got <class 'list'> instead." in str(err.value)
+        assert "`device` must be a `string` or `None`. Got <class 'list'> instead." in str(err.value)

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_unit.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_unit.py
@@ -233,7 +233,7 @@ def test_device_error_msgs(linear_reg_model):
             device=[0]
         )
     if backend == 'pytorch':
-        assert ("`device` must be a `None`, `string`, `integer` or `torch.device` object."
+        assert ("`device` must be a ``None``, ``string``, ``integer`` or `torch.device` object."
                " Got <class 'list'> instead.") in str(err.value)
     elif backend == 'tensorflow':
-        assert "`device` must be a `string` or `None`. Got <class 'list'> instead." in str(err.value)
+        assert "`device` must be a ``string`` or ``None``. Got <class 'list'> instead." in str(err.value)

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_unit.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_unit.py
@@ -233,7 +233,7 @@ def test_device_error_msgs(linear_reg_model):
             device=[0]
         )
     if backend == 'pytorch':
-        assert ("`device` must be a ``None``, ``string``, ``integer`` or `torch.device` object."
+        assert ("`device` must be a ``None``, `string`, `integer` or `torch.device` object."
                " Got <class 'list'> instead.") in str(err.value)
     elif backend == 'tensorflow':
-        assert "`device` must be a ``string`` or ``None``. Got <class 'list'> instead." in str(err.value)
+        assert "`device` must be a `string` or ``None``. Got <class 'list'> instead." in str(err.value)

--- a/alibi/explainers/tests/test_simiarlity/test_grad_methods_unit.py
+++ b/alibi/explainers/tests/test_simiarlity/test_grad_methods_unit.py
@@ -74,7 +74,7 @@ def test_explainer_method_preprocessing(linear_cls_model, random_cls_dataset):
     assert X.shape == (1, 10)
 
     grad_X_test = explainer.backend.get_grads(model, X, Y, loss_fn)
-    assert grad_X_test.shape == (110, )
+    assert grad_X_test.shape == (220, )
 
 
 @pytest.mark.parametrize('linear_cls_model',

--- a/doc/source/overview/faq.md
+++ b/doc/source/overview/faq.md
@@ -68,7 +68,7 @@ This is a known issue with the current implementation, see [here](https://github
 
 ## Similarity explanations
 
-### I'm using the [GradientSimilarity](../methods/Similarity.ipynb) method on a large model and it runs very slow. If I use `precompute_grads=True` I get out of memory errors?
+### I'm using the [GradientSimilarity](../methods/Similarity.ipynb) method on a large model and it runs very slow. If I use `precompute_grads=True` I get out of memory errors. How do I solve this?
 
 Large models with many parameters result in the similarity method running very slow and using `precompute_grads=True` may not be an option due to the memory cost. The best solutions for this problem are:
 

--- a/doc/source/overview/faq.md
+++ b/doc/source/overview/faq.md
@@ -64,3 +64,19 @@ Unfortunately, running this line means it's impossible to run explainers based o
 ### Why am I'm unable to restrict the features allowed to changed in [CounterfactualProto](../methods/CFProto.ipynb)?
 
 This is a known issue with the current implementation, see [here](https://github.com/SeldonIO/alibi/issues/327) and [here](https://github.com/SeldonIO/alibi/issues/366#issuecomment-820299804). It is currently blocked until we migrate the code to use TensorFlow 2.x constructs. In the meantime, it is recommended to use [CFRL](../methods/CFRL.ipynb) for counterfactual explanations with flexible feature-range constraints.
+
+
+## Similarity explanations
+
+### I'm using the [GradientSimilarity](../methods/Similarity.ipynb) method on a large model and it runs very slow. If I use `precompute_grads` I get out of memory errors?
+
+Large models with many parameters result in the similarity method running very slow and using `precompute_grads=True` may not be an option due to the memory cost. The best solutions for this problem are:
+
+- Use the explainer on a reduced dataset. You can use [Prototype Methods](../methods/ProtoSelect.ipynb) to obtain a smaller representative sample.
+- Freeze some parameters in the model so that when computing the gradients the simialrity method excludes them. If using [tensorflow](https://www.tensorflow.org/guide/keras/transfer_learning) you can do this by setting `trainable` to false on layers or specific parameters. For [torch](https://pytorch.org/docs/master/notes/autograd.html#locally-disabling-gradient-computation) we can set `requires_grad=False` on the relevent model parameters.
+
+Note that doing so will cause the explainer to issue a warning on initialization, informing you there are non-trainable parameters in your model and the explainer will not use those when computng the similarity scores.
+
+### I'm using the [GradientSimilarity](../methods/Similarity.ipynb) method on a tensorflow model and I keep getting warnings about non-trainable parameters but I haven't set any to be non-trainable?
+
+This warning likely means that your model has layers that track statistics using non-trainable parameters such as batch normalization layers. The warning should list the specific tensors that are non-trainable so you should be able to check. If this is the case you don't need to worry as similarity methods don't use those parameters anyway. Otherwise you will see this warning if you have set one of the parameters to `trainable=False` and alibi is just making sure you know this is the case.

--- a/doc/source/overview/faq.md
+++ b/doc/source/overview/faq.md
@@ -68,12 +68,12 @@ This is a known issue with the current implementation, see [here](https://github
 
 ## Similarity explanations
 
-### I'm using the [GradientSimilarity](../methods/Similarity.ipynb) method on a large model and it runs very slow. If I use `precompute_grads` I get out of memory errors?
+### I'm using the [GradientSimilarity](../methods/Similarity.ipynb) method on a large model and it runs very slow. If I use `precompute_grads=True` I get out of memory errors?
 
 Large models with many parameters result in the similarity method running very slow and using `precompute_grads=True` may not be an option due to the memory cost. The best solutions for this problem are:
 
 - Use the explainer on a reduced dataset. You can use [Prototype Methods](../methods/ProtoSelect.ipynb) to obtain a smaller representative sample.
-- Freeze some parameters in the model so that when computing the gradients the simialrity method excludes them. If using [tensorflow](https://www.tensorflow.org/guide/keras/transfer_learning) you can do this by setting `trainable` to false on layers or specific parameters. For [torch](https://pytorch.org/docs/master/notes/autograd.html#locally-disabling-gradient-computation) we can set `requires_grad=False` on the relevent model parameters.
+- Freeze some parameters in the model so that when computing the gradients the simialrity method excludes them. If using [tensorflow](https://www.tensorflow.org/guide/keras/transfer_learning) you can do this by setting `trainable=False` on layers or specific parameters. For [pytorch](https://pytorch.org/docs/master/notes/autograd.html#locally-disabling-gradient-computation) we can set `requires_grad=False` on the relevent model parameters.
 
 Note that doing so will cause the explainer to issue a warning on initialization, informing you there are non-trainable parameters in your model and the explainer will not use those when computng the similarity scores.
 


### PR DESCRIPTION
## What is this:

Bugfix for #828.

## Implementation:

Having spoken to @RobertSamoilescu we've agreed on the following plan of action:

- [x] If the tensor is in a sparse format we try to convert it to dense and then to `np.ndarray`. This will also need to be done for sparse representations in pytorch.
- [x] Finally we filter layers with `trainable=False` 
- [x]  If a user passes a model that has some layers set to `trainable=False` then we raise warning to make it clear that those layers won't be used in the computation. Note this should only happen in the model init call!
- [x] Check non-trainable warning behaviour for batch layers...
- [x] Raise informative error if specific layer doesn't convert to numpy
- [x] Instead of filtering for batch norm layers in trainable layers check, just list non-trainable layers in warning.

## More Todo:

- [x] Ensure correct formatting of module and variable names in docstrings: numpy -> `'numpy'`
- [x] Ensure public methods all have correct docstrings with return types etc...
- [x] Add note to FAQ explaining warnings

## Issues:

1. If we fail to convert a sparse tensor to dense or the gradient tensor has no numpy attribute the original plan was to raise a warning informing the user that some tensors grads are not used.
    - Having thought further about this I'm not sure about this? Seems like we'd end up catching a broad range of errors. In principle any model passed should have gradients computable for all layers so it's not clear that we should discard errors that might arise here!?
    - If an error due to something like the above arises we can suggest the user set trainable to false on the layer in question while we figure out a fix? I'm open to doing this differently though!
    - __UPDATE__: having spoken to @RobertSamoilescu, we've agreed it makes sense to raise error here if we can't the gradient to a numpy array. Other errors will not be attempted to be caught. The error will also suggest tot he user they mark the gradinet as non-trainable so they can still get results.

2. tensorflow has two representations of sparsity, 1. `IndexedSlice` which arises as gradients of embedding layers as we've seen and 2. `SparceTensor`. They have different methods of converting to dense representations for instance the below needs to be used:

    ```py
    if isinstance(grad, tf.SparseTensor):
      grad = tf.sparse.to_dense(grad)
    if isinstance(grad, tf.IndexedSlices):
      grad = tf.convert_to_tensor(grad)
    ```
    
    The issue I have is that I can't find any indication that tensorflow layers would ever have sparse gradients other than the `IndexedSlices`  that results from `tf.gather` in the embedding layer. So I'm not sure the above case is needed. You certainly can't take gradients w.r.t. `SparseTensors`. Doing so yeilds:
    
    ```
    ValueError: Type SparseTensor is not supported as a gradient source or gradient target.
    ```
    
    @jklaise and @RobertSamoilescu can either of you think of any situation in which this would arise? For now, I'm going to remove that logic. If an error due to something like the above arises we can suggest the user set trainable to false on the layer in question while we figure out a fix

3. Checking weather or not models contain non-trainable layers is a little non trivial. For instance the `batch_normalization` layer has non-trainable weights and so if a user includes this in there model naive solutions would trigger this warning. I've set it to filter the batch norm layer as according to [the tensorflow docs](https://www.tensorflow.org/guide/keras/transfer_learning#:~:text=The%20only%20built%2Din%20layer,writing%20new%20layers%20from%20scratch.) this is the only layer that is non-trainable. A user might create a custom layer which would throw warnings but I think that's ok as they should be alerted in this case...
  __UPDATE__:: having spoken to @RobertSamoilescu we've agreed to remove the checks for batch normalization as this kind of approach is inherently non-exhaustive and instead replace with a more informative warning that lists all layers not included in grad sim computation!
    
    
