### PR TITLE
Separate code quality step and only run on 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ on:
 jobs:
   build:
     if: github.event.pull_request.draft == false
-    needs: code-quality
 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,14 +69,6 @@ jobs:
         with:
           limit-access-to-actor: true
 
-      - name: Lint with flake8
-        run: |
-          flake8 alibi
-
-      - name: Typecheck with mypy
-        run: |
-          mypy alibi
-
       - name: Test with pytest
         run: |
           pytest -m tf1 alibi
@@ -94,6 +86,29 @@ jobs:
         run: |
           make build_pypi
 
+  code-quality:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt
+          python -m pip install --upgrade --upgrade-strategy eager .[all]
+
+      - name: Lint with flake8
+        run: |
+          flake8 alibi
+
+      - name: Typecheck with mypy
+        run: |
+          mypy alibi
 
   docs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ on:
 jobs:
   build:
     if: github.event.pull_request.draft == false
+    needs: code-quality
 
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
It makes sense to run lints and type-checking only on the latest supported version (currently 3.10) as this will unblock improvement in tooling (e.g. see #874).