### PR TITLE
Replace Python2 type comments with type annotations

### DIFF
--- a/alibi/api/defaults.py
+++ b/alibi/api/defaults.py
@@ -4,89 +4,105 @@ Note that the "name" field is automatically populated upon initialization of the
 Explainer class.
 """
 # Anchors
-DEFAULT_META_ANCHOR = {"name": None,
-                       "type": ["blackbox"],
-                       "explanations": ["local"],
-                       "params": {},
-                       "version": None}  # type: dict
+DEFAULT_META_ANCHOR: dict = {
+    "name": None,
+    "type": ["blackbox"],
+    "explanations": ["local"],
+    "params": {},
+    "version": None
+}
 """
 Default anchor metadata.
 """
 
-DEFAULT_DATA_ANCHOR = {"anchor": [],
-                       "precision": None,
-                       "coverage": None,
-                       "raw": None}  # type: dict
+DEFAULT_DATA_ANCHOR: dict = {
+    "anchor": [],
+    "precision": None,
+    "coverage": None,
+    "raw": None
+}
 """
 Default anchor data.
 """
 
-DEFAULT_DATA_ANCHOR_IMG = {"anchor": [],
-                           "segments": None,
-                           "precision": None,
-                           "coverage": None,
-                           "raw": None}  # type: dict
+DEFAULT_DATA_ANCHOR_IMG: dict = {
+    "anchor": [],
+    "segments": None,
+    "precision": None,
+    "coverage": None,
+    "raw": None
+}
 """
 Default anchor image data.
 """
 
 # CEM
-DEFAULT_META_CEM = {"name": None,
-                    "type": ["blackbox", "tensorflow", "keras"],
-                    "explanations": ["local"],
-                    "params": {},
-                    "version": None}  # type: dict
+DEFAULT_META_CEM: dict = {
+    "name": None,
+    "type": ["blackbox", "tensorflow", "keras"],
+    "explanations": ["local"],
+    "params": {},
+    "version": None
+}
 """
 Default CEM metadata.
 """
-DEFAULT_DATA_CEM = {"PN": None,
-                    "PP": None,
-                    "PN_pred": None,
-                    "PP_pred": None,
-                    "grads_graph": None,
-                    "grads_num": None,
-                    "X": None,
-                    "X_pred": None
-                    }  # type: dict
+DEFAULT_DATA_CEM: dict = {
+    "PN": None,
+    "PP": None,
+    "PN_pred": None,
+    "PP_pred": None,
+    "grads_graph": None,
+    "grads_num": None,
+    "X": None,
+    "X_pred": None
+}
 """
 Default CEM data.
 """
 
 # Counterfactuals
-DEFAULT_META_CF = {"name": None,
-                   "type": ["blackbox", "tensorflow", "keras"],
-                   "explanations": ["local"],
-                   "params": {},
-                   "version": None}  # type: dict
+DEFAULT_META_CF: dict = {
+    "name": None,
+    "type": ["blackbox", "tensorflow", "keras"],
+    "explanations": ["local"],
+    "params": {},
+    "version": None
+}
 """
 Default counterfactual metadata.
 """
 
-DEFAULT_DATA_CF = {"cf": None,
-                   "all": [],
-                   "orig_class": None,
-                   "orig_proba": None,
-                   "success": None}  # type: dict
+DEFAULT_DATA_CF: dict = {
+    "cf": None,
+    "all": [],
+    "orig_class": None,
+    "orig_proba": None,
+    "success": None
+}
 """
 Default counterfactual data.
 """
 
 # CFProto
-DEFAULT_META_CFP = {"name": None,
-                    "type": ["blackbox", "tensorflow", "keras"],
-                    "explanations": ["local"],
-                    "params": {},
-                    "version": None}  # type: dict
+DEFAULT_META_CFP: dict = {
+    "name": None,
+    "type": ["blackbox", "tensorflow", "keras"],
+    "explanations": ["local"],
+    "params": {},
+    "version": None
+}
 """
 Default counterfactual prototype metadata.
 """
 
-DEFAULT_DATA_CFP = {"cf": None,
-                    "all": [],
-                    "orig_class": None,
-                    "orig_proba": None,
-                    "id_proto": None
-                    }  # type: dict
+DEFAULT_DATA_CFP: dict = {
+    "cf": None,
+    "all": [],
+    "orig_class": None,
+    "orig_proba": None,
+    "id_proto": None
+}
 """
 Default counterfactual prototype metadata.
 """
@@ -108,19 +124,19 @@ KernelShap parameters updated and returned in ``metadata['params']``.
 See :py:class:`alibi.explainers.shap_wrappers.KernelShap`.
 """
 
-DEFAULT_META_KERNEL_SHAP = {
+DEFAULT_META_KERNEL_SHAP: dict = {
     "name": None,
     "type": ["blackbox"],
     "task": None,
     "explanations": ["local", "global"],
     "params": dict.fromkeys(KERNEL_SHAP_PARAMS),
     "version": None
-}  # type: dict
+}
 """
 Default KernelShap metadata.
 """
 
-DEFAULT_DATA_KERNEL_SHAP = {
+DEFAULT_DATA_KERNEL_SHAP: dict = {
     "shap_values": [],
     "expected_value": [],
     "categorical_names": {},
@@ -131,24 +147,24 @@ DEFAULT_DATA_KERNEL_SHAP = {
         "instances": None,
         "importances": {},
     }
-}  # type: dict
+}
 """
 Default KernelShap data.
 """
 
 # ALE
-DEFAULT_META_ALE = {
+DEFAULT_META_ALE: dict = {
     "name": None,
     "type": ["blackbox"],
     "explanations": ["global"],
     "params": {},
     "version": None
-}  # type: dict
+}
 """
 Default ALE metadata.
 """
 
