### PR TITLE
Replace Boston with Diabetes dataset for testing

### DIFF
--- a/alibi/confidence/tests/test_model_linearity.py
+++ b/alibi/confidence/tests/test_model_linearity.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from sklearn.datasets import load_iris, load_boston
+from sklearn.datasets import load_iris, load_diabetes
 from sklearn.linear_model import LogisticRegression, LinearRegression
 from sklearn.svm import SVR
 from alibi.confidence.model_linearity import linearity_measure, LinearityMeasure
@@ -31,11 +31,10 @@ def test_linear_superposition(input_shape, nb_instances):
 @pytest.mark.parametrize('nb_instances', (1, 5))
 @pytest.mark.parametrize('nb_samples', (2, 10))
 def test_sample_knn(nb_instances, nb_samples):
-
     iris = load_iris()
     X_train = iris.data
     input_shape = X_train.shape[1:]
-    x = np.ones((nb_instances, ) + input_shape)
+    x = np.ones((nb_instances,) + input_shape)
 
     X_samples = _sample_knn(x=x, X_train=X_train, nb_samples=nb_samples)
 
@@ -43,12 +42,11 @@ def test_sample_knn(nb_instances, nb_samples):
     assert X_samples.shape[1] == nb_samples
 
 
-@pytest.mark.parametrize('nb_instances', (5, ))
-@pytest.mark.parametrize('nb_samples', (3, ))
+@pytest.mark.parametrize('nb_instances', (5,))
+@pytest.mark.parametrize('nb_samples', (3,))
 @pytest.mark.parametrize('input_shape', ((3,), (4, 4, 1)))
 def test_sample_grid(nb_instances, nb_samples, input_shape):
-
-    x = np.ones((nb_instances, ) + input_shape)
+    x = np.ones((nb_instances,) + input_shape)
     nb_features = x.reshape(x.shape[0], -1).shape[1]
     feature_range = np.array([[0, 1] for _ in range(nb_features)])
 
@@ -64,7 +62,6 @@ def test_sample_grid(nb_instances, nb_samples, input_shape):
 @pytest.mark.parametrize('nb_instances', (1, 10))
 @pytest.mark.parametrize('agg', ('global', 'pairwise'))
 def test_linearity_measure_class(method, epsilon, res, nb_instances, agg):
-
     iris = load_iris()
     X_train = iris.data
     y_train = iris.target
@@ -94,9 +91,8 @@ def test_linearity_measure_class(method, epsilon, res, nb_instances, agg):
 @pytest.mark.parametrize('nb_instances', (1, 10))
 @pytest.mark.parametrize('agg', ('global', 'pairwise'))
 def test_linearity_measure_reg(method, epsilon, res, nb_instances, agg):
-
-    boston = load_boston()
-    X_train, y_train = boston.data, boston.target
+    diabetes = load_diabetes()
+    X_train, y_train = diabetes.data, diabetes.target
     x = X_train[0: nb_instances].reshape(nb_instances, -1)
 
     lg = LinearRegression()
@@ -155,7 +151,6 @@ def test_linearity_measure_reg(method, epsilon, res, nb_instances, agg):
 @pytest.mark.parametrize('nb_instances', (1, 10))
 @pytest.mark.parametrize('agg', ('global', 'pairwise'))
 def test_LinearityMeasure_class(method, epsilon, res, nb_instances, agg):
-
     iris = load_iris()
     X_train = iris.data
     y_train = iris.target
@@ -180,9 +175,8 @@ def test_LinearityMeasure_class(method, epsilon, res, nb_instances, agg):
 @pytest.mark.parametrize('nb_instances', (1, 10))
 @pytest.mark.parametrize('agg', ('global', 'pairwise'))
 def test_LinearityMeasure_reg(method, epsilon, res, nb_instances, agg):
-
-    boston = load_boston()
-    X_train, y_train = boston.data, boston.target
+    diabetes = load_diabetes()
+    X_train, y_train = diabetes.data, diabetes.target
     x = X_train[0: nb_instances].reshape(nb_instances, -1)
 
     lg = LinearRegression()

--- a/alibi/explainers/tests/conftest.py
+++ b/alibi/explainers/tests/conftest.py
@@ -19,7 +19,7 @@ from alibi.utils.download import spacy_model
 import tensorflow as tf
 
 import alibi_testing
-from alibi_testing.data import get_adult_data, get_iris_data, get_boston_data, get_mnist_data, \
+from alibi_testing.data import get_adult_data, get_iris_data, get_diabetes_data, get_mnist_data, \
     get_movie_sentiment_data
 
 
@@ -47,8 +47,8 @@ def mnist_data():
 
 
 @pytest.fixture(scope='module')
-def boston_data():
-    return get_boston_data()
+def diabetes_data():
+    return get_diabetes_data()
 
 
 @pytest.fixture(scope='module')

