### PR TITLE
Replaced `np.object` with `object` in `plot_permutation_importance`.

### DIFF
--- a/alibi/explainers/permutation_importance.py
+++ b/alibi/explainers/permutation_importance.py
@@ -933,7 +933,7 @@ def plot_permutation_importance(exp: Explanation,
         n_cols = min(n_cols, n_metric_names)
         n_rows = math.ceil(n_metric_names / n_cols)
 
-        axes = np.empty((n_rows, n_cols), dtype=np.object)
+        axes = np.empty((n_rows, n_cols), dtype=object)
         axes_ravel = axes.ravel()
         gs = GridSpec(n_rows, n_cols)
 


### PR DESCRIPTION
`np.object` is deprecated in latest release of `numpy` (1.24).