### PR TITLE
Revert sphinx version to <6.0.0

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,7 @@
 # dependencies for building docs, separate from dev.txt as this is also used for builds on readthedocs.org
 # core dependencies
 sphinx>=4.2.0, <6.1.0
-sphinx-autodoc-typehints>=1.12.0, <1.20.1  # limited due to https://github.com/tox-dev/sphinx-autodoc-typehints/issues/259 and 260 
+sphinx-autodoc-typehints>=1.12.0, <1.19.3  # limited due to https://github.com/tox-dev/sphinx-autodoc-typehints/issues/259 and 260 
 sphinx-rtd-theme>=1.0.0, <2.0.0
 myst-parser>=0.14, <0.19
 sphinxcontrib-apidoc>=0.3.0, <0.4.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,7 @@
 # dependencies for building docs, separate from dev.txt as this is also used for builds on readthedocs.org
 # core dependencies
 sphinx>=4.2.0, <6.1.0
-sphinx-autodoc-typehints>=1.12.0, <1.20.1
+sphinx-autodoc-typehints>=1.12.0, <1.20.1  # limited due to https://github.com/tox-dev/sphinx-autodoc-typehints/issues/259 and 260 
 sphinx-rtd-theme>=1.0.0, <2.0.0
 myst-parser>=0.14, <0.19
 sphinxcontrib-apidoc>=0.3.0, <0.4.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,6 @@
 # dependencies for building docs, separate from dev.txt as this is also used for builds on readthedocs.org
 # core dependencies
-sphinx>=4.2.0, <6.1.0
+sphinx>=4.2.0, <5.1.0
 sphinx-autodoc-typehints>=1.12.0, <1.19.3  # limited due to https://github.com/tox-dev/sphinx-autodoc-typehints/issues/259 and 260 
 sphinx-rtd-theme>=1.0.0, <2.0.0
 myst-parser>=0.14, <0.19

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,6 @@
 # dependencies for building docs, separate from dev.txt as this is also used for builds on readthedocs.org
 # core dependencies
-sphinx>=4.2.0, <5.1.0
+sphinx>=4.2.0, <6.0.0
 sphinx-autodoc-typehints>=1.12.0, <1.19.3  # limited due to https://github.com/tox-dev/sphinx-autodoc-typehints/issues/259 and 260 
 sphinx-rtd-theme>=1.0.0, <2.0.0
 myst-parser>=0.14, <0.19


### PR DESCRIPTION
Revert `sphinx` to `<6.0.0` since the dependabot CI was not actually testing the new `6.x` versions. See https://github.com/SeldonIO/alibi-detect/pull/700#issuecomment-1373972532. `sphinx-autodoc-typehints` was also bumped so this has been reverted.

Before the bump to `6.x` versions we were on <`5.1.0`. `5.1.x` and `5.2.x` failed for us due to issues with `nbsphinx`. However, I've now upgraded to `<6.0.0` because `5.3.0` appears to work OK (see below).

**Note to self:** Do same for `alibi-detect` post-merge.