-DEFAULT_DATA_ALE = {
+DEFAULT_DATA_ALE: dict = {
     "ale_values": [],
     "constant_value": None,
     "ale0": [],
@@ -156,7 +172,7 @@ DEFAULT_DATA_ALE = {
     "feature_names": None,
     "target_names": None,
     "feature_deciles": None
-}  # type: dict
+}
 """
 Default ALE data.
 """
@@ -177,19 +193,19 @@ TreeShap parameters updated and returned in ``metadata['params']``.
 See :py:class:`alibi.explainers.shap_wrappers.TreeShap`.
 """
 
-DEFAULT_META_TREE_SHAP = {
+DEFAULT_META_TREE_SHAP: dict = {
     "name": None,
     "type": ["whitebox"],
     "task": None,  # updates with 'classification' or 'regression'
     "explanations": ["local", "global"],
     "params": dict.fromkeys(TREE_SHAP_PARAMS),
     "version": None
-}  # type: dict
+}
 """
 Default TreeShap metadata.
 """
 
-DEFAULT_DATA_TREE_SHAP = {
+DEFAULT_DATA_TREE_SHAP: dict = {
     "shap_values": [],
     "shap_interaction_values": [],
     "expected_value": [],
@@ -203,123 +219,135 @@ DEFAULT_DATA_TREE_SHAP = {
         "labels": None,
         "importances": {},
     }
-}  # type: dict
+}
 
 """
 Default TreeShap data.
 """
 
 # Integrated gradients
-DEFAULT_META_INTGRAD = {
+DEFAULT_META_INTGRAD: dict = {
     "name": None,
     "type": ["whitebox"],
     "explanations": ["local"],
     "params": {},
     "version": None
-}  # type: dict
+}
 """
 Default IntegratedGradients metadata.
 """
 
-DEFAULT_DATA_INTGRAD = {
+DEFAULT_DATA_INTGRAD: dict = {
     "attributions": None,
     "X": None,
     "forward_kwargs": None,
     "baselines": None,
     "predictions": None,
     "deltas": None
-}  # type: dict
+}
 """
 Default IntegratedGradients data.
 """
 
-DEFAULT_META_CFRL = {"name": None,
-                     "type": ["blackbox"],
-                     "explanations": ["local"],
-                     "params": {},
-                     "version": None}  # type: dict
+DEFAULT_META_CFRL: dict = {
+    "name": None,
+    "type": ["blackbox"],
+    "explanations": ["local"],
+    "params": {},
+    "version": None
+}
 """
 Default CounterfactualRL metadata.
 """
 
-DEFAULT_DATA_CFRL = {"orig": None,
-                     "cf": None,
-                     "target": None,
-                     "condition": None}  # type: dict
+DEFAULT_DATA_CFRL: dict = {
+    "orig": None,
+    "cf": None,
+    "target": None,
+    "condition": None
+}
 """
 Default CounterfactualRL data.
 """
 
 # Similarity methods
-DEFAULT_META_SIM = {"name": None,
-                    "type": ["whitebox"],
-                    "explanations": ["local"],
-                    "params": {},
-                    "version": None}  # type: dict
+DEFAULT_META_SIM: dict = {
+    "name": None,
+    "type": ["whitebox"],
+    "explanations": ["local"],
+    "params": {},
+    "version": None
+}
 """
 Default SimilarityExplainer metadata.
 """
 
-DEFAULT_DATA_SIM = {"scores": None,
-                    "ordered_indices": None,
-                    "most_similar": None,
-                    "least_similar": None}  # type: dict
+DEFAULT_DATA_SIM: dict = {
+    "scores": None,
+    "ordered_indices": None,
+    "most_similar": None,
+    "least_similar": None
+}
 """
 Default SimilarityExplainer data.
 """
 
-DEFAULT_META_PROTOSELECT = {"name": None,
-                            "type": ["data"],
-                            "explanation": ["global"],
-                            "params": {},
-                            "version": None}  # type: dict
+DEFAULT_META_PROTOSELECT: dict = {
+    "name": None,
+    "type": ["data"],
+    "explanation": ["global"],
+    "params": {},
+    "version": None
+}
 """
 Default ProtoSelect metadata.
 """
 
-DEFAULT_DATA_PROTOSELECT = {"prototypes": None,
-                            "prototype_indices": None,
-                            "prototype_labels": None}  # type: dict
+DEFAULT_DATA_PROTOSELECT: dict = {
+    "prototypes": None,
+    "prototype_indices": None,
+    "prototype_labels": None
+}
 """
 Default ProtoSelect data.
 """
 
 # PartialDependence
-DEFAULT_META_PD = {
+DEFAULT_META_PD: dict = {
     "name": None,
     "type": ["blackbox"],
     "explanations": ["global"],
     "params": {},
     "version": None
-}  # type: dict
+}
 """
 Default PartialDependence metadata.
 """
 
-DEFAULT_DATA_PD = {
+DEFAULT_DATA_PD: dict = {
     "feature_deciles": None,
     "pd_values": None,
     "ice_values": None,
     "feature_values": None,
     "feature_names": None,
-}  # type: dict
+}
 """
 Default PartialDependence data.
 """
 
 # PartialDependenceVariance
-DEFAULT_META_PDVARIANCE = {
+DEFAULT_META_PDVARIANCE: dict = {
     "name": None,
     "type": ["blackbox"],
     "explanations": ["global"],
     "params": {},
     "version": None
-}  # type: dict
+}
 """
 Default PartialDependenceVariance metadata.
 """
 
-DEFAULT_DATA_PDVARIANCE = {
+DEFAULT_DATA_PDVARIANCE: dict = {
     "feature_deciles": None,
     "pd_values": None,
     "feature_values": None,
@@ -328,28 +356,28 @@ DEFAULT_DATA_PDVARIANCE = {
     "feature_interaction": None,
     "conditional_importance": None,
     "conditional_importance_values": None
-}  # type: dict
+}
 """
 Default PartialDependenceVariance data.
 """
 
 # PermutationImportance
-DEFAULT_META_PERMUTATION_IMPORTANCE = {
+DEFAULT_META_PERMUTATION_IMPORTANCE: dict = {
     "name": None,
     "type": ["blackbox"],
     "explanations": ["global"],
     "params": {},
     "version": None
-}  # type: dict
+}
 """
 Default PermutationImportance metadata.
 """
 
-DEFAULT_DATA_PERMUTATION_IMPORTANCE = {
+DEFAULT_DATA_PERMUTATION_IMPORTANCE: dict = {
     "feature_names": None,
     "metric_names": None,
     "feature_importance": None,
-}  # type: dict
+}
 """
 Default PermutationImportance data.
 """

--- a/alibi/api/interfaces.py
+++ b/alibi/api/interfaces.py
@@ -178,8 +178,8 @@ class Explanation:
     """
     Explanation class returned by explainers.
     """
-    meta = attr.ib(repr=alibi_pformat)  # type: dict
-    data = attr.ib(repr=alibi_pformat)  # type: dict
+    meta: dict = attr.ib(repr=alibi_pformat)
+    data: dict = attr.ib(repr=alibi_pformat)
 
     def __attrs_post_init__(self):
         """

--- a/alibi/api/tests/test_interfaces.py
+++ b/alibi/api/tests/test_interfaces.py
@@ -3,11 +3,11 @@ import numpy as np
 import pytest
 from alibi.api.interfaces import Explainer, Explanation, FitMixin
 
-valid_meta = {"type": "blackbox", "explanations": ['local'], "params": {}}  # type: dict
-valid_data = {"anchor": [], "precision": [], "coverage": []}  # type: dict
+valid_meta: dict = {"type": "blackbox", "explanations": ['local'], "params": {}}
+valid_data: dict = {"anchor": [], "precision": [], "coverage": []}
 
-invalid_meta = []  # type: list
-invalid_data = {}  # type: dict
+invalid_meta: list = []
+invalid_data: dict = {}
 
 # testing dictionaries
 data_dicts = [

--- a/alibi/confidence/trustscore.py
+++ b/alibi/confidence/trustscore.py
@@ -112,8 +112,8 @@ class TrustScore:
             Number of prediction classes, needs to be provided if `Y` equals the predicted class.
         """
         self.classes = classes if classes is not None else Y.shape[1]
-        self.kdtrees = [None] * self.classes  # type: Any
-        self.X_kdtree = [None] * self.classes  # type: Any
+        self.kdtrees: Any = [None] * self.classes
+        self.X_kdtree: Any = [None] * self.classes
 
         # KDTree and kNeighborsClassifier need 2D data
         if len(X.shape) > 2:
@@ -179,7 +179,7 @@ class TrustScore:
             X = X.reshape(X.shape[0], -1)
 
         # init distance matrix: [nb instances, nb classes]
-        d = np.tile(np.nan, (X.shape[0], self.classes))  # type: np.ndarray
+        d: np.ndarray = np.tile(np.nan, (X.shape[0], self.classes))
 
         for c in range(self.classes):
             d_tmp = self.kdtrees[c].query(X, k=k)[0]  # get k nearest neighbors for each class

--- a/alibi/explainers/anchors/anchor_base.py
+++ b/alibi/explainers/anchors/anchor_base.py
@@ -22,7 +22,7 @@ class AnchorBaseBeam:
         """
 
         self.sample_fcn = samplers[0]
-        self.samplers = None  # type: Optional[List[Callable]]
+        self.samplers: Optional[List[Callable]] = None
         # Initial size (in batches) of data/raw data samples cache.
         self.sample_cache_size = kwargs.get('sample_cache_size', 10000)
         # when only the max of self.margin or batch size remain emptpy, the cache is
@@ -44,7 +44,7 @@ class AnchorBaseBeam:
 
         prealloc_size = batch_size * self.sample_cache_size
         # t_ indicates that the attribute is a dictionary with entries for each anchor
-        self.state = {
+        self.state: dict = {
             't_coverage': defaultdict(lambda: 0.),  # anchors' coverage
             't_coverage_idx': defaultdict(set),  # index of anchors in coverage set
             't_covered_true': defaultdict(None),  # samples with same pred as instance where t_ applies
@@ -60,7 +60,7 @@ class AnchorBaseBeam:
             'current_idx': 0,
             'n_features': coverage_data.shape[1],  # data set dim after encoding
             'coverage_data': coverage_data,  # coverage data
-        }  # type: dict
+        }
         self.state['t_order'][()] = ()  # Trivial order for the empty result
 
     @staticmethod
@@ -351,7 +351,9 @@ class AnchorBaseBeam:
             if anchor not in self.state['t_order']:
                 self.state['t_order'][anchor] = list(anchor)
 
-        sample_stats, pos, total = [], (), ()  # type: List, Tuple, Tuple
+        sample_stats: List = []
+        pos: Tuple = tuple()
+        total: Tuple = tuple()
         samples_iter = [self.sample_fcn((i, tuple(self.state['t_order'][anchor])), num_samples=batch_size)
                         for i, anchor in enumerate(anchors)]
         for samples, anchor in zip(samples_iter, anchors):
@@ -395,7 +397,7 @@ class AnchorBaseBeam:
             return tuples
 
         # create new anchors: add a feature to every result in current best
-        new_tuples = set()  # type: Set[tuple]
+        new_tuples: Set[tuple] = set()
         for f in all_features:
             for t in previous_best:
                 new_t = self._sort(t + (f,), allow_duplicates=False)
@@ -496,7 +498,7 @@ class AnchorBaseBeam:
             return lambda: np.zeros(size)
 
         state = self.state
-        stats = defaultdict(array_factory((len(anchors),)))  # type: Dict[str, np.ndarray]
+        stats: Dict[str, np.ndarray] = defaultdict(array_factory((len(anchors),)))
         for i, anchor in enumerate(anchors):
             stats['n_samples'][i] = state['t_nsamples'][anchor]
             stats['positives'][i] = state['t_positives'][anchor]
@@ -528,9 +530,9 @@ class AnchorBaseBeam:
         """
 
         state = self.state
-        anchor = {'feature': [], 'mean': [], 'precision': [], 'coverage': [], 'examples': [],
-                  'all_precision': 0, 'num_preds': state['data'].shape[0], 'success': success}  # type: dict
-        current_t = tuple()  # type: tuple
+        anchor: dict = {'feature': [], 'mean': [], 'precision': [], 'coverage': [], 'examples': [],
+                        'all_precision': 0, 'num_preds': state['data'].shape[0], 'success': success}
+        current_t: tuple = tuple()
         # draw pos and negative example where partial result applies if not sampled during search
         to_resample, to_resample_idx = [], []
         for f in state['t_order'][features]:
@@ -692,7 +694,7 @@ class AnchorBaseBeam:
             }
 
         current_size, best_coverage = 1, -1
-        best_of_size = {0: []}  # type: Dict[int, list]
+        best_of_size: Dict[int, list] = {0: []}
         best_anchor = ()
 
         if max_anchor_size is None:

--- a/alibi/explainers/anchors/anchor_image.py
+++ b/alibi/explainers/anchors/anchor_image.py
@@ -17,11 +17,11 @@ from .anchor_explanation import AnchorExplanation
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_SEGMENTATION_KWARGS = {
+DEFAULT_SEGMENTATION_KWARGS: Dict[str, Dict] = {
     'felzenszwalb': {},
     'quickshift': {},
     'slic': {'n_segments': 10, 'compactness': 10, 'sigma': .5, 'start_label': 0}
-}  # type: Dict[str, Dict]
+}
 
 
 def scale_image(image: np.ndarray, scale: tuple = (0, 255)) -> np.ndarray:
@@ -388,7 +388,7 @@ class AnchorImage(Explainer):
 
         self.images_background = images_background
         # a superpixel is perturbed with prob 1 - p_sample
-        self.p_sample = 0.5  # type: float
+        self.p_sample: float = 0.5
 
         # update metadata
         self.meta['params'].update(
@@ -561,7 +561,7 @@ class AnchorImage(Explainer):
             sample_cache_size=binary_cache_size,
             cache_margin=cache_margin,
             **kwargs)
-        result = mab.anchor_beam(
+        result: Any = mab.anchor_beam(
             desired_confidence=threshold,
             delta=delta,
             epsilon=tau,
@@ -574,7 +574,7 @@ class AnchorImage(Explainer):
             verbose=verbose,
             verbose_every=verbose_every,
             **kwargs,
-        )  # type: Any
+        )
 
         return self._build_explanation(
             image, result, sampler.instance_label, params, sampler

--- a/alibi/explainers/anchors/anchor_tabular.py
+++ b/alibi/explainers/anchors/anchor_tabular.py
@@ -62,10 +62,10 @@ class TabularSampler:
         self.categorical_features = categorical_features
         self.feature_values = feature_values
 
-        self.val2idx = {}  # type: Dict[int, DefaultDict[int, Any]]
-        self.cat_lookup = {}  # type: Dict[int, int]
-        self.ord_lookup = {}  # type: Dict[int, set]
-        self.enc2feat_idx = {}  # type: Dict[int, int]
+        self.val2idx: Dict[int, DefaultDict[int, Any]] = {}
+        self.cat_lookup: Dict[int, int] = {}
+        self.ord_lookup: Dict[int, set] = {}
+        self.enc2feat_idx: Dict[int, int] = {}
 
     def deferred_init(self, train_data: Union[np.ndarray, Any], d_train_data: Union[np.ndarray, Any]) -> Any:
         """
@@ -132,7 +132,7 @@ class TabularSampler:
             Instance to be explained.
         """
 
-        label = self.predictor(X.reshape(1, -1))[0]  # type: int
+        label: int = self.predictor(X.reshape(1, -1))[0]
         self.instance_label = label
 
     def set_n_covered(self, n_covered: int) -> None:
@@ -162,7 +162,7 @@ class TabularSampler:
         """
 
         all_features = self.numerical_features + self.categorical_features
-        val2idx = {f_id: defaultdict(None) for f_id in all_features}  # type: Dict[int, DefaultDict[int, np.ndarray]]
+        val2idx: Dict[int, DefaultDict[int, np.ndarray]] = {f_id: defaultdict(None) for f_id in all_features}
         for feat in val2idx:
             for value in range(len(self.feature_values[feat])):
                 val2idx[feat][value] = (self.d_train_data[:, feat] == value).nonzero()[0]
@@ -474,11 +474,11 @@ class TabularSampler:
         """
 
         # bins one can sample from for each numerical feature (key: feat id)
-        allowed_bins = {}  # type: Dict[int, Set[int]]
+        allowed_bins: Dict[int, Set[int]] = {}
         # index of database rows (values) for each feature in result (key: feat id)
-        allowed_rows = {}  # type: Dict[int, Any[int]]
+        allowed_rows: Dict[int, Any[int]] = {}
         # feats for which there are not training records in the desired bin/with that value
-        unk_feat_values = []  # type: List[Tuple[int, str, Optional[int]]]
+        unk_feat_values: List[Tuple[int, str, Optional[int]]] = []
         cat_enc_ids = [enc_id for enc_id in anchor if enc_id in self.cat_lookup.keys()]
         ord_enc_ids = [enc_id for enc_id in anchor if enc_id in self.ord_lookup.keys()]
         if cat_enc_ids:
@@ -652,7 +652,7 @@ class AnchorTabular(Explainer, FitMixin):
 
         self.numerical_features = [x for x in range(len(feature_names)) if x not in self.categorical_features]
 
-        self.samplers = []  # type: list
+        self.samplers: list = []
         self.ohe = ohe
         self.seed = seed
 
@@ -839,7 +839,7 @@ class AnchorTabular(Explainer, FitMixin):
             sample_cache_size=binary_cache_size,
             cache_margin=cache_margin,
             **kwargs)
-        result = mab.anchor_beam(
+        result: Any = mab.anchor_beam(
             delta=delta, epsilon=tau,
             desired_confidence=threshold,
             beam_size=beam_size,
@@ -849,7 +849,7 @@ class AnchorTabular(Explainer, FitMixin):
             coverage_samples=coverage_samples,
             verbose=verbose,
             verbose_every=verbose_every,
-        )  # type: Any
+        )
         self.mab = mab
 
         return self._build_explanation(X, result, self.instance_label, params)
@@ -926,7 +926,7 @@ class AnchorTabular(Explainer, FitMixin):
                     ordinal_ranges[feat_id][0], min(list(self.ord_lookup[idx])) - 1
                 )
 
-        handled = set()  # type: Set[int]
+        handled: Set[int] = set()
         for idx in anchor_idxs:
             feat_id = self.enc2feat_idx[idx]
             if idx in self.cat_lookup:

--- a/alibi/explainers/anchors/anchor_tabular_distributed.py
+++ b/alibi/explainers/anchors/anchor_tabular_distributed.py
@@ -314,7 +314,7 @@ class DistributedAnchorTabular(AnchorTabular):
             cache_margin=cache_margin,
             **kwargs,
         )
-        result = mab.anchor_beam(
+        result: Any = mab.anchor_beam(
             delta=delta, epsilon=tau,
             desired_confidence=threshold,
             beam_size=beam_size,
@@ -324,7 +324,7 @@ class DistributedAnchorTabular(AnchorTabular):
             coverage_samples=coverage_samples,
             verbose=verbose,
             verbose_every=verbose_every,
-        )  # type: Any
+        )
         self.mab = mab
 
         return self._build_explanation(X, result, self.instance_label, params)

--- a/alibi/explainers/anchors/anchor_text.py
+++ b/alibi/explainers/anchors/anchor_text.py
@@ -442,7 +442,7 @@ class AnchorText(Explainer):
             **kwargs
         )
 
-        result = mab.anchor_beam(
+        result: Any = mab.anchor_beam(
             delta=delta,
             epsilon=tau,
             batch_size=batch_size,
@@ -455,7 +455,7 @@ class AnchorText(Explainer):
             verbose=verbose,
             verbose_every=verbose_every,
             **kwargs,
-        )  # type: Any
+        )
 
         if self.sampling_strategy == self.SAMPLING_LANGUAGE_MODEL:
             # take the whole word (this points just to the first part of the word)

--- a/alibi/explainers/anchors/language_model_text_sampler.py
+++ b/alibi/explainers/anchors/language_model_text_sampler.py
@@ -60,8 +60,10 @@ class LanguageModelSampler(AnchorTextSampler):
                 self.subwords_mask[vocab[token]] = True
 
         # define head, tail part of the text
-        self.head, self.tail = '', ''  # type: str, str
-        self.head_tokens, self.tail_tokens = [], []  # type: List[str], List[str]
+        self.head: str = ''
+        self.tail: str = ''
+        self.head_tokens: List[str] = []
+        self.tail_tokens: List[str] = []
 
     def get_sample_ids(self,
                        punctuation: str = string.punctuation,

--- a/alibi/explainers/anchors/text_samplers.py
+++ b/alibi/explainers/anchors/text_samplers.py
@@ -58,7 +58,8 @@ class Neighbors:
         # the word itself is excluded so we add one to return the expected number of words
         top_n += 1
 
-        texts, similarities = [], []  # type: List, List
+        texts: List = []
+        similarities: List = []
         if word in self.nlp.vocab:
             word_vocab = self.nlp.vocab[word]
             queries = [w for w in self.to_check if w.is_lower == word_vocab.is_lower]
@@ -165,10 +166,12 @@ class UnknownSampler(AnchorTextSampler):
 
         # set nlp and perturbation options
         self.nlp = load_spacy_lexeme_prob(nlp)
-        self.perturb_opts = perturb_opts  # type: Union[Dict, None]
+        self.perturb_opts: Union[Dict, None] = perturb_opts
 
         # define buffer for word, punctuation and position
-        self.words, self.punctuation, self.positions = [], [], []  # type: List, List, List
+        self.words: List = []
+        self.punctuation: List = []
+        self.positions: List = []
 
     def set_text(self, text: str) -> None:
         """
@@ -269,7 +272,7 @@ class SimilaritySampler(AnchorTextSampler):
         self._synonyms_generator = Neighbors(self.nlp)
 
         # dict containing an np.array of similar words with same part of speech and an np.array of similarities
-        self.synonyms = {}  # type: Dict[str, Dict[str, np.ndarray]]
+        self.synonyms: Dict[str, Dict[str, np.ndarray]] = {}
         self.tokens: 'spacy.tokens.Doc'
         self.words: List[str] = []
         self.positions: List[int] = []

--- a/alibi/explainers/cem.py
+++ b/alibi/explainers/cem.py
@@ -282,7 +282,7 @@ class CEM(Explainer, FitMixin):
             new_vars = [x for x in end_vars if x.name not in start_vars]
 
         # variables to initialize
-        self.setup = []  # type: list
+        self.setup: list = []
         self.setup.append(self.orig.assign(self.assign_orig))
         self.setup.append(self.target.assign(self.assign_target))
         self.setup.append(self.const.assign(self.assign_const))
@@ -528,7 +528,8 @@ class CEM(Explainer, FitMixin):
                                        self.assign_adv_s: X,
                                        self.assign_no_info: self.no_info_val})
 
