### PR TITLE
Use forwardref for DistributedExplainer to avoid import errors when r…

### DIFF
--- a/alibi/explainers/shap_wrappers.py
+++ b/alibi/explainers/shap_wrappers.py
@@ -770,7 +770,7 @@ class KernelShap(Explainer, FitMixin):
         self._update_metadata(params, params=True)
         return self
 
-    def _init_shap_object(self) -> Union[KernelExplainerWrapper, DistributedExplainer]:
+    def _init_shap_object(self) -> Union[KernelExplainerWrapper, 'DistributedExplainer']:
         """ Initialize explainer as a `KernelExplainerWrapper` or as a `DistributedExplainer`. """
         explainer_args = (self.predictor, self.background_data)
         explainer_kwargs: Dict[str, Union[str, int, None]] = {'link': self.link}


### PR DESCRIPTION
…ay absent

Uncovered by https://github.com/SeldonIO/alibi/actions/runs/5574933741/jobs/10184185215?pr=947