### PR TITLE
Build docs on Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
           python-version: '3.10'
       - name: Install dependencies
         run: |
+          apt install pandoc
           python -m pip install --upgrade pip
           python -m pip install -r requirements/docs.txt
           python -m pip freeze

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,6 @@ defaults:
   run:
     shell: bash  # To override PowerShell on Windows
 
-env:
-  DEFAULT_PY_VERSION: '3.10'  # Default Python version to use for licence/docs builds etc.
-
 on:
   # Trigger the workflow on push or pull request,
   # push only for the master branch,
@@ -43,7 +40,7 @@ jobs:
           - os: windows-latest
             python-version: '3.9'  # PyTorch doesn't yet have 3.10 support on Windows (https://pytorch.org/get-started/locally/#windows-python)
           - os: macos-latest
-            python-version: $DEFAULT_PY_VERSION
+            python-version: '3.10'
 
     steps:
       - name: Checkout code
@@ -104,7 +101,7 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.DEFAULT_PY_VERSION }}
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -126,7 +123,7 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.DEFAULT_PY_VERSION }}
+          python-version: '3.10'
       - name: Check 3rd party licenses haven't changed
         run: |
           pip install "tox>=3.21.0,<4.0.0"
@@ -142,7 +139,7 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.DEFAULT_PY_VERSION }}
+          python-version: '3.10'
       - name: Check optional dependency imports are protected
         run: |
           pip install "tox>=3.21.0,<4.0.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: docker pull readthedocs/build:ubuntu-22.04-2022.03.15
+      image: readthedocs/build:ubuntu-22.04-2022.03.15
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
           python-version: '3.10'
       - name: Install dependencies
         run: |
-          sudo apt-get install pandoc
+          sudo apt-get -y install pandoc latexmk
           python -m pip install --upgrade pip
           python -m pip install -r requirements/docs.txt
           python -m pip freeze

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           - os: windows-latest
             python-version: '3.9'  # PyTorch doesn't yet have 3.10 support on Windows (https://pytorch.org/get-started/locally/#windows-python)
           - os: macos-latest
-            python-version: $DEFAULT_PY_VERSION
+            python-version: ${{ env.DEFAULT_PY_VERSION }}
 
     steps:
       - name: Checkout code
@@ -104,7 +104,7 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v4
         with:
-          python-version: $DEFAULT_PY_VERSION
+          python-version: ${{ env.DEFAULT_PY_VERSION }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -126,7 +126,7 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v4
         with:
-          python-version: $DEFAULT_PY_VERSION
+          python-version: ${{ env.DEFAULT_PY_VERSION }}
       - name: Check 3rd party licenses haven't changed
         run: |
           pip install "tox>=3.21.0,<4.0.0"
@@ -142,7 +142,7 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v4
         with:
-          python-version: $DEFAULT_PY_VERSION
+          python-version: ${{ env.DEFAULT_PY_VERSION }}
       - name: Check optional dependency imports are protected
         run: |
           pip install "tox>=3.21.0,<4.0.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
 
     container:
       image: readthedocs/build:ubuntu-22.04-2022.03.15
+      options: --user root
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
           python-version: '3.10'
       - name: Install dependencies
         run: |
-          apt install pandoc
+          sudo apt-get install pandoc
           python -m pip install --upgrade pip
           python -m pip install -r requirements/docs.txt
           python -m pip freeze

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    container:
+      image: docker pull readthedocs/build:ubuntu-22.04-2022.03.15
+
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.x
@@ -104,7 +107,6 @@ jobs:
           python-version: '3.10'
       - name: Install dependencies
         run: |
-          sudo apt-get -y install pandoc latexmk
           python -m pip install --upgrade pip
           python -m pip install -r requirements/docs.txt
           python -m pip freeze

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ defaults:
   run:
     shell: bash  # To override PowerShell on Windows
 
+env:
+  DEFAULT_PY_VERSION: '3.10'  # Default Python version to use for licence/docs builds etc.
+
 on:
   # Trigger the workflow on push or pull request,
   # push only for the master branch,
@@ -14,7 +17,7 @@ on:
       - 'feature/*'
   pull_request:
     # don't trigger for draft PRs
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
   # Trigger workflow once per day at midnight
   schedule:
     - cron: '0 0 * * *'
@@ -34,13 +37,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ ubuntu-latest ]
         python-version: [ '3.7', '3.8', '3.9', '3.10' ]
         include: # Run macos and windows tests on only one python version
           - os: windows-latest