-            X_der_batch, X_der_batch_s = [], []  # type: Any, Any
+            X_der_batch: Any = []
+            X_der_batch_s: Any = []
 
             for i in range(self.max_iterations):
 

--- a/alibi/explainers/cfproto.py
+++ b/alibi/explainers/cfproto.py
@@ -641,7 +641,7 @@ class CounterfactualProto(Explainer, FitMixin):
             new_vars = [x for x in end_vars if x.name not in start_vars]
 
         # variables to initialize
-        self.setup = []  # type: list
+        self.setup: list = []
         self.setup.append(self.orig.assign(self.assign_orig))
         self.setup.append(self.target.assign(self.assign_target))
         self.setup.append(self.const.assign(self.assign_const))
@@ -713,7 +713,7 @@ class CounterfactualProto(Explainer, FitMixin):
         else:
             preds = np.argmax(self.predict(train_data), axis=1)
 
-        self.cat_vars_ord = dict()  # type: dict
+        self.cat_vars_ord: dict = dict()
         if self.is_cat:  # compute distance metrics for categorical variables
 
             if self.ohe:  # convert OHE to ordinal encoding
@@ -768,7 +768,7 @@ class CounterfactualProto(Explainer, FitMixin):
                                                  update_feature_range=False)
 
                 # combine abdm and mvdm
