### PR TITLE
Fix AnchorText metadata including invalid parameters (#459)

### DIFF
--- a/alibi/explainers/anchors/anchor_text.py
+++ b/alibi/explainers/anchors/anchor_text.py
@@ -186,8 +186,9 @@ class AnchorText(Explainer):
         self.model: Union['spacy.language.Language', LanguageModel]  #: Language model to be used.
 
         # validate kwargs
-        self.perturb_opts, all_opts = self._validate_kwargs(sampling_strategy=sampling_strategy, nlp=nlp,
-                                                            language_model=language_model, **kwargs)
+        self.perturb_opts = self._validate_kwargs(
+            sampling_strategy=sampling_strategy, nlp=nlp,
+            language_model=language_model, **kwargs)
 
         # set perturbation
         self.perturbation: Any = \
@@ -195,13 +196,13 @@ class AnchorText(Explainer):
 
         # update metadata
         self.meta['params'].update(seed=seed)
-        self.meta['params'].update(**all_opts)
+        self.meta['params'].update(**self.perturb_opts)
 
     def _validate_kwargs(self,
                          sampling_strategy: str,
                          nlp: Optional['spacy.language.Language'] = None,
                          language_model: Optional['LanguageModel'] = None,
-                         **kwargs: Any) -> Tuple[dict, dict]:
+                         **kwargs: Any) -> dict:
 
         # set sampling method
         sampling_strategy = sampling_strategy.strip().lower()
@@ -237,7 +238,6 @@ class AnchorText(Explainer):
         # get default args
         default_args: dict = self.DEFAULTS[self.sampling_strategy]
         perturb_opts: dict = deepcopy(default_args)  # contains only the perturbation params
-        all_opts = deepcopy(default_args)  # contains params + some potential incorrect params
 
         # compute common keys
         allowed_keys = set(perturb_opts.keys())
@@ -251,8 +251,7 @@ class AnchorText(Explainer):
 
         # update defaults args and all params
         perturb_opts.update({key: kwargs[key] for key in common_keys})
-        all_opts.update(kwargs)
-        return perturb_opts, all_opts
+        return perturb_opts
 
     def sampler(self, anchor: Tuple[int, tuple], num_samples: int, compute_labels: bool = True) -> \
             Union[List[Union[np.ndarray, np.ndarray, np.ndarray, np.ndarray, float, int]], List[np.ndarray]]:

--- a/alibi/explainers/tests/test_anchor_text.py
+++ b/alibi/explainers/tests/test_anchor_text.py
@@ -154,6 +154,24 @@ def test_neighbors(nlp):
     assert np.isclose((np.sort(similarity_score)[::-1] - similarity_score).sum(), 0.)
 
 
+def test_metadata_excludes_invalid_params(nlp):
+    """Regression test for #459: ``meta['params']`` should record only the
+    validated perturbation parameters, not misspelled/invalid kwargs."""
+    def predictor(x):
+        return np.zeros((len(x), 2))
+
+    explainer = AnchorText(
+        predictor=predictor,
+        sampling_strategy=AnchorText.SAMPLING_UNKNOWN,
+        nlp=nlp,
+        sample_proba=0.6,       # valid perturbation parameter
+        not_a_real_param=123,   # invalid / misspelled kwarg
+    )
+    params = explainer.meta['params']
+    assert 'not_a_real_param' not in params
+    assert params['sample_proba'] == 0.6
+
+
 @pytest.mark.parametrize('lang_model', ['DistilbertBaseUncased', 'BertBaseUncased', 'RobertaBase'], indirect=True)
 @pytest.mark.parametrize('text, min_num',
                          [("This is ... a sentence, with a long ?!?, lot of punctuation; test this.", 5)])


### PR DESCRIPTION
Fixes #459

## Problem

`AnchorText.meta['params']` recorded **all** parameters passed via `kwargs`, including misspelled or otherwise invalid ones. `_validate_kwargs` returned two dicts — `perturb_opts` (only the validated perturbation params) and `all_opts` (the defaults plus the raw `kwargs`) — and `__init__` updated the metadata from `all_opts`:

```python
self.perturb_opts, all_opts = self._validate_kwargs(...)
...
self.meta['params'].update(**all_opts)
```

So an invalid key like `sampl_proba=0.6` (typo) would be logged as incorrect but still leak into `meta['params']`.

## Fix

Per the issue, record only the validated `self.perturb_opts` in the metadata, and drop `all_opts` entirely — `_validate_kwargs` is only called here, so it now returns just `perturb_opts`:

- `self.meta['params'].update(**self.perturb_opts)`
- `_validate_kwargs` return type `Tuple[dict, dict]` → `dict`; removed the `all_opts` deepcopy/update.

## Test

Added `test_metadata_excludes_invalid_params` (mirrors `test_neighbors`, using the `nlp` fixture): constructs an `AnchorText` with one valid (`sample_proba`) and one invalid (`not_a_real_param`) kwarg and asserts the invalid one is absent from `meta['params']` while the valid one is retained.

I wasn't able to run the full test suite locally (it needs the spaCy model + heavy deps), but both files parse cleanly and the change matches the fix described in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)