### PR TITLE
Change test timeout method to thread

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ addopts =
     --durations=50
     --durations-min=1.0
     --timeout=600
+    --timeout_method=thread
 #    -n auto
 #    --forked
 markers =


### PR DESCRIPTION
To help debug the `macos-latest` CI test suite timeouts.