-                self.d_abs = {}  # type: Dict
+                self.d_abs: Any = {}
                 new_feature_range = tuple([f.copy() for f in self.feature_range])
                 for k, v in d_abs_abdm.items():
                     self.d_abs[k] = v * w + d_abs_mvdm[k] * (1 - w)
@@ -787,7 +787,7 @@ class CounterfactualProto(Explainer, FitMixin):
                                                                   update_feature_range=update_feature_range)
 
             # create array used for ragged tensor placeholder
-            self.d_abs_ragged = []  # type: Any
+            self.d_abs_ragged: Any = []
             for _, v in self.d_abs.items():
                 n_pad = self.max_cat - len(v)
                 v_pad = np.pad(v, (0, n_pad), 'constant')
@@ -796,8 +796,8 @@ class CounterfactualProto(Explainer, FitMixin):
 
         if self.enc_model:
             enc_data = self.enc.predict(train_data)  # type: ignore[union-attr]
-            self.class_proto = {}  # type: dict
-            self.class_enc = {}  # type: dict
+            self.class_proto: dict = {}
+            self.class_enc: dict = {}
             for i in range(self.classes):
                 idx = np.where(preds == i)[0]
                 self.class_proto[i] = np.expand_dims(np.mean(enc_data[idx], axis=0), axis=0)
