### PR TITLE
Fix test models to output logits and work with default loss functions

### DIFF
--- a/alibi/explainers/tests/test_simiarlity/conftest.py
+++ b/alibi/explainers/tests/test_simiarlity/conftest.py
@@ -151,7 +151,6 @@ def tf_linear_model(input_shape, output_shape):
         tf.keras.layers.InputLayer(input_shape=input_shape),
         tf.keras.layers.Flatten(),
         tf.keras.layers.Dense(output_shape),
-        tf.keras.layers.Softmax()
     ])
 
 
@@ -167,7 +166,6 @@ def torch_linear_model(input_shape_arg, output_shape_arg):
             self.linear_stack = nn.Sequential(
                 nn.Flatten(start_dim=1),
                 nn.Linear(input_shape, output_shape),
-                nn.Softmax()
             )
 
         def forward(self, x):


### PR DESCRIPTION
Fixes the issue described here: https://github.com/SeldonIO/alibi/pull/968#issuecomment-1759663785

I opted to change both models to output logits (for consistency), this requires keeping `from_logits=True` for the `tensorflow` loss function (default is `False`).