--- a/alibi/explainers/tests/test_ale.py
+++ b/alibi/explainers/tests/test_ale.py
@@ -14,9 +14,9 @@ from alibi.explainers.ale import (_plot_one_ale_num, adaptive_grid, ale_num,
 
 
 @pytest.mark.parametrize('min_bin_points', [1, 4, 10])
-@pytest.mark.parametrize('dataset', [lazy_fixture('boston_data')])
+@pytest.mark.parametrize('dataset', [lazy_fixture('diabetes_data')])
 @pytest.mark.parametrize('lr_regressor',
-                         [lazy_fixture('boston_data')],
+                         [lazy_fixture('diabetes_data')],
                          indirect=True,
                          ids='reg=lr_{}'.format)
 def test_ale_num_linear_regression(min_bin_points, lr_regressor, dataset):

--- a/alibi/explainers/tests/test_cfrl.py
+++ b/alibi/explainers/tests/test_cfrl.py
@@ -15,7 +15,7 @@ from alibi.explainers.backends.cfrl_tabular import get_he_preprocessor, split_oh
 
 @pytest.mark.parametrize('dataset', [lazy_fixture('iris_data'),
                                      lazy_fixture('adult_data'),
-                                     lazy_fixture('boston_data')])
+                                     lazy_fixture('diabetes_data')])
 def test_he_preprocessor(dataset):
     """ Test the heterogeneous preprocessor and inverse preprocessor. """
     # Unpack dataset.
@@ -41,7 +41,7 @@ def test_he_preprocessor(dataset):
 
 @pytest.mark.parametrize('dataset', [lazy_fixture("iris_data"),
                                      lazy_fixture("adult_data"),
-                                     lazy_fixture("boston_data")])
+                                     lazy_fixture("diabetes_data")])
 def test_split_ohe(dataset):
     """ Test the one-hot encoding splitting of a dataset. """
 
@@ -71,7 +71,7 @@ def test_split_ohe(dataset):
 
 @pytest.mark.parametrize('dataset', [lazy_fixture("iris_data"),
                                      lazy_fixture("adult_data"),
-                                     lazy_fixture("boston_data")])
+                                     lazy_fixture("diabetes_data")])
 def test_get_numerical_condition(dataset):
     """ Test the training numerical conditional generator. """
 
@@ -116,7 +116,7 @@ def test_get_numerical_condition(dataset):
 
 @pytest.mark.parametrize('dataset', [lazy_fixture("iris_data"),
                                      lazy_fixture("adult_data"),
-                                     lazy_fixture("boston_data")])
+                                     lazy_fixture("diabetes_data")])
 def test_get_categorical_condition(dataset):
     """ Test the training categorical conditional generator. """
 
@@ -161,7 +161,7 @@ def test_get_categorical_condition(dataset):
 @pytest.mark.parametrize('seed', [0, 1, 2, 3])
 @pytest.mark.parametrize('dataset', [lazy_fixture("iris_data"),
                                      lazy_fixture("adult_data"),
-                                     lazy_fixture("boston_data")])
+                                     lazy_fixture("diabetes_data")])
 def test_sample(dataset, seed):
     """ Test sampling reconstruction. """
 

--- a/alibi/explainers/tests/test_partial_dependence.py
+++ b/alibi/explainers/tests/test_partial_dependence.py
@@ -186,17 +186,17 @@ def test_explanation_numerical_shapes(rf_classifier, iris_data, grid_resolution,
             assert exp.data['ice_values'][i].shape == (num_targets, num_instances, len(exp.data['feature_values'][i]))
 
 
-@pytest.mark.parametrize('rf_regressor', [lazy_fixture('boston_data')], indirect=True)
+@pytest.mark.parametrize('rf_regressor', [lazy_fixture('diabetes_data')], indirect=True)
 @pytest.mark.parametrize('kind', ['average', 'individual', 'both'])
 @pytest.mark.parametrize('features', [
     [0, 1, 2],
     [(0, 1), (0, 2), (1, 2)],
     [0, 1, (0, 1)]
 ])
-def test_blackbox_regression(rf_regressor, boston_data, kind, features):
+def test_blackbox_regression(rf_regressor, diabetes_data, kind, features):
     """ Test the black-box predictor for a regression function. """
     rf, _ = rf_regressor
-    X_train = boston_data['X_train']
+    X_train = diabetes_data['X_train']
 
     # define explainer and compute explanation
     explainer = PartialDependence(predictor=rf.predict)


### PR DESCRIPTION
Due to `scikit-learn=1.2` deprecating the Boston housing dataset we're replacing our test functions to use the Diabetes dataset instead.

As a follow-up to this, we also need to replace 2 examples (most likely using the California housing datset) plus any other mentions of the Boston dataset:
```
examples/ale_regression_boston.ipynb
examples/cfproto_housing.ipynb
```
