### PR TITLE
Fix score/metric function signature inspection

### DIFF
--- a/alibi/explainers/permutation_importance.py
+++ b/alibi/explainers/permutation_importance.py
@@ -461,8 +461,7 @@ class PermutationImportance(Explainer):
         -------
         Evaluation of the metric.
         """
-        args = inspect.getfullargspec(metric_fn)
-        str_args = args.args + args.kwonlyargs
+        str_args = inspect.signature(metric_fn).parameters.keys()
 
         if 'y_true' not in str_args:
             raise ValueError('The `scoring` function must have the argument `y_true` in its definition.')


### PR DESCRIPTION
Fixes #835.

I've decided to keep signature validation as it would be trickier to try to call an arbitrary callable with the correct arguments (e.g. positional only wouldn't work for things like `accuracy_score` from `sklearn` since it has an additional kwarg `normalize` before `sample_weights`. We could also just rely on passing in kwargs directly and let the calling fail if no such kwargs are present, but this might lead to more obscure errors).

`inspect.signature` seems more robust, in particular it follows wrapped decorators so the original function signature should always be preserved: https://docs.python.org/3/library/inspect.html#introspecting-callables-with-the-signature-object