### PR TITLE
Fix plot_pd function to work with matplotlib 3.8.0 changes

### DIFF
--- a/alibi/explainers/partial_dependence.py
+++ b/alibi/explainers/partial_dependence.py
@@ -1096,8 +1096,10 @@ def plot_pd(exp: Explanation,
     for ax_group in one_way_axs.values():
         min_val = min([ax_pd_lim[0] for _, ax_pd_lim in ax_group])
         max_val = max([ax_pd_lim[1] for _, ax_pd_lim in ax_group])
-        ax_group[0][0].get_shared_y_axes().join(ax_group[0][0], *[ax[0] for ax in ax_group[1:]])
-        ax_group[0][0].set_ylim(min_val, max_val)
+        axs = [ax[0] for ax in ax_group]
+        for ax1, ax2 in zip(axs, axs[1:]):
+            ax1.sharey(ax2)
+        axs[0].set_ylim(min_val, max_val)
 
     fig.set(**fig_kw)
     return axes

--- a/alibi/explainers/partial_dependence.py
+++ b/alibi/explainers/partial_dependence.py
@@ -1097,8 +1097,8 @@ def plot_pd(exp: Explanation,
         min_val = min([ax_pd_lim[0] for _, ax_pd_lim in ax_group])
         max_val = max([ax_pd_lim[1] for _, ax_pd_lim in ax_group])
         axs = [ax[0] for ax in ax_group]
-        for ax1, ax2 in zip(axs, axs[1:]):
-            ax1.sharey(ax2)
+        for ax in axs[1:]:
+            ax.sharey(axs[0])
         axs[0].set_ylim(min_val, max_val)
 
     fig.set(**fig_kw)


### PR DESCRIPTION
Closes #964.

Have checked that the output plots on the `pdp_regression_bike.ipynb` notebook are the same.