@@ -1083,7 +1083,7 @@ class CounterfactualProto(Explainer, FitMixin):
         overall_best_grad = (np.zeros(self.shape), np.zeros(self.shape))
 
         # keep track of counterfactual evolution
-        self.cf_global = {i: [] for i in range(self.c_steps)}  # type: dict
+        self.cf_global: dict = {i: [] for i in range(self.c_steps)}
 
         # iterate over nb of updates for 'c'
         for _ in range(self.c_steps):
@@ -1106,7 +1106,8 @@ class CounterfactualProto(Explainer, FitMixin):
                 feed_dict[self.assign_map] = self.d_abs_ragged
             self.sess.run(self.setup, feed_dict=feed_dict)
 
-            X_der_batch, X_der_batch_s = [], []  # type: Any, Any
+            X_der_batch: Any = []
+            X_der_batch_s: Any = []
 
             for i in range(self.max_iterations):
 

--- a/alibi/explainers/cfproto.py
+++ b/alibi/explainers/cfproto.py
@@ -768,7 +768,7 @@ class CounterfactualProto(Explainer, FitMixin):
                                                  update_feature_range=False)
 
                 # combine abdm and mvdm
-                self.d_abs: Any = {}
+                self.d_abs: Dict = {}
                 new_feature_range = tuple([f.copy() for f in self.feature_range])
                 for k, v in d_abs_abdm.items():
                     self.d_abs[k] = v * w + d_abs_mvdm[k] * (1 - w)

