### PR TITLE
Reset predictor for SHAP.

### DIFF
--- a/alibi/explainers/shap_wrappers.py
+++ b/alibi/explainers/shap_wrappers.py
@@ -992,8 +992,9 @@ class KernelShap(Explainer, FitMixin):
             New prediction function.
         """
         self.predictor = predictor
-        # TODO: check if we need to reinitialize self._explainer (potentially not, as it should hold a reference
-        #  to self.predictor) however, the shap.KernelExplainer may utilize the Callable to set some attributes
+
+        if self._fitted:
+            self._explainer.model = shap_utils.convert_to_model(self.predictor)
         # TODO: check if we need to do more for the distributed case
 
 
@@ -1628,3 +1629,9 @@ class TreeShap(Explainer, FitMixin):
         """
         # TODO: check what else should be done (e.g. validate dtypes again?)
         self.predictor = predictor
+
+        if self._fitted:
+            self._explainer.model = shap.explainers._tree.TreeEnsemble(predictor,
+                                                                       self._explainer.data,
+                                                                       self._explainer.data_missing,
+                                                                       self._explainer.model_output)

--- a/alibi/explainers/shap_wrappers.py
+++ b/alibi/explainers/shap_wrappers.py
@@ -749,20 +749,7 @@ class KernelShap(Explainer, FitMixin):
 
         # perform grouping if requested by the user
         self.background_data = self._get_data(background_data, group_names, groups, weights, **kwargs)
-        explainer_args = (self.predictor, self.background_data)
-        explainer_kwargs: Dict[str, Union[str, int, None]] = {'link': self.link}
-        # distribute computation
-        if self.distribute:
-            # set seed for each process
-            explainer_kwargs['seed'] = self.seed
-            self._explainer = DistributedExplainer(
-                self.distributed_opts,
-                KernelExplainerWrapper,
-                explainer_args,
-                explainer_kwargs,
-            )  #
-        else:
-            self._explainer = KernelExplainerWrapper(*explainer_args, **explainer_kwargs)
+        self._explainer = self._init_shap_object()
         self.expected_value = self._explainer.expected_value
         if not self._explainer.vector_out:
             logger.warning(
@@ -781,8 +768,25 @@ class KernelShap(Explainer, FitMixin):
             'transpose': self.transposed,
         }
         self._update_metadata(params, params=True)
-
         return self
+
+    def _init_shap_object(self) -> Union[KernelExplainerWrapper, DistributedExplainer]:
+        """ Initialize explainer as a `KernelExplainerWrapper` or as a `DistributedExplainer`. """
+        explainer_args = (self.predictor, self.background_data)
+        explainer_kwargs: Dict[str, Union[str, int, None]] = {'link': self.link}
+
+        # distribute computation
+        if self.distribute:
+            # set seed for each process
+            explainer_kwargs['seed'] = self.seed
+            return DistributedExplainer(
+                self.distributed_opts,
+                KernelExplainerWrapper,
+                explainer_args,
+                explainer_kwargs,
+            )
+
+        return KernelExplainerWrapper(*explainer_args, **explainer_kwargs)
 
     def explain(self,
                 X: Union[np.ndarray, pd.DataFrame, sparse.spmatrix],
@@ -992,10 +996,7 @@ class KernelShap(Explainer, FitMixin):
             New prediction function.
         """
         self.predictor = predictor
-
-        if self._fitted:
-            self._explainer.model = shap_utils.convert_to_model(self.predictor)
-        # TODO: check if we need to do more for the distributed case
+        self._explainer = self._init_shap_object()
 
 
 # TODO: Look into pyspark support requirements if requested
@@ -1179,14 +1180,9 @@ class TreeShap(Explainer, FitMixin):
                                f'A larger background dataset will be sampled with replacement to '
                                f'{TREE_SHAP_BACKGROUND_SUPPORTED_SIZE} instances.')
 
-        perturbation = 'interventional' if background_data is not None else 'tree_path_dependent'
+        self.perturbation = 'interventional' if background_data is not None else 'tree_path_dependent'
         self.background_data = background_data
-        self._explainer: shap.TreeExplainer = shap.TreeExplainer(
-            self.predictor,
-            data=self.background_data,
-            model_output=self.model_output,
-            feature_perturbation=perturbation,
-        )
+        self._explainer = self._init_shap_object()
         self.expected_value = self._explainer.expected_value
 
         self.scalar_output = False
@@ -1201,12 +1197,20 @@ class TreeShap(Explainer, FitMixin):
         # update metadata
         params = {
             'summarise_background': self.summarise_background,
-            'algorithm': perturbation,
+            'algorithm': self.perturbation,
             'kwargs': kwargs,
         }
         self._update_metadata(params, params=True)
-
         return self
+
+    def _init_shap_object(self) -> shap.TreeExplainer:
+        """ Initialize explainer as a `shap.TreeExplainer`. """
+        return shap.TreeExplainer(
+            self.predictor,
+            data=self.background_data,
+            model_output=self.model_output,
+            feature_perturbation=self.perturbation,
+        )
 
     @staticmethod
     def _check_inputs(background_data: Union[pd.DataFrame, np.ndarray]) -> None:
@@ -1629,9 +1633,4 @@ class TreeShap(Explainer, FitMixin):
         """
         # TODO: check what else should be done (e.g. validate dtypes again?)
         self.predictor = predictor
-
-        if self._fitted:
-            self._explainer.model = shap.explainers._tree.TreeEnsemble(predictor,
-                                                                       self._explainer.data,
-                                                                       self._explainer.data_missing,
-                                                                       self._explainer.model_output)
+        self._explainer = self._init_shap_object()


### PR DESCRIPTION
This PR fixes the `reset_predictor` functionality within `KernelShap` and `TreeShap`. The current implementation does not reset the predictor within the wrapped `shap` object. This means that if an explainer is loaded and a different predictor ispassed as argument to `load_explainer` function (i.e., basically just keeping the configuration of the explainer but changing the predictor), still the predictor used in the initialization of the explainer will be used.