-            python-version:  '3.9'  # PyTorch doesn't yet have 3.10 support on Windows (https://pytorch.org/get-started/locally/#windows-python)
+            python-version: '3.9'  # PyTorch doesn't yet have 3.10 support on Windows (https://pytorch.org/get-started/locally/#windows-python)
           - os: macos-latest
-            python-version:  '3.10'
+            python-version: $DEFAULT_PY_VERSION
 
     steps:
       - name: Checkout code
@@ -94,30 +97,24 @@ jobs:
 
   docs:
 
-    runs-on: ubuntu-18.04
-
-    container:
-      image: readthedocs/build:latest
-      options: --user root
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
-      - name: Create a virtualenv to use for docs build
-        run: |
-          python3.8 -m virtualenv $HOME/docs
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v4
+        with:
+          python-version: $DEFAULT_PY_VERSION
       - name: Install dependencies
         run: |
-          . $HOME/docs/bin/activate
           python -m pip install --upgrade pip
           python -m pip install -r requirements/docs.txt
           python -m pip freeze
       - name: Build documentation to html
         run: |
-          . $HOME/docs/bin/activate
           make build_docs
       - name: Build documentation to pdf via latex
         run: |
-          . $HOME/docs/bin/activate
           make build_latex
 
   licenses:
@@ -129,7 +126,7 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: $DEFAULT_PY_VERSION
       - name: Check 3rd party licenses haven't changed
         run: |
           pip install "tox>=3.21.0,<4.0.0"
@@ -145,7 +142,7 @@ jobs:
       - name: Set up Python 3.x
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: $DEFAULT_PY_VERSION
       - name: Check optional dependency imports are protected
         run: |
           pip install "tox>=3.21.0,<4.0.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           - os: windows-latest
             python-version: '3.9'  # PyTorch doesn't yet have 3.10 support on Windows (https://pytorch.org/get-started/locally/#windows-python)
           - os: macos-latest
-            python-version: ${{ env.DEFAULT_PY_VERSION }}
+            python-version: $DEFAULT_PY_VERSION
 
     steps:
       - name: Checkout code

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,8 +5,11 @@
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
 build:
-  image: latest # Python 3.8 available on latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
   apt_packages:
     - pandoc
 
@@ -20,6 +23,5 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.8
    install:
    - requirements: requirements/docs.txt

--- a/doc/README.md
+++ b/doc/README.md
@@ -15,7 +15,7 @@ To build the documentation, first we need to install Python requirements:
 We also need `pandoc` for parsing Jupyter notebooks, the easiest way
 to install this is using conda:
 