--- a/alibi/explainers/counterfactual.py
+++ b/alibi/explainers/counterfactual.py
@@ -271,7 +271,7 @@ class Counterfactual(Explainer):
             self.apply_grads = opt.apply_gradients(grad_and_var, global_step=self.global_step)
 
         # variables to initialize
-        self.setup = []  # type: list
+        self.setup: list = []
         self.setup.append(self.orig.assign(self.assign_orig))
         self.setup.append(self.cf.assign(self.assign_cf))
         self.setup.append(self.target.assign(self.assign_target))

--- a/alibi/explainers/integrated_gradients.py
+++ b/alibi/explainers/integrated_gradients.py
@@ -1153,8 +1153,9 @@ class IntegratedGradients(Explainer):
             paths.append(path)
 
         if forward_kwargs:
-            paths_kwargs = {k: np.concatenate([forward_kwargs[k] for _ in range(self.n_steps)], axis=0)
-                            for k in forward_kwargs.keys()}  # type: Optional[dict]
+            paths_kwargs: Optional[dict] = {k: np.concatenate([forward_kwargs[k]
+                                            for _ in range(self.n_steps)], axis=0)
+                                            for k in forward_kwargs.keys()}
         else:
             paths_kwargs = None
 
@@ -1269,8 +1270,9 @@ class IntegratedGradients(Explainer):
         paths = np.concatenate([baselines + alphas[i] * (X - baselines) for i in range(self.n_steps)], axis=0)
 
         if forward_kwargs:
-            paths_kwargs = {k: np.concatenate([forward_kwargs[k] for _ in range(self.n_steps)], axis=0)
-                            for k in forward_kwargs.keys()}  # type: Optional[dict]
+            paths_kwargs: Optional[dict] = {k: np.concatenate([forward_kwargs[k]
+                                            for _ in range(self.n_steps)], axis=0)
+                                            for k in forward_kwargs.keys()}
         else:
             paths_kwargs = None
 

--- a/alibi/explainers/partial_dependence.py
+++ b/alibi/explainers/partial_dependence.py
@@ -484,8 +484,8 @@ class PartialDependenceBase(Explainer, ABC):
         `Explanation` object.
         """
         feature_deciles, feature_values = [], []
-        pd_values = [] if kind in [Kind.AVERAGE, Kind.BOTH] else None  # type: Optional[List[np.ndarray]]
-        ice_values = [] if kind in [Kind.INDIVIDUAL, Kind.BOTH] else None  # type: Optional[List[np.ndarray]]
+        pd_values: Optional[List[np.ndarray]] = [] if kind in [Kind.AVERAGE, Kind.BOTH] else None
+        ice_values: Optional[List[np.ndarray]] = [] if kind in [Kind.INDIVIDUAL, Kind.BOTH] else None
 
         for pd in pds:
             feature_values.append(pd['values'])

--- a/alibi/explainers/shap_wrappers.py
+++ b/alibi/explainers/shap_wrappers.py
@@ -78,8 +78,8 @@ def rank_by_importance(shap_values: List[np.ndarray],
             logger.warning(msg.format(len(feature_names), shap_values[0].shape[1]))
             feature_names = ['feature_{}'.format(i) for i in range(shap_values[0].shape[1])]
 
-    importances = {}  # type: Dict[str, Dict[str, Union[np.ndarray, List[str]]]]
-    avg_mag = []  # type: List
+    importances: Dict[str, Dict[str, Union[np.ndarray, List[str]]]] = {}
+    avg_mag: List = []
 
     # rank the features by average shap value for each class in turn
     for class_idx in range(len(shap_values)):
@@ -163,7 +163,7 @@ def sum_categories(values: np.ndarray, start_idx: Sequence[int], enc_feat_dim: S
         unchanged.
         """
 
-        slices = []  # type: List[int]
+        slices: List[int] = []
         # first columns may not be reduced
         if start[0] > 0:
             slices.extend(tuple(range(start[0])))
