### PR TITLE
build(make): Add helper target and install all optionals by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
+.PHONY: install-dev
+install-dev:
+	pip install -r requirements/dev.txt
+
 .PHONY: install
 install:
-	pip install -e .
+	pip install -e .[all]
 
 .PHONY: test
 test:
@@ -60,5 +64,3 @@ check_licenses:
 tox-env=default
 repl:
 	env COMMAND="python" tox -e $(tox-env)
-
-


### PR DESCRIPTION
This is how it's done in Alibi Detect [1].

[1] https://github.com/jesse-c/alibi-detect/blob/cefb3dd253595ab2385db130269536beac85287f/Makefile#L1-L7
