### PR TITLE
Run CI on Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11']
         include: # Run macos and windows tests on only one python version
           - os: windows-latest
             python-version: '3.9'  # PyTorch doesn't yet have 3.10 support on Windows (https://pytorch.org/get-started/locally/#windows-python)

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ if __name__ == '__main__':
               "Programming Language :: Python :: 3.8",
               "Programming Language :: Python :: 3.9",
               "Programming Language :: Python :: 3.10",
+              "Programming Language :: Python :: 3.11",
               "License :: OSI Approved :: Apache Software License",
               "Topic :: Scientific/Engineering",
           ])


### PR DESCRIPTION
Resolves #821.

Likely needs https://github.com/SeldonIO/alibi/pull/893/ to be merged first.

TODO:
 - [x] CI passes (`torch 1.13.1`): https://github.com/SeldonIO/alibi/actions/runs/5313153279/jobs/9618649347?pr=932
 - [ ]  ~CI passes `torch 2.x`~ (not needed for this PR as `3.11` is supported by `1.13.1`
 - [x] Update `README.md` (no update required as version info is pulled in from published PyPI releases)
 - [x] Update docs (no update required as only lower version bound is mentioned in `docs/source/overview/getting_started.md`
 - [x] Update `setup.py`