### PR TITLE
Prevent none value in gradients when some of the inputs have not impact to the target

### DIFF
--- a/alibi/explainers/integrated_gradients.py
+++ b/alibi/explainers/integrated_gradients.py
@@ -401,9 +401,13 @@ def _gradients_input(model: Union[tf.keras.models.Model],
     grads = tape.gradient(preds, x)
 
     # if there are inputs have not impact to the output, the gradient is None, but we need to return a tensor
+    if isinstance(x, list):
+        shape = x[0].shape
+    else:
+        shape = x.shape
     for idx, grad in enumerate(grads):
         if grad is None:
-            grads[idx] = tf.convert_to_tensor(np.zeros(x[idx].shape), dtype=x[idx].dtype)
+            grads[idx] = tf.convert_to_tensor(np.zeros(shape), dtype=x[idx].dtype)
     return grads
 
 
@@ -502,9 +506,13 @@ def _gradients_layer(model: Union[tf.keras.models.Model],
     else:
         grads = tape.gradient(preds, layer.result)
     # if there are inputs have not impact to the output, the gradient is None, but we need to return a tensor
+    if isinstance(x, list):
+        shape = x[0].shape
+    else:
+        shape = x.shape
     for idx, grad in enumerate(grads):
         if grad is None:
-            grads[idx] = tf.convert_to_tensor(np.zeros(x[idx].shape), dtype=x[idx].dtype)
+            grads[idx] = tf.convert_to_tensor(np.zeros(shape), dtype=x[idx].dtype)
     delattr(layer, 'inp')
     delattr(layer, 'result')
     layer.call = orig_call

--- a/alibi/explainers/integrated_gradients.py
+++ b/alibi/explainers/integrated_gradients.py
@@ -400,6 +400,10 @@ def _gradients_input(model: Union[tf.keras.models.Model],
 
     grads = tape.gradient(preds, x)
 
+    # if there are inputs have not impact to the output, the gradient is None, but we need to return a tensor
+    for idx, grad in enumerate(grads):
+        if grad is None:
+            grads[idx] = tf.convert_to_tensor(np.zeros(x[idx].shape), dtype=x[idx].dtype)
     return grads
 
 
@@ -497,7 +501,10 @@ def _gradients_layer(model: Union[tf.keras.models.Model],
         grads = tape.gradient(preds, layer.inp)
     else:
         grads = tape.gradient(preds, layer.result)
-
+    # if there are inputs have not impact to the output, the gradient is None, but we need to return a tensor
+    for idx, grad in enumerate(grads):
+        if grad is None:
+            grads[idx] = tf.convert_to_tensor(np.zeros(x[idx].shape), dtype=x[idx].dtype)
     delattr(layer, 'inp')
     delattr(layer, 'result')
     layer.call = orig_call


### PR DESCRIPTION
This is to fix the gradients which could have none values. There are scenarios that some of the inputs have not impact to the target value, IG generates None type grads, something like [ [gradient 1], [gradient 2], None, None], and then when calculating the sum in the _calculate_sum_int method, "grads = tf.concat(batches[j], 0)" line throws errors like "None type can't convert to tensor".

Here is the full stack of errors:
-----
An error was encountered:
Attempt to convert a value (None) with an unsupported type (<class 'NoneType'>) to a Tensor.
Traceback (most recent call last):
  File "/tmp/5948054080360197755", line 229, in execute
    exec(code, global_dict)
  File "<livy-input-b09adda1-e7d5-4a23-8b9a-06a36c7dca3d>", line 8, in <module>
    baselines=None)
  File "/usr/local/lib/python3.7/dist-packages/alibi/explainers/integrated_gradients.py", line 828, in explain
    attribute_to_layer_inputs)
  File "/usr/local/lib/python3.7/dist-packages/alibi/explainers/integrated_gradients.py", line 1069, in _compute_attributions_list_input
    step_sizes, j)
  File "/usr/local/lib/python3.7/dist-packages/alibi/explainers/integrated_gradients.py", line 614, in _calculate_sum_int
    grads = tf.concat(batches[j], 0)
  File "/usr/local/lib/python3.7/dist-packages/tensorflow/python/util/dispatch.py", line 206, in wrapper
    return target(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/tensorflow/python/ops/array_ops.py", line 1769, in concat
    return gen_array_ops.concat_v2(values=values, axis=axis, name=name)
  File "/usr/local/lib/python3.7/dist-packages/tensorflow/python/ops/gen_array_ops.py", line 1218, in concat_v2
    values, axis, name=name, ctx=_ctx)
  File "/usr/local/lib/python3.7/dist-packages/tensorflow/python/ops/gen_array_ops.py", line 1248, in concat_v2_eager_fallback
    _attr_T, values = _execute.args_to_matching_eager(list(values), ctx, [])
  File "/usr/local/lib/python3.7/dist-packages/tensorflow/python/eager/execute.py", line 274, in args_to_matching_eager
    t, dtype, preferred_dtype=default_dtype, ctx=ctx)
  File "/usr/local/lib/python3.7/dist-packages/tensorflow/python/profiler/trace.py", line 163, in wrapped
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/tensorflow/python/framework/ops.py", line 1566, in convert_to_tensor
    ret = conversion_func(value, dtype=dtype, name=name, as_ref=as_ref)
  File "/usr/local/lib/python3.7/dist-packages/tensorflow/python/framework/constant_op.py", line 346, in _constant_tensor_conversion_function
    return constant(v, dtype=dtype, name=name)
  File "/usr/local/lib/python3.7/dist-packages/tensorflow/python/framework/constant_op.py", line 272, in constant
    allow_broadcast=True)
  File "/usr/local/lib/python3.7/dist-packages/tensorflow/python/framework/constant_op.py", line 283, in _constant_impl
    return _constant_eager_impl(ctx, value, dtype, shape, verify_shape)
  File "/usr/local/lib/python3.7/dist-packages/tensorflow/python/framework/constant_op.py", line 308, in _constant_eager_impl
    t = convert_to_eager_tensor(value, ctx, dtype)
  File "/usr/local/lib/python3.7/dist-packages/tensorflow/python/framework/constant_op.py", line 106, in convert_to_eager_tensor
    return ops.EagerTensor(value, ctx.device_name, dtype)
ValueError: Attempt to convert a value (None) with an unsupported type (<class 'NoneType'>) to a Tensor.