-`conda install -c conda-forge pandoc=1.19.2`
+`conda install -c conda-forge pandoc=2.9.2.1`
 
 Note: the older version of pandoc is used because this is available on `readthedocs.org` where we host our docs, the newer version fixes a lot of bugs, but using a newer version locally is misleading as to whether the docs will render properly on RTD, also see [gotchas](#gotchas-when-writing-notebooks-as-examples).
 
@@ -82,8 +82,8 @@ We use Jupyter notebooks for examples and method descriptions and invoke the [nb
 * For references and footnotes, the tag indicating the section needs to start with an uppercase letter, e.g. `[[1]](#References)` linking to a section `<a id='References'></a>
 [1](#f_1) reference here`
 * Whilst superscript (for e.g. footnotes) can be rendered in Jupyter using `<sup></sup>` tags, this won't work in the static docs. To avoid jarring appearence of footnote numbers in the text, wrap them in parentheses, e.g. <sup>`(1)`</sup> will be rendered inline as `(1)`.
-* Avoid starting a cell with an html tag, e.g. for making hyperlinks to link back to the reference in the text `<a id='ref1'></a>`. The (older) version of `pandoc==1.19.2` used both on CI and `readthedocs.org` machines cannot handle it and may fail to build the docs. Recommended action is to put such tags at the end of the cell.
-* Avoid using underscores in alternative text for images, e.g. instead of `![my_pic](my_pic.png)` use `![my-pic](my_pic.png)`, this is due to the old version of `pandoc==1.19.2` used on `reathedocs.org`.
+* Avoid starting a cell with an html tag, e.g. for making hyperlinks to link back to the reference in the text `<a id='ref1'></a>`. The (older) version of `pandoc==2.9.2.1` used both on CI and `readthedocs.org` machines cannot handle it and may fail to build the docs. Recommended action is to put such tags at the end of the cell.
+* Avoid using underscores in alternative text for images, e.g. instead of `![my_pic](my_pic.png)` use `![my-pic](my_pic.png)`, this is due to the old version of `pandoc==2.9.2.1` used on `reathedocs.org`.
 * Avoid nesting markdown markups, e.g. italicising a hyperlink, this might not render
 * ~~When embedding images in notebooks which are linked to via a `.nblink` file, an `extra-media` key needs to be added in the `.nblink` file. See the [nbsphinx-link](https://github.com/vidartf/nbsphinx-link) docs, or [alibi_detect_deploy.nblink](https://github.com/SeldonIO/alibi-detect/blob/master/doc/source/examples/alibi_detect_deploy.nblink) for an example in alibi-detect.~~ Prefer using the following to produce self-contained notebooks:
 * To add a static image to an example, use the syntax `![my-image.png](attachment:my_image.png)` and execute the cell. This will embed the actual binary image into the example notebook so that the notebook is self-contained (note that some notebooks won't be self-contained due to dependencies on data or models under `doc/source/examples/assets`). Afterwards, ensure the image is located in the `doc/source/examples/assets` directory and committed to the repository.

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,16 +1,16 @@
 # dependencies for building docs, separate from dev.txt as this is also used for builds on readthedocs.org
 # core dependencies
 sphinx>=4.2.0, <6.0.0
-sphinx-autodoc-typehints>=1.12.0, <1.21  # limited due to https://github.com/tox-dev/sphinx-autodoc-typehints/issues/260 
+sphinx-autodoc-typehints>=1.12.0, <1.21  # limited due to https://github.com/tox-dev/sphinx-autodoc-typehints/issues/260
 sphinx-rtd-theme>=1.0.0, <2.0.0
 myst-parser>=0.14, <0.19
 sphinxcontrib-apidoc>=0.3.0, <0.4.0
 nbsphinx>=0.8.5, <0.9.0
-sphinx_design==0.3.0  # Pinning for now as sphinx_design is v.new and still in flux. 
+sphinx_design==0.3.0  # Pinning for now as sphinx_design is v.new and still in flux.
 ipykernel>=5.1.0, <7.0.0 # required for executing notebooks via nbsphinx
 ipython>=7.2.0, <9.0.0 # required for executing notebooks nbsphinx
 # dependencies required for imports to work and docs to render properly (as mocking doesn't work well)
 # these should be identical to the ones in `setup.py` or `dev.txt`
 shap>=0.40.0, <0.42.0 # https://github.com/SeldonIO/alibi/issues/333
 # pandoc
-# pandoc==1.19.2 # NB: as this is not a Python library, it should be installed manually on the system or via a package manager such as `conda`
+# pandoc==2.9.2.1 # NB: as this is not a Python library, it should be installed manually on the system or via a package manager such as `conda`


### PR DESCRIPTION
 - `.readthedocs.yml` is updated from the legacy format to the current format
 - The docs on RTD are now built with `ubuntu-22.04` and using Python 3.10
 - ~Removed dependency on RTD image for GA docs build (as RTD do not recommend using them), now the GA build is run on a generic `ubuntu-latest` image (currently correpsonding to `ubuntu-22.04` on Python 3.10~ - latex builds require lots of dependencies, so easiest to use the RTD image after all
 - ~Factored out the Python 3.10 version under a global workflow variable `DEFAULT_PY_VERSION`~ Not possible, see https://github.com/orgs/community/discussions/25295#discussioncomment-3247326