### PR TITLE
Included callable layer selector support for `IntegratedGradients`.

### DIFF
--- a/alibi/exceptions.py
+++ b/alibi/exceptions.py
@@ -52,3 +52,11 @@ class NotFittedError(AlibiException):
         super().__init__(
             f"This {object_name} instance is not fitted yet. Call 'fit' with appropriate arguments first."
         )
+
+
+class SerializationError(AlibiException):
+    """
+    This exception is raised whenever an explainer cannot be serialized.
+    """
+    def __init__(self, message: str):
+        super().__init__(message)

--- a/alibi/explainers/integrated_gradients.py
+++ b/alibi/explainers/integrated_gradients.py
@@ -783,6 +783,7 @@ def _validate_output(model: tf.keras.Model,
 class LayerState(str, Enum):
     UNSPECIFIED = 'unspecified'
     NON_SERIALIZABLE = 'non-serializable'
+    CALLABLE = 'callable'
 
 
 class IntegratedGradients(Explainer):
@@ -843,8 +844,7 @@ class IntegratedGradients(Explainer):
         if layer is None:
             self.orig_call: Optional[Callable] = None
             self.layer = None
-            layer_meta: Optional[Union[int, LayerState, Callable[[tf.keras.Model], tf.keras.layers.Layer]]] = \
-                LayerState.UNSPECIFIED
+            layer_meta: Union[int, LayerState] = LayerState.UNSPECIFIED
 
         elif isinstance(layer, tf.keras.layers.Layer):
             self.orig_call = layer.call
@@ -862,7 +862,8 @@ class IntegratedGradients(Explainer):
         elif callable(layer):
             self.layer = layer(self.model)
             self.orig_call = self.layer.call
-            layer_meta = layer
+            self.callable_layer = layer
+            layer_meta = LayerState.CALLABLE
 
         else:
             raise TypeError(f'Unsupported layer type. Received {type(layer)}.')

--- a/alibi/explainers/integrated_gradients.py
+++ b/alibi/explainers/integrated_gradients.py
@@ -844,7 +844,7 @@ class IntegratedGradients(Explainer):
         if layer is None:
             self.orig_call: Optional[Callable] = None
             self.layer = None
-            layer_meta: Union[int, LayerState] = LayerState.UNSPECIFIED
+            layer_meta: Union[int, str] = LayerState.UNSPECIFIED.value
 
         elif isinstance(layer, tf.keras.layers.Layer):
             self.orig_call = layer.call
@@ -853,17 +853,17 @@ class IntegratedGradients(Explainer):
             try:
                 layer_meta = model.layers.index(layer)
             except ValueError:
-                layer_meta = LayerState.NON_SERIALIZABLE
-                logger.info('Layer not in the list of `model.layers`. Passing the layer directly would not '
-                            'permit the serialization of the explainer. This is due to nested layers. To permit '
-                            'the serialization of the explainer, provide the layer as a callable which returns '
-                            'the layer given the model.')
+                layer_meta = LayerState.NON_SERIALIZABLE.value
+                logger.warning('Layer not in the list of `model.layers`. Passing the layer directly would not '
+                               'permit the serialization of the explainer. This is due to nested layers. To permit '
+                               'the serialization of the explainer, provide the layer as a callable which returns '
+                               'the layer given the model.')
 
         elif callable(layer):
             self.layer = layer(self.model)
             self.orig_call = self.layer.call
             self.callable_layer = layer
-            layer_meta = LayerState.CALLABLE
+            layer_meta = LayerState.CALLABLE.value
 
         else:
             raise TypeError(f'Unsupported layer type. Received {type(layer)}.')

--- a/alibi/saving.py
+++ b/alibi/saving.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import numbers
 import os
 from pathlib import Path
 import sys
@@ -123,17 +124,18 @@ def _simple_load(path: Union[str, os.PathLike], predictor, meta) -> 'Explainer':
 
 def _load_IntegratedGradients(path: Union[str, os.PathLike], predictor: 'Union[tensorflow.keras.Model]',
                               meta: dict) -> 'IntegratedGradients':
-    layer_num = meta['params']['layer']
-    if layer_num == 0:
-        layer = None
+    layer_meta = meta['params']['layer']
+
+    if isinstance(layer_meta, numbers.Integral):
+        layer = None if layer_meta == 0 else predictor.layers[layer_meta]
     else:
-        layer = predictor.layers[layer_num]
+        layer = layer_meta(predictor)
 
     with open(Path(path, 'explainer.dill'), 'rb') as f:
         explainer = dill.load(f)
+
     explainer.reset_predictor(predictor)
     explainer.layer = layer
-
     return explainer
 
 

--- a/alibi/tests/test_saving.py
+++ b/alibi/tests/test_saving.py
@@ -21,6 +21,7 @@ from alibi.explainers import (
     CounterfactualRLTabular,
     GradientSimilarity
 )
+from alibi.explainers.integrated_gradients import LayerState
 from alibi.saving import load_explainer
 from alibi_testing.data import get_adult_data, get_iris_data, get_movie_sentiment_data
 import alibi_testing
@@ -143,11 +144,11 @@ def ale_explainer(iris_data, lr_classifier):
 
 
 @pytest.fixture(scope='module',
-                params=[None, 1, lambda model: model.layers[1]])
+                params=[LayerState.UNSPECIFIED, 1, lambda model: model.layers[1]])
 def ig_explainer(request, iris_data, ffn_classifier):
     layer_meta = request.param
 
-    if layer_meta is None:
+    if layer_meta == LayerState.UNSPECIFIED:
         layer = None
     elif isinstance(layer_meta, numbers.Integral):
         layer = ffn_classifier.layers[layer_meta]

--- a/alibi/tests/test_saving.py
+++ b/alibi/tests/test_saving.py
@@ -144,16 +144,17 @@ def ale_explainer(iris_data, lr_classifier):
 
 
 @pytest.fixture(scope='module',
-                params=[LayerState.UNSPECIFIED, 1, lambda model: model.layers[1]])
+                params=[LayerState.UNSPECIFIED, LayerState.CALLABLE, 1])
 def ig_explainer(request, iris_data, ffn_classifier):
     layer_meta = request.param
 
-    if layer_meta == LayerState.UNSPECIFIED:
-        layer = None
+    if layer_meta == LayerState.CALLABLE:
+        def layer(model):
+            return model.layers[1]
     elif isinstance(layer_meta, numbers.Integral):
         layer = ffn_classifier.layers[layer_meta]
     else:
-        layer = layer_meta  # callable case
+        layer = None
 
     ig = IntegratedGradients(model=ffn_classifier, layer=layer)
     return ig


### PR DESCRIPTION
This PR includes callable layer selector support for `IntegratedGradients`.  Previously, the reloading functionality was using the index of the layer within the `model.layers` list. Such an approach fails when the model is constructed base on nested layers. With the new functionality, the user can pass a function which select the desired model. 

