### PR TITLE
Exclude overview.ipynb from testing

### DIFF
--- a/testing/test_notebooks.py
+++ b/testing/test_notebooks.py
@@ -34,11 +34,12 @@ EXCLUDE_NOTEBOOKS = {
     'xgboost_model_fitting_adult.ipynb',  # very expensive hyperparameter tuning
     'integrated_gradients_transformers.ipynb',  # forward pass through BERT to get embeddings is very slow
     'similarity_explanations_imagenet.ipynb',  # forward pass through ResNet too slow
-    'similarity_explanations_20ng.ipymb', # times out, likely due to the EmbeddingModel being slow
+    'similarity_explanations_20ng.ipynb', # times out, likely due to the EmbeddingModel being slow
+    # the following cannot be run without a kernel restart mid-way due to using graph mode in TF
+    'overview.ipynb',
 }
 if platform.system() == 'Windows':
    EXCLUDE_NOTEBOOKS.add('protoselect_adult_cifar10.ipynb')  # Exclude <your notebook> on Windows due to the use of wget
-   EXCLUDE_NOTEBOOKS.add('similarity_explanations_20ng.ipynb')  # times out, likely due to the EmbeddingModel being slow
    EXCLUDE_NOTEBOOKS.add('trustscore_mnist.ipynb')  # times out
 if platform.system() == 'Darwin':
     EXCLUDE_NOTEBOOKS.add('trustscore_mnist.ipynb')  # times out


### PR DESCRIPTION
This is because a kernel restart is required midway due to disabling eager mode for counterfactual examples (cannot be re-enabled programmatically).

It's possible that we could refactor this to use the `numpy()` call elsewhere, but it's not immediately clear how to do this.

Also fixes a typo and removes a redundant line.