### PR TITLE
Update notebook to account for changed `pandas` `value_counts` method…

### DIFF
--- a/doc/source/examples/permutation_importance_classification_leave.ipynb
+++ b/doc/source/examples/permutation_importance_classification_leave.ipynb
@@ -272,7 +272,7 @@
    ],
    "source": [
     "target_perc = df[target_name].value_counts(normalize=True).mul(100).rename('percent').reset_index().rename({'index': 'left'}, axis=1)  # rename \"index\" on pandas 1.x\n",
-    "g = sns.catplot(data=target_perc, x='index', y='percent', kind='bar')\n",
+    "g = sns.catplot(data=target_perc, x='left', y='percent', kind='bar')\n",
     "g.ax.set_ylim(0, 100)\n",
     "\n",
     "for p in g.ax.patches:\n",

--- a/doc/source/examples/permutation_importance_classification_leave.ipynb
+++ b/doc/source/examples/permutation_importance_classification_leave.ipynb
@@ -271,7 +271,7 @@
     }
    ],
    "source": [
-    "target_perc = df[target_name].value_counts(normalize=True).mul(100).rename('percent').reset_index().rename({'index': 'left'}, axis=1)\n",
+    "target_perc = df[target_name].value_counts(normalize=True).mul(100).rename('percent').reset_index().rename({'index': 'left'}, axis=1)  # rename \"index\" on pandas 1.x\n",
     "g = sns.catplot(data=target_perc, x='index', y='percent', kind='bar')\n",
     "g.ax.set_ylim(0, 100)\n",
     "\n",

--- a/doc/source/examples/permutation_importance_classification_leave.ipynb
+++ b/doc/source/examples/permutation_importance_classification_leave.ipynb
@@ -271,7 +271,7 @@
     }
    ],
    "source": [
-    "target_perc = df[target_name].value_counts(normalize=True).mul(100).rename('percent').reset_index()\n",
+    "target_perc = df[target_name].value_counts(normalize=True).mul(100).rename('percent').reset_index().rename({'index': 'left'}, axis=1)\n",
     "g = sns.catplot(data=target_perc, x='index', y='percent', kind='bar')\n",
     "g.ax.set_ylim(0, 100)\n",
     "\n",
@@ -922,7 +922,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -936,7 +936,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
… behaviour

Resolves #909. Uses a version-agnostic code to rename the column `index` to `left`. Note that this reduces to a no-op in 2.x as the column is already called `left`, fortunately the code doesn't throw an error if a column name doesn't exist which allows us to have version-agnostic code here.