### PR TITLE
Update Anchor explainers to use non-global numpy rng

### DIFF
--- a/alibi/explainers/anchors/anchor_text.py
+++ b/alibi/explainers/anchors/anchor_text.py
@@ -191,7 +191,7 @@ class AnchorText(Explainer):
 
         # set perturbation
         self.perturbation: Any = \
-            self.CLASS_SAMPLER[self.sampling_strategy](self.model, self.perturb_opts)  #: Perturbation method.
+            self.CLASS_SAMPLER[self.sampling_strategy](self.model, self.perturb_opts, self.seed)  #: Perturbation method.
 
         # update metadata
         self.meta['params'].update(seed=seed)

--- a/alibi/explainers/anchors/anchor_text.py
+++ b/alibi/explainers/anchors/anchor_text.py
@@ -133,7 +133,7 @@ class AnchorText(Explainer):
                  sampling_strategy: str = 'unknown',
                  nlp: Optional['spacy.language.Language'] = None,
                  language_model: Union['LanguageModel', None] = None,
-                 seed: int = 0,
+                 seed: Optional[int] = None,
                  **kwargs: Any) -> None:
         """
         Initialize anchor text explainer.
@@ -176,7 +176,7 @@ class AnchorText(Explainer):
             If the return type of `predictor` is not `np.ndarray`.
         """
         super().__init__(meta=copy.deepcopy(DEFAULT_META_ANCHOR))
-        self._seed(seed)
+        self.seed = seed
 
         # set the predictor
         self.predictor = self._transform_predictor(predictor)
@@ -542,9 +542,3 @@ class AnchorText(Explainer):
             New predictor function.
         """
         self.predictor = self._transform_predictor(predictor)
-
-    def _seed(self, seed: int) -> None:
-        np.random.seed(seed)
-        # If LanguageModel is used, we need to set the seed for tf as well.
-        if hasattr(self, 'model') and isinstance(self.model, LanguageModelSampler):
-            self.perturbation.seed(seed)


### PR DESCRIPTION
This is the first of a series of PR to remove (or at least reduce) the library's usage of global random state - we shouldn't be setting global seeds as that would change the state of any application using `alibi`.

This PR only targets the `Anchor*` explainers for simplicity. The code is refactored to use the new [`numpy.random.Generator`](https://numpy.org/doc/stable/reference/random/generator.html#numpy.random.default_rng) objects.

Note on `tensorflow`: even though they have initial support for [`tf.random.Generator`](https://www.tensorflow.org/api_docs/python/tf/random/Generator), it doesn't include support for all distributions, e.g. `categorical` which we use. Because of this I've left the global `tf.random.set_seed` for now.

- [ ] TODO: run notebooks to check functionality:
  - [x] `anchor_tabular_adult.ipynb` - works as expected
  - [x] `anchor_tabular_iris.ipynb` - works as expected
  - [x] `anchor_image_fashion_mnist.ipynb` - `seed` argument to `explain` has no effect, should be removed. Otherwise seems to work as expected (couldn't trigger different explanations for the sample image just yet - see note below)
  - [x] `anchor_image_imagenet.ipynb` - works the same as `fashion_mnist` with the same note
  - [ ] `anchor_text_movie.ipynb`
    - [x] - `unknown` sampling - works as expected
    - [ ]  - `similarity` sampling
    - [ ]  - `language_model` sampling 

**Note:** `AnchorTabular` and `AnchorImage` have different behaviour with this PR. This is because `AnchorImageSampler` gets initialized in `explain` and uses the `self.seed` attribute making it deterministic on reruns of `explain` on the same instance. By contrast, `AnchorTabular` initializes the `AnchorTabularSampler` during `__init__` and thus is not deterministic from one `explain` call to the other. In fact, `AnchorImage` is the odd one out as sampler initialization happens during `__init__` also for `AnchorText`.