@@ -205,10 +205,10 @@ def sum_categories(values: np.ndarray, start_idx: Sequence[int], enc_feat_dim: S
     return np.add.reduceat(values, slices, axis=1)
 
 
-DISTRIBUTED_OPTS = {
+DISTRIBUTED_OPTS: Dict = {
     'n_cpus': None,
     'batch_size': 1,
-}  # type: dict
+}
 """
 Default distributed options for KernelShap:
 
@@ -750,7 +750,7 @@ class KernelShap(Explainer, FitMixin):
         # perform grouping if requested by the user
         self.background_data = self._get_data(background_data, group_names, groups, weights, **kwargs)
         explainer_args = (self.predictor, self.background_data)
-        explainer_kwargs = {'link': self.link}  # type: Dict[str, Union[str, int, None]]
+        explainer_kwargs: Dict[str, Union[str, int, None]] = {'link': self.link}
         # distribute computation
         if self.distribute:
             # set seed for each process
@@ -910,9 +910,9 @@ class KernelShap(Explainer, FitMixin):
         # TODO: Plotting default should be same space as the explanation? How do we figure out what space they
         #  explain in?
 
-        cat_vars_start_idx = kwargs.get('cat_vars_start_idx', ())  # type: Sequence[int]
-        cat_vars_enc_dim = kwargs.get('cat_vars_enc_dim', ())  # type: Sequence[int]
-        summarise_result = kwargs.get('summarise_result', False)  # type: bool
+        cat_vars_start_idx: Sequence[int] = kwargs.get('cat_vars_start_idx', ())
+        cat_vars_enc_dim: Sequence[int] = kwargs.get('cat_vars_enc_dim', ())
+        summarise_result: bool = kwargs.get('summarise_result', False)
         if summarise_result:
             self._check_result_summarisation(summarise_result, cat_vars_start_idx, cat_vars_enc_dim)
         if self.summarise_result:
@@ -1180,12 +1180,12 @@ class TreeShap(Explainer, FitMixin):
 
         perturbation = 'interventional' if background_data is not None else 'tree_path_dependent'
         self.background_data = background_data
-        self._explainer = shap.TreeExplainer(
+        self._explainer: shap.TreeExplainer = shap.TreeExplainer(
             self.predictor,
             data=self.background_data,
             model_output=self.model_output,
             feature_perturbation=perturbation,
-        )  # type: shap.TreeExplainer
+        )
         self.expected_value = self._explainer.expected_value
 
         self.scalar_output = False
@@ -1514,9 +1514,9 @@ class TreeShap(Explainer, FitMixin):
         y = kwargs.get('y')
         if y is None:
             y = np.array([])
-        cat_vars_start_idx = kwargs.get('cat_vars_start_idx', ())  # type: Sequence[int]
-        cat_vars_enc_dim = kwargs.get('cat_vars_enc_dim', ())  # type: Sequence[int]
-        summarise_result = kwargs.get('summarise_result', False)  # type: bool
+        cat_vars_start_idx: Sequence[int] = kwargs.get('cat_vars_start_idx', ())
+        cat_vars_enc_dim: Sequence[int] = kwargs.get('cat_vars_enc_dim', ())
+        summarise_result: bool = kwargs.get('summarise_result', False)
 
         # check if interactions were computed
         if len(shap_output[0].shape) == 3:
@@ -1546,7 +1546,7 @@ class TreeShap(Explainer, FitMixin):
         # NB: raw output of a regression or classification task will not work for pyspark (predict not implemented)
         if self.model_output == 'log_loss':
             loss = self._explainer.model.predict(X, y, tree_limit=self.tree_limit)
-            raw_predictions = []  # type: Any
+            raw_predictions: Any = []
         else:
             loss = []
             raw_predictions = self._explainer.model.predict(X, tree_limit=self.tree_limit)
@@ -1555,7 +1555,7 @@ class TreeShap(Explainer, FitMixin):
                 raw_predictions = raw_predictions.squeeze(-1)
 
         # predicted class
-        argmax_pred = []  # type: Any
+        argmax_pred: Any = []
         if self.task != 'regression':
             if not isinstance(raw_predictions, list):
                 if self.scalar_output:

--- a/alibi/prototypes/protoselect.py
+++ b/alibi/prototypes/protoselect.py
@@ -164,7 +164,7 @@ class ProtoSelect(Summariser, FitMixin):
                            f'the prototypes selection set. Automatically setting `num_prototypes={num_prototypes}`.')
 
         # dictionary of prototypes indices for each class
-        protos = {l: [] for l in range(len(self.label_mapping))}  # type: Dict[int, List[int]]  # noqa: E741
+        protos: Dict[int, List[int]] = {l: [] for l in range(len(self.label_mapping))}  # noqa: E741
         # set of available prototypes indices. Note that initially we start with the entire set of Z,
         # but as the algorithm progresses, we remove the indices of the prototypes that we already selected.
         available_indices = set(range(len(self.Z)))

--- a/alibi/utils/discretizer.py
+++ b/alibi/utils/discretizer.py
@@ -30,8 +30,8 @@ class Discretizer(object):
         bins = self.bins(data)
         bins = [np.unique(x) for x in bins]
 
-        self.feature_intervals = {}  # type: Dict[int, list]
-        self.lambdas = {}            # type: Dict[int, Callable]
+        self.feature_intervals: Dict[int, list] = {}
+        self.lambdas: Dict[int, Callable] = {}
         for feature, qts in zip(self.to_discretize, bins):
 
             # get nb of borders (nb of bins - 1) and the feature name

--- a/alibi/utils/distance.py
+++ b/alibi/utils/distance.py
@@ -122,8 +122,8 @@ def abdm(X: np.ndarray,
     # combine dict for categorical with binned features
     cat_vars_combined = {**cat_vars, **cat_vars_bin}
 
-    d_pair: dict = {}
-    X_cat_eq: dict = {}
+    d_pair: Dict = {}
+    X_cat_eq: Dict = {}
     for col, n_cat in cat_vars.items():
         X_cat_eq[col] = []
         for i in range(n_cat):  # for each category in categorical variable, store instances of each category

--- a/alibi/utils/distance.py
+++ b/alibi/utils/distance.py
@@ -122,8 +122,8 @@ def abdm(X: np.ndarray,
     # combine dict for categorical with binned features
     cat_vars_combined = {**cat_vars, **cat_vars_bin}
 
-    d_pair = {}  # type: Dict
-    X_cat_eq = {}  # type: Dict
+    d_pair: dict = {}
+    X_cat_eq: dict = {}
     for col, n_cat in cat_vars.items():
         X_cat_eq[col] = []
         for i in range(n_cat):  # for each category in categorical variable, store instances of each category

--- a/alibi/utils/mapping.py
+++ b/alibi/utils/mapping.py
@@ -139,7 +139,7 @@ def ohe_to_ord(X_ohe: np.ndarray, cat_vars_ohe: dict) -> Tuple[np.ndarray, dict]
     """
     n, cols = X_ohe.shape
     ohe_vars_keys = list(cat_vars_ohe.keys())
-    X_list = []  # type: List
+    X_list: List = []
     c = 0
     cat_vars_ord = {}
     while c < cols:

--- a/alibi/utils/tests/test_distributed.py
+++ b/alibi/utils/tests/test_distributed.py
@@ -21,7 +21,7 @@ class MockExplainer:
     def __init__(self, sleep_time: int, multiplier: int = 3):
         self.sleep_time = sleep_time
         self.multiplier = multiplier
-        self.proc_id = None  # type: Optional[int]
+        self.proc_id: Optional[int] = None
 
     def get_explanation(self, X: Union[Tuple[int, np.ndarray], np.ndarray], **kwargs):
         """


### PR DESCRIPTION
## What is this:

Removes python2 type comments with type annotations, fixes #863. Required before we can merge #825.
